### PR TITLE
added config option to disable methane recipes from all edibles

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -55,6 +55,10 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static boolean ignoreErrorOrInvalidRecipes = true;
 
+    @Config.Comment("Setting this to false causes GTCE to not register additional methane recipes for foods in the centrifuge.")
+    @Config.RequiresMcRestart
+    public static boolean addFoodMethaneRecipes = true;    
+    
     @Config.Comment("Category that contains configs for changing vanilla recipes")
     @Config.RequiresMcRestart
     public static VanillaRecipes vanillaRecipes = new VanillaRecipes();

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -399,19 +399,21 @@ public class MachineRecipeLoader {
         RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5).inputs(new ItemStack(Items.NETHER_WART)).fluidOutputs(Materials.Methane.getFluid(18)).buildAndRegister();
         RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5).inputs(new ItemStack(Blocks.BROWN_MUSHROOM)).fluidOutputs(Materials.Methane.getFluid(18)).buildAndRegister();
         RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5).inputs(new ItemStack(Blocks.RED_MUSHROOM)).fluidOutputs(Materials.Methane.getFluid(18)).buildAndRegister();
-        for(Item item : ForgeRegistries.ITEMS.getValuesCollection()) {
-            if(item instanceof ItemFood) {
-                ItemFood itemFood = (ItemFood) item;
-                Collection<ItemStack> subItems = ModHandler.getAllSubItems(new ItemStack(item, 1, GTValues.W));
-                for(ItemStack itemStack : subItems) {
-                    int healAmount = itemFood.getHealAmount(itemStack);
-                    float saturationModifier = itemFood.getSaturationModifier(itemStack);
-                    if(healAmount > 0) {
-                        FluidStack outputStack = Materials.Methane.getFluid(Math.round(9 * healAmount * (1.0f + saturationModifier)));
-                        RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5).inputs(itemStack).fluidOutputs(outputStack).buildAndRegister();
-                    }
-                }
-            }
+        if (ConfigHolder.addFoodMethaneRecipes) {
+	        for(Item item : ForgeRegistries.ITEMS.getValuesCollection()) {
+	            if(item instanceof ItemFood) {
+	                ItemFood itemFood = (ItemFood) item;
+	                Collection<ItemStack> subItems = ModHandler.getAllSubItems(new ItemStack(item, 1, GTValues.W));
+	                for(ItemStack itemStack : subItems) {
+	                    int healAmount = itemFood.getHealAmount(itemStack);
+	                    float saturationModifier = itemFood.getSaturationModifier(itemStack);
+	                    if(healAmount > 0) {
+	                        FluidStack outputStack = Materials.Methane.getFluid(Math.round(9 * healAmount * (1.0f + saturationModifier)));
+	                        RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5).inputs(itemStack).fluidOutputs(outputStack).buildAndRegister();
+	                    }
+	                }
+	            }
+	        }
         }
     }
 


### PR DESCRIPTION
Should add all methane recipes from food by default, users will need to manually set this to false to disable.