### PR TITLE
Fixed server-side localized item names and tooltips for MetaItems/Blocks/Tools

### DIFF
--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -4,13 +4,13 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
@@ -50,8 +50,8 @@ public class MachineItemBlock extends ItemBlock {
 
         //item specific tooltip like: gregtech.machine.lathe.lv.tooltip
         String tooltipLocale = metaTileEntity.getMetaName() + ".tooltip";
-        if (I18n.hasKey(tooltipLocale)) {
-            String[] lines = I18n.format(tooltipLocale).split("/n");
+        if (I18n.canTranslate(tooltipLocale)) {
+            String[] lines = I18n.translateToLocal(tooltipLocale).split("/n");
             tooltip.addAll(Arrays.asList(lines));
         }
 
@@ -60,8 +60,8 @@ public class MachineItemBlock extends ItemBlock {
             String tierlessTooltipLocale = ((TieredMetaTileEntity) metaTileEntity).getTierlessTooltipKey();
             //only add tierless tooltip if it's key is not equal to normal tooltip key (i.e if machine name has dot in it's name)
             //case when it's not true would be any machine extending from TieredMetaTileEntity but having only one tier
-            if (!tooltipLocale.equals(tierlessTooltipLocale) && I18n.hasKey(tierlessTooltipLocale)) {
-                String[] lines = I18n.format(tierlessTooltipLocale).split("/n");
+            if (!tooltipLocale.equals(tierlessTooltipLocale) && I18n.canTranslate(tierlessTooltipLocale)) {
+                String[] lines = I18n.translateToLocal(tierlessTooltipLocale).split("/n");
                 tooltip.addAll(Arrays.asList(lines));
             }
         }

--- a/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
@@ -92,7 +92,6 @@ public class MaterialMetaItem extends StandardMetaItem {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack itemStack) {
         if(itemStack.getItemDamage() < metaItemOffset) {
             if (!generatedItems.contains((short) itemStack.getItemDamage())) {

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -22,7 +22,6 @@ import gregtech.api.unification.stack.ItemMaterialInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
@@ -34,6 +33,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -360,7 +360,6 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         if (stack.getItemDamage() >= metaItemOffset) {
             T item = getItem(stack);
@@ -372,26 +371,25 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             if(fluidHandlerItem != null) {
                 FluidStack fluidInside = fluidHandlerItem.drain(Integer.MAX_VALUE, false);
                 String name = fluidInside == null ? "metaitem.fluid_cell.empty" : fluidInside.getUnlocalizedName();
-                return I18n.format("metaitem." + item.unlocalizedName + ".name", I18n.format(name));
+                return I18n.translateToLocalFormatted("metaitem." + item.unlocalizedName + ".name", I18n.translateToLocal(name));
             }
-            return I18n.format("metaitem." + item.unlocalizedName + ".name");
+            return I18n.translateToLocal("metaitem." + item.unlocalizedName + ".name");
         }
         return super.getItemStackDisplayName(stack);
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack itemStack, @Nullable World worldIn, List<String> lines, ITooltipFlag tooltipFlag) {
         T item = getItem(itemStack);
         if (item == null) return;
         String unlocalizedTooltip = "metaitem." + item.unlocalizedName + ".tooltip";
-        if (I18n.hasKey(unlocalizedTooltip)) {
-            lines.addAll(Arrays.asList(I18n.format(unlocalizedTooltip).split("/n")));
+        if (I18n.canTranslate(unlocalizedTooltip)) {
+            lines.addAll(Arrays.asList(I18n.translateToLocal(unlocalizedTooltip).split("/n")));
         }
 
         IElectricItem electricItem = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (electricItem != null) {
-            lines.add(I18n.format("metaitem.generic.electric_item.tooltip",
+            lines.add(I18n.translateToLocalFormatted("metaitem.generic.electric_item.tooltip",
                 electricItem.discharge(Long.MAX_VALUE, Integer.MAX_VALUE, true, false, true),
                 electricItem.getMaxCharge(),
                 electricItem.getTier()));
@@ -403,11 +401,11 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             IFluidTankProperties fluidTankProperties = fluidHandler.getTankProperties()[0];
             FluidStack fluid = fluidTankProperties.getContents();
             if (fluid != null) {
-                lines.add(I18n.format("metaitem.generic.fluid_container.tooltip",
+                lines.add(I18n.translateToLocalFormatted("metaitem.generic.fluid_container.tooltip",
                     fluid.amount,
                     fluidTankProperties.getCapacity(),
                     fluid.getLocalizedName()));
-            } else lines.add(I18n.format("metaitem.generic.fluid_container.tooltip_empty"));
+            } else lines.add(I18n.translateToLocal("metaitem.generic.fluid_container.tooltip_empty"));
         }
 
         for (IItemBehaviour behaviour : getBehaviours(itemStack)) {

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -18,7 +18,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.items.MetaItems;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -39,6 +38,7 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -381,13 +381,12 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         if (stack.getItemDamage() >= metaItemOffset) {
             T item = getItem(stack);
             SolidMaterial primaryMaterial = getPrimaryMaterial(stack);
             String materialName = primaryMaterial == null ? "" : String.valueOf(primaryMaterial.getLocalizedName());
-            return I18n.format("metaitem." + item.unlocalizedName + ".name", materialName);
+            return I18n.translateToLocalFormatted("metaitem." + item.unlocalizedName + ".name", materialName);
         }
         return super.getItemStackDisplayName(stack);
     }
@@ -404,17 +403,17 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         int maxInternalDamage = getMaxInternalDamage(itemStack);
 
         if (maxInternalDamage > 0) {
-            lines.add(I18n.format("metaitem.tool.tooltip.durability", maxInternalDamage - getInternalDamage(itemStack), maxInternalDamage));
+            lines.add(I18n.translateToLocalFormatted("metaitem.tool.tooltip.durability", maxInternalDamage - getInternalDamage(itemStack), maxInternalDamage));
         }
         if (primaryMaterial != null) {
-            lines.add(I18n.format("metaitem.tool.tooltip.primary_material", primaryMaterial.getLocalizedName(), primaryMaterial.harvestLevel));
+            lines.add(I18n.translateToLocalFormatted("metaitem.tool.tooltip.primary_material", primaryMaterial.getLocalizedName(), primaryMaterial.harvestLevel));
         }
         if (handleMaterial != null) {
-            lines.add(I18n.format("metaitem.tool.tooltip.handle_material", handleMaterial.getLocalizedName(), handleMaterial.harvestLevel));
+            lines.add(I18n.translateToLocalFormatted("metaitem.tool.tooltip.handle_material", handleMaterial.getLocalizedName(), handleMaterial.harvestLevel));
         }
         if (primaryMaterial != null && toolStats.showBasicAttributes()) {
-            lines.add(I18n.format("metaitem.tool.tooltip.attack_damage", toolStats.getBaseDamage(itemStack) + primaryMaterial.harvestLevel));
-            lines.add(I18n.format("metaitem.tool.tooltip.mining_speed", primaryMaterial.toolSpeed));
+            lines.add(I18n.translateToLocalFormatted("metaitem.tool.tooltip.attack_damage", toolStats.getBaseDamage(itemStack) + primaryMaterial.harvestLevel));
+            lines.add(I18n.translateToLocalFormatted("metaitem.tool.tooltip.mining_speed", primaryMaterial.toolSpeed));
         }
 
         super.addInformation(itemStack, worldIn, lines, tooltipFlag);

--- a/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
@@ -21,7 +21,6 @@ public class ItemBlockPipe<PipeType extends Enum<PipeType> & IPipeType<NodeDataT
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         PipeType pipeType = blockPipe.getPipeType(stack);
         return pipeType.getOrePrefix().getLocalNameForItem(blockPipe.material);

--- a/src/main/java/gregtech/api/unification/material/type/Material.java
+++ b/src/main/java/gregtech/api/unification/material/type/Material.java
@@ -8,7 +8,7 @@ import gregtech.api.unification.material.MaterialIconSet;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.GTControlledRegistry;
 import gregtech.api.util.GTLog;
-import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import stanhebben.zenscript.annotations.*;
@@ -319,10 +319,9 @@ public abstract class Material implements Comparable<Material> {
 	    return "material." + toString();
     }
 
-	@SideOnly(Side.CLIENT)
     @ZenGetter("localizedName")
 	public String getLocalizedName() {
-		return I18n.format(getUnlocalizedName());
+		return I18n.translateToLocal(getUnlocalizedName());
 	}
 
 	@Override

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -8,9 +8,9 @@ import gregtech.api.unification.material.type.*;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.Condition;
 import gregtech.api.util.GTUtility;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.Validate;
@@ -543,13 +543,12 @@ public enum OrePrefix {
         currentProcessingPrefix.set(null);
     }
 
-    @SideOnly(Side.CLIENT)
     public String getLocalNameForItem(Material material) {
         String specfiedUnlocalized = "item." + material.toString() + "." + this.name();
-        if (I18n.hasKey(specfiedUnlocalized)) return I18n.format(specfiedUnlocalized);
+        if (I18n.canTranslate(specfiedUnlocalized)) return I18n.translateToLocal(specfiedUnlocalized);
         String unlocalized = "item.material.oreprefix." + this.name();
         String matLocalized = material.getLocalizedName();
-        String formatted = I18n.format(unlocalized, matLocalized);
+        String formatted = I18n.translateToLocalFormatted(unlocalized, matLocalized);
         return formatted.equals(unlocalized) ? matLocalized : formatted;
     }
 

--- a/src/main/java/gregtech/common/blocks/CompressedItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/CompressedItemBlock.java
@@ -29,7 +29,6 @@ public class CompressedItemBlock extends ItemBlock {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         Material material = getBlockState(stack).getValue(block.variantProperty);
         return OrePrefix.block.getLocalNameForItem(material);

--- a/src/main/java/gregtech/common/blocks/FrameItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/FrameItemBlock.java
@@ -29,7 +29,6 @@ public class FrameItemBlock extends ItemBlock {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         Material material = getBlockState(stack).getValue(block.variantProperty);
         return OrePrefix.frameGt.getLocalNameForItem(material);

--- a/src/main/java/gregtech/common/blocks/OreItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/OreItemBlock.java
@@ -28,7 +28,6 @@ public class OreItemBlock extends ItemBlock {
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public String getItemStackDisplayName(ItemStack stack) {
         IBlockState blockState = getBlockState(stack);
         StoneType stoneType = blockState.getValue(block.STONE_TYPE);

--- a/src/main/java/gregtech/common/pipelike/cable/ItemBlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/ItemBlockCable.java
@@ -4,10 +4,10 @@ import gregtech.api.GTValues;
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.block.ItemBlockPipe;
 import gregtech.api.util.GTUtility;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -26,8 +26,8 @@ public class ItemBlockCable extends ItemBlockPipe<Insulation, WireProperties> {
         Insulation insulation = blockPipe.getPipeType(stack);
         WireProperties wireProperties = blockPipe.getProperties(insulation);
         String voltageName = GTValues.VN[GTUtility.getTierByVoltage(wireProperties.voltage)];
-        tooltip.add(I18n.format("gregtech.cable.voltage", wireProperties.voltage, voltageName));
-        tooltip.add(I18n.format("gregtech.cable.amperage", wireProperties.amperage));
-        tooltip.add(I18n.format("gregtech.cable.loss_per_block", wireProperties.lossPerBlock));
+        tooltip.add(I18n.translateToLocalFormatted("gregtech.cable.voltage", wireProperties.voltage, voltageName));
+        tooltip.add(I18n.translateToLocalFormatted("gregtech.cable.amperage", wireProperties.amperage));
+        tooltip.add(I18n.translateToLocalFormatted("gregtech.cable.loss_per_block", wireProperties.lossPerBlock));
     }
 }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/ItemBlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/ItemBlockFluidPipe.java
@@ -2,9 +2,9 @@ package gregtech.common.pipelike.fluidpipe;
 
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.block.ItemBlockPipe;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
@@ -20,8 +20,8 @@ public class ItemBlockFluidPipe extends ItemBlockPipe<FluidPipeType, FluidPipePr
     public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
         FluidPipeType fluidPipeType = blockPipe.getPipeType(stack);
         FluidPipeProperties pipeProperties = blockPipe.getProperties(fluidPipeType);
-        tooltip.add(I18n.format("gregtech.fluid_pipe.throughput", pipeProperties.throughput));
-        tooltip.add(I18n.format("gregtech.fluid_pipe.max_temperature", pipeProperties.maxFluidTemperature));
-        if(!pipeProperties.gasProof) tooltip.add(I18n.format("gregtech.fluid_pipe.non_gas_proof"));
+        tooltip.add(I18n.translateToLocalFormatted("gregtech.fluid_pipe.throughput", pipeProperties.throughput));
+        tooltip.add(I18n.translateToLocalFormatted("gregtech.fluid_pipe.max_temperature", pipeProperties.maxFluidTemperature));
+        if(!pipeProperties.gasProof) tooltip.add(I18n.translateToLocal("gregtech.fluid_pipe.non_gas_proof"));
     }
 }


### PR DESCRIPTION
This pull request addresses issues with other mods which handle item names server side, like Quark and its "Item Linking" feature.
Before fix:
![](https://feen.us/fvhvlofp.png)
After fix:
![](https://feen.us/rllawdcl.png)

(you can safely ignore the I18n deprecation warnings, vanilla code uses it in many places)