### PR TITLE
Fix multiblock GUI on dedicated servers

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class AdvancedTextWidget extends Widget {
     protected int maxWidthLimit;
 
-    private ClientSideField<WrapScreen> wrapScreen = new ClientSideField<>(WrapScreen::new);
+    private ClientSideField<WrapScreen> wrapScreen = new ClientSideField<>(() -> new WrapScreen());
     protected Consumer<List<ITextComponent>> textSupplier;
     protected BiConsumer<String, ClickData> clickHandler;
     private List<ITextComponent> displayText = new ArrayList<>();


### PR DESCRIPTION
The old constructor reference will leave a client only class in the method signature in the resulting bytecode. This in turn leads to JVM attempts to load said client only class on every initialization of AdvancedTextWidget (and boom). Turning it into a lambda should solve the problem.