### PR TITLE
fix logging texture error

### DIFF
--- a/src/main/resources/assets/gregtech/blockstates/multiblock_casing.json
+++ b/src/main/resources/assets/gregtech/blockstates/multiblock_casing.json
@@ -35,12 +35,12 @@
       },
       "fusion": {
         "textures": {
-          "all": "gregtech:blocks/multiblock_machines/fusion/fusioni_8"
+          "all": "gregtech:blocks/multiblock/fusion/fusioni_8"
         }
       },
       "fusion_mk2": {
         "textures": {
-          "all": "gregtech:blocks/multiblock_machines/fusion/fusionii_8"
+          "all": "gregtech:blocks/multiblock/fusion/fusionii_8"
         }
       }
     }


### PR DESCRIPTION
Before:
```
[19:03:08] [main/ERROR]: +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=
[19:03:08] [main/ERROR]: The following texture errors were found.
[19:03:08] [main/ERROR]: ==================================================
[19:03:08] [main/ERROR]:   DOMAIN gregtech
[19:03:08] [main/ERROR]: --------------------------------------------------
[19:03:08] [main/ERROR]:   domain gregtech is missing 2 textures
[19:03:08] [main/ERROR]:     domain gregtech has 2 locations:
[19:03:08] [main/ERROR]:       mod gregtech resources at /home/harry/Documents/Repos/GregTech/out/production/GregTech
[19:03:08] [main/ERROR]:       unknown resourcepack type gregtech.api.model.ResourcePackHook : Gregtech Internal Resource Pack
[19:03:08] [main/ERROR]: -------------------------
[19:03:08] [main/ERROR]:     The missing resources for domain gregtech are:
[19:03:08] [main/ERROR]:       textures/blocks/multiblock_machines/fusion/fusioni_8.png
[19:03:08] [main/ERROR]:       textures/blocks/multiblock_machines/fusion/fusionii_8.png
[19:03:08] [main/ERROR]: -------------------------
[19:03:08] [main/ERROR]:     No other errors exist for domain gregtech
[19:03:08] [main/ERROR]: ==================================================
[19:03:08] [main/ERROR]: +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=
```

Blocks still show up in world fine.