### PR TITLE
Add ability to disable GT ore gen on a per dimension basis

### DIFF
--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -40,14 +40,21 @@ public class WorldGeneratorImpl implements IWorldGenerator {
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();
+        World world = event.getWorld();
         if(ConfigHolder.disableVanillaOres &&
-            ORE_EVENT_TYPES.contains(eventType)) {
+            ORE_EVENT_TYPES.contains(eventType) &&
+            canGenerateInWorld(world)) {
             event.setResult(Result.DENY);
         }
     }
 
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
+    	
+    	//if the user has specified that gregtech not generate ores here, then do not generate them
+    	if(!canGenerateInWorld(world))
+    		return;
+    	
         int selfGridX = Math.floorDiv(chunkX, GRID_SIZE_X);
         int selfGridZ = Math.floorDiv(chunkZ, GRID_SIZE_Z);
         List<OreDepositDefinition> generatedOres = generateInternal(world, selfGridX, selfGridZ, chunkX, chunkZ);
@@ -90,6 +97,13 @@ public class WorldGeneratorImpl implements IWorldGenerator {
         }
     }
 
+    private boolean canGenerateInWorld(World world) {
+    	for(String str : ConfigHolder.oreGenDimensionIdBlackList)
+    		if( str.equalsIgnoreCase(Integer.toString(world.provider.getDimension())))
+    			return false;
+    	return true;
+    }
+    
     private List<OreDepositDefinition> generateInternal(World world, int selfGridX, int selfGridZ, int chunkX, int chunkZ) {
         List<OreDepositDefinition> allGeneratedOres = Collections.emptyList();
         int halfSizeX = (GRID_SIZE_X - 1) / 2;

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -53,6 +53,10 @@ public class ConfigHolder {
         "By default, GTCE will sort ore dictionary registrations alphabetically comparing their owner ModIDs.")
     public static boolean useCustomModPriorities = false;
 
+    @Config.Comment("Specifies a list of dimension ids where gregtech will not generate ores.")
+    @Config.RequiresMcRestart
+    public static String[] oreGenDimensionIdBlackList = new String[0];
+    
     @Config.Comment("Specifies priorities of mods in ore dictionary item registration. First ModID has highest priority, last - lowest. " +
         "Unspecified ModIDs follow standard sorting, but always have lower priority than last specified ModID.")
     @Config.RequiresMcRestart


### PR DESCRIPTION
Background:
There's a handful of mods that add dimensions to minecraft that are considered surface worlds.  In some cases modpack authors or users want to have gregtech generate its ore in the overworld and not in these dimensions added by these other mods.
Gregtech currently does not currently appear to fire an `OreGenEvent.GenerateMinable` event when checking to generate ores.  Additionally doing so might make disabling ore gen painful.

To solve this problem, I'd like to propose a config option that is a list of dimension ids where the user does not want gregtech to do oregen.  Where the values are checked against the dimid in which generation is about to occur in `gregtech.api.worldgen.generator.generate`.

I don't like the idea of iterating over a loop in `generate` to check the dimids, but unless the list is very large the performance impact is expected to be pretty small.

Thanks for your time!