### PR TITLE
Bugfix/Missing localization for vanilla fluids

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -486,8 +486,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
                 .getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (fluidHandlerItem != null) {
                 FluidStack fluidInside = fluidHandlerItem.drain(Integer.MAX_VALUE, false);
-                String name = fluidInside == null ? "metaitem.fluid_cell.empty" : fluidInside.getUnlocalizedName();
-                return I18n.format(unlocalizedName, I18n.format(name));
+                return I18n.format(unlocalizedName, fluidInside == null ? I18n.format("metaitem.fluid_cell.empty") : fluidInside.getLocalizedName());
             }
             return I18n.format(unlocalizedName);
         }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -647,7 +647,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         if (tagCompound != null && tagCompound.hasKey("Fluid", NBT.TAG_COMPOUND)) {
             FluidStack fluidStack = FluidStack.loadFluidStackFromNBT(tagCompound.getCompoundTag("Fluid"));
             if (fluidStack != null) {
-                tooltip.add(I18n.format("gregtech.machine.fluid_tank.fluid", fluidStack.amount, I18n.format(fluidStack.getUnlocalizedName())));
+                tooltip.add(I18n.format("gregtech.machine.fluid_tank.fluid", fluidStack.amount, fluidStack.getLocalizedName()));
             }
         }
     }


### PR DESCRIPTION
**Problem:**
Vanilla Minecraft fluids does not have localized name in Cell name & Tank tooltip
**Why:**
When Forge provides unlocalized name for fluid it will put `fluid.` before it. And this will prevent vanilla fluids from being localized as they are not registered with this prefix.
**How solved:**
By using fluid localized name provided by Forge without localizing it in GTCE code.

Before:
![2020-04-01_21 00 10](https://user-images.githubusercontent.com/3093101/78176884-888ddb00-745d-11ea-8db5-aaa5485bfd8b.png)
![2020-04-01_21 00 12](https://user-images.githubusercontent.com/3093101/78176887-89267180-745d-11ea-85dd-ebdeb46f5155.png)
After:
![2020-04-01_21 05 42](https://user-images.githubusercontent.com/3093101/78176902-8e83bc00-745d-11ea-9f71-973855e8037b.png)
![2020-04-01_21 05 44](https://user-images.githubusercontent.com/3093101/78176905-8f1c5280-745d-11ea-9423-9ae4904fde01.png)
