### PR TITLE
Fix incorrect PBF fuel values, fix NPE with PBF fuel slot

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -43,6 +43,8 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
 
+import static gregtech.api.GTValues.M;
+
 public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBase {
 
     private int maxProgressDuration;
@@ -216,6 +218,8 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
             return 2;
         }
         MaterialStack materialStack = OreDictUnifier.getMaterial(fuelType);
+        if(materialStack == null) return 0;
+        if(materialStack.amount != M) return 0;
         if(materialStack.material == Materials.Coal ||
             materialStack.material == Materials.Charcoal) {
             return 1;


### PR DESCRIPTION
Fixes an issue where clicking a non-fuel item into the fuel slot results in a crash, and fixes an issue where tiny piles of dust count as full fuel items (and blocks count as single items).