### PR TITLE
Pump: stop and re-calculate when touching solid block

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -182,7 +182,17 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
 
         if (fluidSourceBlocks.isEmpty()) {
             if (getTimer() % 20 == 0) {
-                this.pumpHeadY++;
+                BlockPos downPos = selfPos.down(1);
+                if (downPos != null && downPos.getY() >= 0) {
+                    IBlockState downBlock = getWorld().getBlockState(downPos);
+                    if (downBlock.getBlock() instanceof BlockLiquid ||
+                        downBlock.getBlock() instanceof IFluidBlock ||
+                        !downBlock.isTopSolid()) {
+                        this.pumpHeadY++;
+                    }
+                }
+
+                // Always recheck next time
                 writeCustomData(200, b -> b.writeVarInt(pumpHeadY));
                 markDirty();
                 //schedule queue rebuild because we changed our position and no fluid is available


### PR DESCRIPTION
Currently, pump pipes will ignore solid blocks in the way.
This patch makes pump stop and re-calculate pumping area when touching solid-top block.

Also fixes #740 
