### PR TITLE
Fix Coil Progression Block

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -471,7 +471,7 @@ public class RecipeMaps {
      * </pre>
      */
 
-    @ZenProperty public static final RecipeMap<CrackingRecipeBuilder> CRACKING_RECIPES = new RecipeMap<>("craker", 0, 0, 0, 0, 1, 2, 1, 2, 1, new CrackingRecipeBuilder().notOptimized());
+    @ZenProperty public static final RecipeMap<CrackingRecipeBuilder> CRACKING_RECIPES = new RecipeMap<>("cracker", 0, 0, 0, 0, 1, 2, 1, 2, 1, new CrackingRecipeBuilder().notOptimized());
 
     /**
      * Example:

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -54,10 +54,10 @@ public class BlockWireCoil extends VariantBlock<BlockWireCoil.CoilType> {
         KANTHAL("kanthal", 2700, 2, 1),
         NICHROME("nichrome", 3600, 4, 1),
         TUNGSTENSTEEL("tungstensteel", 4500, 8, 1),
-        HSS_G("hss_g", 4700, 8, 2),
-        NAQUADAH("naquadah", 5400, 16, 1),
-        NAQUADAH_ALLOY("naquadah_alloy", 7200, 16, 2),
-        SUPERCONDUCTOR("superconductor", 8600, 16, 4),
+        HSS_G("hss_g", 5400, 8, 2),
+        NAQUADAH("naquadah", 7200, 16, 1),
+        NAQUADAH_ALLOY("naquadah_alloy", 8600, 16, 2),
+        SUPERCONDUCTOR("superconductor", 9001, 16, 4),
         FUSION_COIL("fusion_coil", 9700, 16, 8);
 
         private final String name;

--- a/src/main/java/gregtech/loaders/load/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/load/OreDictionaryLoader.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 import static gregtech.api.GTValues.W;
 
 public class OreDictionaryLoader {
-    
+
     public static void init() {
         GTLog.logger.info("Registering OreDict entries.");
 


### PR DESCRIPTION
 Currently, it's impossible to make Naquadah and Naquadah Alloy due to their Coils having the temperature needed for them to be made. This pull request moves the values one down, as they were in GT5U, so they can be obtainable. Additionally it fixes the cracker's recipe map since it hasn't been fixed in weeks and it doesn't deserve its own pull request.