### PR TITLE
Allow non electric tools to break

### DIFF
--- a/src/main/scala/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/scala/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -277,7 +277,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     public boolean isUsable(ItemStack stack, int damage) {
         IElectricItem capability = stack.getCapability(IElectricItem.CAPABILITY_ELECTRIC_ITEM, null);
         if(capability == null || capability.getMaxCharge() == 0) {
-            return getInternalDamage(stack) + damage < getMaxInternalDamage(stack);
+            return true;
         }
         return capability.canUse(damage) && getInternalDamage(stack) + (damage / 10) < getMaxInternalDamage(stack);
     }
@@ -342,6 +342,9 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     private void setInternalDamage(ItemStack itemStack, int damage) {
         NBTTagCompound statsTag = itemStack.getOrCreateSubCompound("GT.ToolStats");
         statsTag.setInteger("Damage", damage);
+        if(getInternalDamage(itemStack) >= getMaxInternalDamage(itemStack)) {
+            itemStack.setCount(0);
+        }
     }
 
     @Nullable

--- a/src/main/scala/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/scala/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -343,7 +343,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         NBTTagCompound statsTag = itemStack.getOrCreateSubCompound("GT.ToolStats");
         statsTag.setInteger("Damage", damage);
         if(getInternalDamage(itemStack) >= getMaxInternalDamage(itemStack)) {
-            itemStack.setCount(0);
+            itemStack.shrink(1);
         }
     }
 


### PR DESCRIPTION
If the last use is used on a hammer etc. it will disappear. It seems that when breaking ores with a hammer if it doesn't have enough durability left to break the ore then the ore block itself will be dropped rather than the crushed stuff. I don't think this is a bad thing.