### PR TITLE
Fix SideOnly related issues on dedicated servers

### DIFF
--- a/src/main/java/gregtech/api/gui/Widget.java
+++ b/src/main/java/gregtech/api/gui/Widget.java
@@ -357,9 +357,15 @@ public abstract class Widget {
         @SideOnly(Side.CLIENT)
         private T fieldValue;
 
-        public ClientSideField(Supplier<T> initializer) {
+        /**
+         * See {@link gregtech.api.gui.widgets.AdvancedTextWidget} for example usage.
+         * Extra attention must be paid to avoid leaving client only classes in the method signature
+         * of classes that could be loaded in a dedicated server.
+         */
+        @SuppressWarnings("unchecked")
+        public ClientSideField(Supplier<?> initializer) {
             if (isClientSide()) {
-                this.fieldValue = initializer.get();
+                this.fieldValue = (T) initializer.get();
             }
         }
 

--- a/src/main/java/gregtech/common/blocks/surfacerock/TileEntitySurfaceRock.java
+++ b/src/main/java/gregtech/common/blocks/surfacerock/TileEntitySurfaceRock.java
@@ -24,9 +24,7 @@ public class TileEntitySurfaceRock extends TileEntity {
     private Material material = Materials.Aluminium;
     private List<Material> undergroundMaterials = new ArrayList<>();
 
-    @SideOnly(Side.CLIENT)
     public Object cachedModel = null;
-    @SideOnly(Side.CLIENT)
     public Object cacheKey = null;
 
     public Material getMaterial() {


### PR DESCRIPTION
The unchecked at ClientSideField is necessary, or you have to use unchecked at object instantiation site.

The two field in surface rock have type of Object which is safe. They have initializers so they will be referenced in constructor. Having SideOnly cause any constructor call to fail with NoSuchFieldError.

If you don't like my approach, feel free to close my PR and create your own solution.