### PR TITLE
Change fluid recipe lookup to use fluid names instead of Fluid instances

### DIFF
--- a/src/main/java/gregtech/api/recipes/FluidKey.java
+++ b/src/main/java/gregtech/api/recipes/FluidKey.java
@@ -8,11 +8,11 @@ import java.util.Objects;
 
 public class FluidKey {
 
-    public final Fluid fluid;
+    public final String fluid;
     public final NBTTagCompound tag;
 
     public FluidKey(FluidStack fluidStack) {
-        this.fluid = fluidStack.getFluid();
+        this.fluid = fluidStack.getFluid().getName();
         this.tag = fluidStack.tag;
     }
 
@@ -33,7 +33,7 @@ public class FluidKey {
     @Override
     public String toString() {
         return "FluidKey{" +
-            "fluid=" + fluid.getName() +
+            "fluid=" + fluid +
             ", tag=" + tag +
             '}';
     }


### PR DESCRIPTION
Fixes an issue where BuildCraft oil cannot be refined in a Distillery, among others.