### PR TITLE
Fixed harvest level for DustMaterial ores

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockCompressed.java
+++ b/src/main/java/gregtech/common/blocks/BlockCompressed.java
@@ -51,8 +51,8 @@ public final class BlockCompressed extends DelayedStateBlock {
     @Override
     public int getHarvestLevel(IBlockState state) {
         Material material = state.getValue(variantProperty);
-        if(material instanceof SolidMaterial) {
-            return ((SolidMaterial) material).harvestLevel;
+        if(material instanceof DustMaterial) {
+            return ((DustMaterial) material).harvestLevel;
         }
         return 0;
     }

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -85,8 +85,8 @@ public class BlockOre extends BlockFalling implements IBlockOre {
     @Override
     public int getHarvestLevel(IBlockState state) {
         StoneType stoneType = state.getValue(STONE_TYPE);
-        if (material instanceof SolidMaterial) {
-            int toolQuality = ((SolidMaterial) material).harvestLevel;
+        if (material instanceof DustMaterial) {
+            int toolQuality = ((DustMaterial) material).harvestLevel;
             return Math.max(stoneType.stoneMaterial.harvestLevel, toolQuality > 1 ? toolQuality - 1 : toolQuality);
         }
         return 1;


### PR DESCRIPTION
BlockOre.getHarvestLevel would return 1 for all ores that were not at least SolidMaterial. This meant that materials like galena (harvest level 3) could be mined with a flint pickaxe.

I made the same change for BlockCompressed, but keeping the shovel harvest level at 0 for dust-like blocks may have been intended behavior.