### PR TITLE
Bugfix/some ore veins not being generated because of surface rocks

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -5,8 +5,8 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.world.IBiome;
 import gregtech.api.GTValues;
+import gregtech.api.unification.material.type.DustMaterial;
 import gregtech.api.unification.material.type.DustMaterial.MatFlags;
-import gregtech.api.unification.material.type.IngotMaterial;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.api.util.WorldBlockPredicate;
 import gregtech.api.worldgen.filler.BlockFiller;
@@ -82,7 +82,7 @@ public class OreDepositDefinition {
         }
         //legacy surface rock specifier support
         if (configRoot.has("surface_stone_material")) {
-            IngotMaterial surfaceStoneMaterial = (IngotMaterial) OreConfigUtils.getMaterialByName(configRoot.get("surface_stone_material").getAsString());
+            DustMaterial surfaceStoneMaterial = OreConfigUtils.getMaterialByName(configRoot.get("surface_stone_material").getAsString());
             if (!surfaceStoneMaterial.hasFlag(MatFlags.GENERATE_ORE)) {
                 throw new IllegalArgumentException("Material " + surfaceStoneMaterial + " doesn't have surface rock variant");
             }

--- a/src/main/resources/assets/gregtech/worldgen/end/manganese_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/end/manganese_vein.json
@@ -3,7 +3,7 @@
   "density": 0.3,
   "max_height": 30,
   "min_height": 20,
-  "surface_stone_material": "manganese",
+  "surface_stone_material": "aluminium",
   "dimension_filter": ["name:the_end"],
 
   "generator": {

--- a/src/main/resources/assets/gregtech/worldgen/overworld/beryllium_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/beryllium_vein.json
@@ -2,7 +2,7 @@
   "weight": 40,
   "density": 0.3,
   "max_height": 35,
-  "surface_stone_material": "silicon",
+  "surface_stone_material": "emerald",
 
   "generator": {
     "type": "ellipsoid",
@@ -21,7 +21,7 @@
           "weight": 30,
           "value": "ore:emerald"
         },
-		{
+		    {
           "weight": 20,
           "value": "ore:thorium"
         }

--- a/src/main/resources/assets/gregtech/worldgen/overworld/lapis_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/lapis_vein.json
@@ -3,7 +3,7 @@
   "density": 0.5,
   "max_height": 50,
   "min_height": 20,
-  "surface_stone_material": "aluminum",
+  "surface_stone_material": "aluminium",
 
   "generator": {
     "type": "ellipsoid",

--- a/src/main/resources/assets/gregtech/worldgen/overworld/monazite_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/monazite_vein.json
@@ -3,7 +3,7 @@
   "density": 0.4,
   "max_height": 40,
   "min_height": 20,
-  "surface_stone_material": "silicon",
+  "surface_stone_material": "monazite",
 
   "generator": {
     "type": "ellipsoid",
@@ -22,7 +22,7 @@
           "weight": 20,
           "value": "ore:monazite"
         },
-		{
+		    {
           "weight": 20,
           "value": "ore:neodymium"
         }

--- a/src/main/resources/assets/gregtech/worldgen/overworld/quartz_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/quartz_vein.json
@@ -2,7 +2,7 @@
   "weight": 70,
   "density": 0.4,
   "min_height": 40,
-  "surface_stone_material": "silicon",
+  "surface_stone_material": "quartzite",
 
   "generator": {
     "type": "ellipsoid",

--- a/src/main/resources/assets/gregtech/worldgen/overworld/redstone_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/redstone_vein.json
@@ -3,7 +3,7 @@
   "density": 0.4,
   "max_height": 50,
   "min_height": 10,
-  "surface_stone_material": "silicon",
+  "surface_stone_material": "redstone",
 
   "generator": {
     "type": "ellipsoid",


### PR DESCRIPTION
Fixed problems with some of ore veins not being generated. Problem was in parsing of vein definitions (as can be seen in log), all of them failing on surface rock.

Surface rocks were fixed by allowing use of dust materials in them (applies to surface rocks on gem veins, and it is lowest allowed material in generator). Fixing typo. And replacing invalid (don't have ore variant) surface rock materials - new materials are either from same ore vein definition for different dimension or just from ores in definition it self.

Problematic/fixed veins:
end\beryllium_vein
end\lapis_vein
end\manganese_vein
end\olivine_vein
end\tungstate_vein
nether\redstone_vein
nether\sulfur_vein
overworld\apatite_vein
overworld\beryllium_vein
overworld\coal_vein
overworld\diamond_vein
overworld\lapis_vein
overworld\lignitecoal_vein
overworld\monazite_vein
overworld\olivine_vein
overworld\quartz_vein
overworld\redstone_vein

Log:
[2020-03-25-6.log](https://github.com/GregTechCE/GregTech/files/4390467/2020-03-25-6.log)

Fixed vein example:
![2020-03-26_23 29 52](https://user-images.githubusercontent.com/3093101/77705576-4af20380-6fc0-11ea-9f3e-11b9420a6eff.png)