### PR TITLE
Fixed energy network ignoring sideness on connecting to machine

### DIFF
--- a/src/main/java/gregtech/common/pipelike/cable/tile/CableEnergyContainer.java
+++ b/src/main/java/gregtech/common/pipelike/cable/tile/CableEnergyContainer.java
@@ -85,7 +85,7 @@ public class CableEnergyContainer implements IEnergyContainer {
             if (tileEntity == null || tileEntityCable.getPipeBlock().getPipeTileEntity(tileEntity) != null) {
                 continue; //do not emit into other cable tile entities
             }
-            IEnergyContainer energyContainer = tileEntity.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
+            IEnergyContainer energyContainer = tileEntity.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, facing.getOpposite());
             if (energyContainer == null) continue;
             amperesUsed += energyContainer.acceptEnergyFromNetwork(facing.getOpposite(), voltage, amperage - amperesUsed);
             if (amperesUsed == amperage)


### PR DESCRIPTION
Energy network did not correctly provide information from which side is energy being pushed to machine, which prevented cover capability checks which in the end prevented Shutter Cover to work correctly.

Fixes #1030 

Tested all different sets of block accepting energy and all covers. 