### PR TITLE
Improvement/update dependencies to last version

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,10 +1,10 @@
 minecraft.version=1.12.2
-forge.version=14.23.5.2838
-ccl.version=3.2.2.355
+forge.version=14.23.5.2847
+ccl.version=3.2.3.358
 chickenasm.version=1.0.2.9
-forestry.version=5.8.0.256
-jei.version=4.9.1.188
-multipart.version=2.4.2.58
+forestry.version=5.8.2.387
+jei.version=4.15.0.291
+multipart.version=2.6.2.83
 baubles.version=1.5.2
-crafttweaker.version=1.12-4.1.8.9
-top.version=1.4.23-16
+crafttweaker.version=1.12-4.1.9.6
+top.version=1.4.28-17

--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -49,7 +49,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @Mod(modid = GTValues.MODID,
     name = "GregTech Community Edition",
     acceptedMinecraftVersions = "[1.12,1.13)",
-    dependencies = "required:forge@[14.23.5.2838,);" + CodeChickenLib.MOD_VERSION_DEP + "after:forestry;after:forgemultipartcbe;after:jei@[4.8.6,);after:crafttweaker;")
+    dependencies = "required:forge@[14.23.5.2847,);" + CodeChickenLib.MOD_VERSION_DEP + "after:forestry;after:forgemultipartcbe;after:jei@[4.15.0,);after:crafttweaker;")
 public class GregTechMod {
 
     static {

--- a/src/main/java/gregtech/GregTechVersion.java
+++ b/src/main/java/gregtech/GregTechVersion.java
@@ -6,7 +6,7 @@ public final class GregTechVersion {
     //This number is incremented every major feature update
     public static final int MINOR = 9;
     //This number is incremented every time the feature is added, or bug is fixed. resets every major version change
-    public static final int REVISION = 1;
+    public static final int REVISION = 2;
     //This number is incremented every build, and never reset. Should always be 0 in the repo code.
     public static final int BUILD = 0;
 


### PR DESCRIPTION
All dependencies were updated to latest/last official version available
(last is really meant as LAST because most of them did not get update in years)

Forge updated to 14.23.5.2847

CraftTweaker updated to 4.1.9.6
CodeChickenLib updated to 3.2.3.358
Forestry updated to 5.8.2.387
ForgeMultipart updated to 2.6.2.83
JEI updated to 4.15.0.291
The One Probe updated to 1.4.28

Bump version