### PR TITLE
Added Extractor recipe for Beetroot

### DIFF
--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -239,6 +239,11 @@ public class MetaItem2 extends MaterialMetaItem {
             .outputs(new ItemStack(Items.DYE, 3, 9))
             .buildAndRegister();
 
+        RecipeMaps.EXTRACTOR_RECIPES.recipeBuilder()
+            .inputs(new ItemStack(Items.BEETROOT, 1))
+            .outputs(new ItemStack(Items.DYE, 2, 1))
+            .buildAndRegister();
+
         // Misc
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
             .inputs(new ItemStack(Items.DYE, 1, EnumDyeColor.BROWN.getDyeDamage()))


### PR DESCRIPTION
Extractor recipe: 1 beetroot -> 2 red dyes
As we already have all other recipes for vanilla dyes this is just for feature parity.

Fixes: #1037 

![2020-03-26_20 53 31](https://user-images.githubusercontent.com/3093101/77691866-eaee6380-6fa5-11ea-9bdf-2ba22b32a14b.png)
![2020-03-26_20 56 15](https://user-images.githubusercontent.com/3093101/77691870-eb86fa00-6fa5-11ea-9e50-d6a40a5ac868.png)