### PR TITLE
added a config option to specify bonus EU output per turbine type

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -63,6 +63,18 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static VanillaRecipes vanillaRecipes = new VanillaRecipes();
 
+    @Config.Comment("Sets the bonus EU output of Steam Turbines.")
+    @Config.RequiresMcRestart
+    public static int steamTurbineBonusOutput = 6144;
+
+    @Config.Comment("Sets the bonus EU output of Plasma Turbines.")
+    @Config.RequiresMcRestart
+    public static int plasmaTurbineBonusOutput = 6144;    
+
+    @Config.Comment("Sets the bonus EU output of Gas Turbines.")
+    @Config.RequiresMcRestart
+    public static int gasTurbineBonusOutput = 6144;    
+    
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf paper crafting recipe. Default is true.")

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -7,6 +7,7 @@ import gregtech.api.recipes.machines.FuelRecipeMap;
 import gregtech.api.recipes.recipes.FuelRecipe;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.FluidMaterial;
+import gregtech.common.ConfigHolder;
 import gregtech.common.MetaFluids;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityRotorHolder;
 import gregtech.common.metatileentities.multi.electric.generator.MetaTileEntityLargeTurbine.TurbineType;
@@ -20,8 +21,7 @@ public class LargeTurbineWorkableHandler extends FuelRecipeLogic {
 
     private static final int CYCLE_LENGTH = 230;
     private static final int BASE_ROTOR_DAMAGE = 11;
-    private static final int BASE_EU_OUTPUT = 2048;
-    private static final int EU_OUTPUT_BONUS = 6144;
+    private static final int BASE_EU_OUTPUT = 2048;  
 
     private MetaTileEntityLargeTurbine largeTurbine;
     private int rotorCycleLength = CYCLE_LENGTH;
@@ -65,10 +65,10 @@ public class LargeTurbineWorkableHandler extends FuelRecipeLogic {
         MetaTileEntityRotorHolder rotorHolder = largeTurbine.getAbilities(MetaTileEntityLargeTurbine.ABILITY_ROTOR_HOLDER).get(0);
         if (rotorHolder.hasRotorInInventory()) {
             double rotorEfficiency = rotorHolder.getRotorEfficiency();
-            double totalEnergyOutput = (BASE_EU_OUTPUT + EU_OUTPUT_BONUS * rotorEfficiency);
+            double totalEnergyOutput = (BASE_EU_OUTPUT + getBonusForTurbineType(largeTurbine) * rotorEfficiency);
             return MathHelper.ceil(totalEnergyOutput);
         }
-        return BASE_EU_OUTPUT + EU_OUTPUT_BONUS;
+        return BASE_EU_OUTPUT + getBonusForTurbineType(largeTurbine);
     }
 
     @Override
@@ -92,13 +92,32 @@ public class LargeTurbineWorkableHandler extends FuelRecipeLogic {
         }
     }
 
+    private int getBonusForTurbineType(MetaTileEntityLargeTurbine t) {
+    	int bonus;
+    	switch (t.turbineType) {
+		case GAS:
+			bonus = ConfigHolder.gasTurbineBonusOutput;
+			break;
+		case PLASMA:
+			bonus = ConfigHolder.plasmaTurbineBonusOutput;			
+			break;
+		case STEAM:
+			bonus = ConfigHolder.steamTurbineBonusOutput;			
+			break;
+		default:
+			bonus = 1;
+			break;		
+    	}
+    	return bonus;
+    }
+    
     @Override
     public long getRecipeOutputVoltage() {
         MetaTileEntityRotorHolder rotorHolder = largeTurbine.getAbilities(MetaTileEntityLargeTurbine.ABILITY_ROTOR_HOLDER).get(0);
         double relativeRotorSpeed = rotorHolder.getRelativeRotorSpeed();
         if (rotorHolder.getCurrentRotorSpeed() > 0 && rotorHolder.hasRotorInInventory()) {
             double rotorEfficiency = rotorHolder.getRotorEfficiency();
-            double totalEnergyOutput = (BASE_EU_OUTPUT + EU_OUTPUT_BONUS * rotorEfficiency) * (relativeRotorSpeed * relativeRotorSpeed);
+            double totalEnergyOutput = (BASE_EU_OUTPUT + getBonusForTurbineType(largeTurbine) * rotorEfficiency) * (relativeRotorSpeed * relativeRotorSpeed);
             return MathHelper.ceil(totalEnergyOutput);
         }
         return 0L;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -92,23 +92,13 @@ public class LargeTurbineWorkableHandler extends FuelRecipeLogic {
         }
     }
 
-    private int getBonusForTurbineType(MetaTileEntityLargeTurbine t) {
-    	int bonus;
-    	switch (t.turbineType) {
-		case GAS:
-			bonus = ConfigHolder.gasTurbineBonusOutput;
-			break;
-		case PLASMA:
-			bonus = ConfigHolder.plasmaTurbineBonusOutput;			
-			break;
-		case STEAM:
-			bonus = ConfigHolder.steamTurbineBonusOutput;			
-			break;
-		default:
-			bonus = 1;
-			break;		
+    private int getBonusForTurbineType(MetaTileEntityLargeTurbine turbine) {
+    	switch (turbine.turbineType) {
+		    case GAS: return ConfigHolder.gasTurbineBonusOutput;
+		    case PLASMA: return ConfigHolder.plasmaTurbineBonusOutput;
+		    case STEAM: return ConfigHolder.steamTurbineBonusOutput;
+		    default: return 1;
     	}
-    	return bonus;
     }
     
     @Override


### PR DESCRIPTION
This should in theory allow you to set whatever you want for base GTCE and pack specific configurations can better tweak the numbers for their pack. The goal here is to allow packdevs some flexibility without you having to modify base GTCE to accommodate different packs. 