### PR TITLE
don't register plate recipes twice

### DIFF
--- a/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
+++ b/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
@@ -470,9 +470,6 @@ public class OreProcessingHandler {
                 .EUt(16).duration((int) (material.getMass() / 2L))
                 .buildAndRegister();
 
-            ModHandler.addShapedRecipe(String.format("plate_%s", material.toString()),
-                plateStack, "h", "I", "I", 'I', new UnificationEntry(ingotPrefix, material));
-
             if (material.hasFlag(MetalMaterial.MatFlags.GENERATE_DENSE)) {
                 ItemStack denseStack = OreDictUnifier.get(OrePrefix.plateDense, material);
                 RecipeMaps.BENDER_RECIPES.recipeBuilder()

--- a/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
+++ b/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
@@ -449,12 +449,6 @@ public class OreProcessingHandler {
             .duration(20).EUt(8)
             .buildAndRegister();
 
-        if (material.hasFlag(SolidMaterial.MatFlags.MORTAR_GRINDABLE)) {
-            ModHandler.addShapelessRecipe(String.format("mortar_grind_%s", material.toString()),
-                OreDictUnifier.get(OrePrefix.dust, material),
-                'm', new UnificationEntry(ingotPrefix, material));
-        }
-
         if (material.hasFlag(MatFlags.GENERATE_PLATE) && !material.hasFlag(NO_SMASHING)) {
             ItemStack plateStack = OreDictUnifier.get(OrePrefix.plate, material);
             RecipeMaps.BENDER_RECIPES.recipeBuilder()
@@ -868,6 +862,9 @@ public class OreProcessingHandler {
                             .EUt(16)
                             .buildAndRegister();
                     }
+                    ModHandler.addShapedRecipe(String.format("gem_to_plate_%s", material),
+                        stack, "h", "X",
+                        'X', new UnificationEntry(OrePrefix.gem, material));
                 }
 
                 if (!material.hasFlag(MatFlags.NO_WORKING)) {
@@ -926,17 +923,6 @@ public class OreProcessingHandler {
                 .duration(40)
                 .EUt(8)
                 .buildAndRegister();
-        }
-
-        if (!material.hasFlag(NO_SMASHING)) {
-            ItemStack stack = OreDictUnifier.get(platePrefix, material);
-            ModHandler.addShapedRecipe(String.format("ingot_to_plate_%s", material),
-                stack, "h", "X", "X",
-                'X', new UnificationEntry(OrePrefix.ingot, material));
-
-            ModHandler.addShapedRecipe(String.format("gem_to_plate_%s", material),
-                stack, "h", "X",
-                'X', new UnificationEntry(OrePrefix.gem, material));
         }
 
         if (material.hasFlag(MORTAR_GRINDABLE)) {

--- a/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
+++ b/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java
@@ -470,6 +470,9 @@ public class OreProcessingHandler {
                 .EUt(16).duration((int) (material.getMass() / 2L))
                 .buildAndRegister();
 
+            ModHandler.addShapedRecipe(String.format("plate_%s", material.toString()),
+                plateStack, "h", "I", "I", 'I', new UnificationEntry(ingotPrefix, material));
+
             if (material.hasFlag(MetalMaterial.MatFlags.GENERATE_DENSE)) {
                 ItemStack denseStack = OreDictUnifier.get(OrePrefix.plateDense, material);
                 RecipeMaps.BENDER_RECIPES.recipeBuilder()


### PR DESCRIPTION
Closes #89.
There is the same code twice in `OreProcessingHandler`.
Process ingot: https://github.com/GregTechCE/GregTech/blob/1a6122fefae1a99e0354a9b78bb6398b985fe36c/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java#L473-L474.

Process plate: https://github.com/GregTechCE/GregTech/blob/1a6122fefae1a99e0354a9b78bb6398b985fe36c/src/main/scala/gregtech/loaders/oreprocessing/OreProcessingHandler.java#L933-L935.

Correct me if I'm wrong.
