### PR TITLE
renamed worldgen extract lock file to be twitch-import friendly

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -93,13 +93,15 @@ public class WorldGenRegistry {
         oreVeinCache.clear();
         Path configPath = Loader.instance().getConfigDir().toPath().resolve(GTValues.MODID);
         Path worldgenRootPath = configPath.resolve("worldgen");
+        Path jarFileExtractLockOld = configPath.resolve(".worldgen_extracted");
         Path jarFileExtractLock = configPath.resolve("worldgen_extracted");
         if(!Files.exists(worldgenRootPath)) {
             Files.createDirectories(worldgenRootPath);
         }
         //attempt extraction if file extraction lock is absent or worldgen root directory is empty
-        if(!Files.exists(jarFileExtractLock) || !Files.list(worldgenRootPath).findFirst().isPresent()) {
-            if(!Files.exists(jarFileExtractLock)) {
+        // todo: "Old" is fugly.  Deprecate and/or replace with pattern-match on name
+        if((!Files.exists(jarFileExtractLock) && !Files.exists(jarFileExtractLockOld)) || !Files.list(worldgenRootPath).findFirst().isPresent()) {
+            if(!Files.exists(jarFileExtractLock) && !Files.exists(jarFileExtractLockOld)) {
                 //create extraction lock only if it doesn't exist
                 Files.createFile(jarFileExtractLock);
             }

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -101,7 +101,7 @@ public class WorldGenRegistry {
         //attempt extraction if file extraction lock is absent or worldgen root directory is empty
         // todo: "Old" is fugly.  Deprecate and/or replace with pattern-match on name
         if((!Files.exists(jarFileExtractLock) && !Files.exists(jarFileExtractLockOld)) || !Files.list(worldgenRootPath).findFirst().isPresent()) {
-            if(!Files.exists(jarFileExtractLock) && !Files.exists(jarFileExtractLockOld)) {
+            if(!Files.exists(jarFileExtractLock)) {
                 //create extraction lock only if it doesn't exist
                 Files.createFile(jarFileExtractLock);
             }

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -93,7 +93,7 @@ public class WorldGenRegistry {
         oreVeinCache.clear();
         Path configPath = Loader.instance().getConfigDir().toPath().resolve(GTValues.MODID);
         Path worldgenRootPath = configPath.resolve("worldgen");
-        Path jarFileExtractLock = configPath.resolve(".worldgen_extracted");
+        Path jarFileExtractLock = configPath.resolve("worldgen_extracted");
         if(!Files.exists(worldgenRootPath)) {
             Files.createDirectories(worldgenRootPath);
         }


### PR DESCRIPTION
Just allows any twitch users to leverage the custom-worldgen capabilities.  If the "." is present, these users will have their custom worldgen destroyed.

Only impacts twitch users as far as I know.