### PR TITLE
Fix some smelting recipe registration

### DIFF
--- a/src/main/scala/gregtech/api/recipes/ModHandler.java
+++ b/src/main/scala/gregtech/api/recipes/ModHandler.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 
 public class ModHandler {
 
+    private static final Map<ItemStack, ItemStack> SMELTING_LIST = FurnaceRecipes.instance().getSmeltingList();
     /**
      * Returns if that Liquid is Water or Distilled Water
      */
@@ -177,6 +178,10 @@ public class ModHandler {
         }
         if (skip) return;
 
+        ItemStack test = FurnaceRecipes.instance().getSmeltingResult(input);
+        if(test != ItemStack.EMPTY) {
+            FurnaceRecipes.instance().getSmeltingList().keySet().removeIf(toRemove -> ItemStack.areItemStacksEqual(toRemove, input));
+        }
 
         GameRegistry.addSmelting(input, output.copy(), 0.0F);
     }


### PR DESCRIPTION
To register a smelting recipe it seems you have to remove the old one first. I've sorted this out for a few but for some reason not all of them work. Not sure why.

Before:
<details>

```
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreRedstone@0 = 5xitem.redstone@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@2 = 1xitem.meta_item@10062
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@5 = 1xitem.meta_item@10044
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreGold@0 = 1xitem.ingotGold@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@3 = 1xitem.meta_item@10035
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.for.resources@0 = 4xitem.for.apatite@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@6 = 1xitem.meta_item@10051
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreCoal@0 = 1xitem.coal@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreLapis@0 = 6xitem.dyePowder@4
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.netherquartz@0 = 2xitem.netherquartz@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.for.resources@1 = 1xitem.for.ingot_copper@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@0 = 1xitem.for.ingot_copper@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.for.resources@2 = 1xitem.for.ingot_tin@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.thermalfoundation.ore@1 = 1xitem.for.ingot_tin@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreEmerald@0 = 1xitem.emerald@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreIron@0 = 1xitem.ingotIron@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.ore_cinnabar@0 = 1xitem.meta_item@2103
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreDiamond@0 = 1xitem.diamond@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2094 = 1xitem.meta_item@10094
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@66 = 1xitem.meta_item@10062
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2062 = 1xitem.meta_item@10062
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@66 = 1xitem.meta_item@10062
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@69 = 1xitem.meta_item@10044
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2044 = 1xitem.meta_item@10044
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@69 = 1xitem.meta_item@10044
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@1 = 1xitem.ingotGold@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2026 = 1xitem.ingotGold@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@1 = 1xitem.ingotGold@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@99 = 1xitem.for.ingot_bronze@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2095 = 1xitem.for.ingot_bronze@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@99 = 1xitem.for.ingot_bronze@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@67 = 1xitem.meta_item@10035
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2035 = 1xitem.meta_item@10035
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@67 = 1xitem.meta_item@10035
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2079 = 1xitem.meta_item@10079
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2025 = 1xitem.meta_item@10025
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@70 = 1xitem.meta_item@10051
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2051 = 1xitem.meta_item@10051
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@70 = 1xitem.meta_item@10051
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2090 = 1xitem.ingotIron@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2311 = 1xitem.meta_item@10311
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2007 = 1xitem.meta_item@10007
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2011 = 1xitem.meta_item@10011
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2069 = 1xitem.meta_item@10069
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2010 = 1xitem.meta_item@10010
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2297 = 1xitem.meta_item@10297
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2063 = 1xitem.meta_item@10063
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2238 = 1xitem.meta_item@10238
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2140 = 1xitem.meta_item@10140
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2091 = 1xitem.meta_item@10091
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2054 = 1xitem.meta_item@10054
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@64 = 1xitem.for.ingot_copper@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2018 = 1xitem.for.ingot_copper@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@64 = 1xitem.for.ingot_copper@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@97 = 1xitem.meta_item@10112
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2112 = 1xitem.meta_item@10112
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@97 = 1xitem.meta_item@10112
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2006 = 1xitem.meta_item@10006
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2312 = 1xitem.meta_item@10312
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@65 = 1xitem.for.ingot_tin@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2071 = 1xitem.for.ingot_tin@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@65 = 1xitem.for.ingot_tin@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2012 = 1xitem.meta_item@10012
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2052 = 1xitem.meta_item@10052
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@0 = 1xitem.ingotIron@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2033 = 1xitem.ingotIron@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@0 = 1xitem.ingotIron@0
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2076 = 1xitem.meta_item@10076
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2109 = 1xitem.meta_item@10109
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2205 = 1xitem.meta_item@10205
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2058 = 1xitem.meta_item@10058
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2031 = 1xitem.meta_item@10031
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2013 = 1xitem.meta_item@10013
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2197 = 1xitem.meta_item@10197
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2053 = 1xitem.meta_item@10053
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2066 = 1xitem.meta_item@10066
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@98 = 1xitem.meta_item@10126
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2126 = 1xitem.meta_item@10126
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.thermalfoundation.material@98 = 1xitem.meta_item@10126
[01:08:26] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2142 = 1xitem.meta_item@10142
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2017 = 1xitem.meta_item@10017
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2067 = 1xitem.meta_item@10067
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2087 = 1xitem.meta_item@10087
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2189 = 1xitem.meta_item@10189
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2237 = 1xitem.meta_item@10237
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2008 = 1xitem.meta_item@10008
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2129 = 1xitem.meta_item@10129
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2043 = 1xitem.meta_item@10043
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2038 = 1xitem.meta_item@10038
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2039 = 1xitem.meta_item@10039
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2002 = 1xitem.meta_item@10002
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2064 = 1xitem.meta_item@10064
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2036 = 1xitem.meta_item@10036
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2075 = 1xitem.meta_item@10075
[01:08:27] [main/INFO]: Ignored smelting recipe with conflicting input: 1xitem.meta_item@2003 = 1xitem.meta_item@10003
```
</details>

After:
<details>

```
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreRedstone@0 = 5xitem.redstone@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreGold@0 = 1xitem.ingotGold@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreCoal@0 = 1xitem.coal@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreLapis@0 = 6xitem.dyePowder@4
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.netherquartz@0 = 2xitem.netherquartz@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreEmerald@0 = 1xitem.emerald@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreIron@0 = 1xitem.ingotIron@0
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.ore_cinnabar@0 = 1xitem.meta_item@2103
[01:55:43] [main/INFO]: Ignored smelting recipe with conflicting input: 1xtile.oreDiamond@0 = 1xitem.diamond@0
```
</details>

Stuff where the items are from GTCE is a little suspicious (are they being registered twice?) but I haven't really looked into it.