### PR TITLE
added idle timeout to update method

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -44,6 +44,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
     protected NonNullList<ItemStack> itemOutputs;
     protected final Random random = new Random();
 
+    private int recipeIdleTime;
     private boolean isActive;
     private boolean workingEnabled = true;
     private boolean hasNotEnoughEnergy;
@@ -104,9 +105,11 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
             if (workingEnabled) {
                 if (progressTime > 0) {
                     updateRecipeProgress();
+                    recipeIdleTime = ConfigHolder.maxIdleTime;
                 }
-                if (progressTime == 0) {
+                if (progressTime == 0 && ++recipeIdleTime > ConfigHolder.maxIdleTime) {
                     trySearchNewRecipe();
+                    recipeIdleTime = 0;
                 }
             }
             if (wasActiveAndNeedsUpdate) {

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -7,6 +7,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.machines.FuelRecipeMap;
 import gregtech.api.recipes.recipes.FuelRecipe;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.common.capabilities.Capability;
@@ -26,6 +27,7 @@ public class FuelRecipeLogic extends MTETrait implements IControllable {
     public final long maxVoltage;
 
     private int recipeDurationLeft;
+    private int recipeIdleTime;
     private long recipeOutputVoltage;
 
     private boolean isActive;
@@ -74,9 +76,11 @@ public class FuelRecipeLogic extends MTETrait implements IControllable {
                         this.wasActiveAndNeedsUpdate = true;
                     }
                 }
+                recipeIdleTime = ConfigHolder.maxIdleTime;
             }
-            if (recipeDurationLeft == 0) {
+            if (recipeDurationLeft == 0 && ++recipeIdleTime > ConfigHolder.maxIdleTime) {
                 tryAcquireNewRecipe();
+                recipeIdleTime = 0;
             }
         }
         if (wasActiveAndNeedsUpdate) {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -30,6 +30,10 @@ public class ConfigHolder {
     @Config.Comment("Energy use multiplier for electric items. Default: 100")
     public static int energyUsageMultiplier = 100;
 
+    @Config.RangeInt(min = 0, max = 60)
+    @Config.Comment("Timeout for recalulation incomplete machine recipes. Default: 10")
+    public static int maxIdleTime = 10;
+
     @Config.RangeInt(min = 0, max = 100)
     @Config.Comment("Chance with which flint and steel will create fire. Default: 50")
     public static int flintChanceToCreateFire = 50;


### PR DESCRIPTION
At first, your code looks very well from my job point of view! Good implementation.

**Now my hack:**

Inside the AbstractRecipeLogic.java class the recipe will be checked at the update() method.
The main parameter progressTime control the actions.

progressTime > 0: updateRecipeProgress() with recipe recalculation after maxProgressTime
progressTime == 0: trySearchNewRecipe() with recipe search every tick

The seaching for valid recipes was using expensive calculations with recipe.matches() and findRecipe().

The new parameter recipeIdleTime delay the recipe recalculation.
I added a maxIdleTime to the ConfigHolder with a default of 10 (0.5s).

A better choice should be to eleminate the recipe search from the update() method and adding this behaviour to the fluid/item input and output handler. I was not diving deep enough in your code to find good modifications.

**Important!**
I had no test environment to verify the effect.