### PR TITLE
Fix for Server-side loading on WrenchOverlayRenderer 

### DIFF
--- a/src/main/java/gregtech/common/render/WrenchOverlayRenderer.java
+++ b/src/main/java/gregtech/common/render/WrenchOverlayRenderer.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(Side.CLIENT)
 public class WrenchOverlayRenderer {
 
     @SubscribeEvent


### PR DESCRIPTION
WrenchOverlayRenderer being marked as @SideOnly(Side.CLIENT) tries to load due to @Mod.EventBusSubscriber without specified side even on server, makin whole launch to stop.