### PR TITLE
Bugfix/surface rocks

### DIFF
--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -2,7 +2,6 @@ package gregtech.api.worldgen.populator;
 
 import com.google.gson.JsonObject;
 import gregtech.api.unification.OreDictUnifier;
-import gregtech.api.unification.material.type.DustMaterial;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.worldgen.config.OreConfigUtils;
@@ -38,10 +37,7 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
 
     @Override
     public void loadFromConfig(JsonObject object) {
-        DustMaterial material = OreConfigUtils.getMaterialByName(object.get("material").getAsString());
-        if (!(material instanceof DustMaterial))
-            throw new IllegalArgumentException("Only dust materials are supported for surface rocks");
-        this.material = material;
+        this.material = OreConfigUtils.getMaterialByName(object.get("material").getAsString());
     }
 
     @Override

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -65,11 +65,10 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
 
     private void setStoneBlock(World world, BlockPos blockPos, Collection<Material> undergroundMaterials) {
         boolean surfaceRockPlaced = world.setBlockState(blockPos, MetaBlocks.SURFACE_ROCK_NEW.getDefaultState());
-        if(surfaceRockPlaced)
-        {
+        if (surfaceRockPlaced) {
             TileEntitySurfaceRock tileEntity = (TileEntitySurfaceRock) world.getTileEntity(blockPos);
-            if(tileEntity != null)
-                tileEntity.setData(material, undergroundMaterials);
+            if (tileEntity != null)
+                tileEntity.setData(this.material, undergroundMaterials);
         }
     }
 
@@ -78,7 +77,7 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
         int stonesCount = random.nextInt(2);
         if (world.getWorldType() != WorldType.FLAT && stonesCount > 0) {
             Set<Material> undergroundMaterials = findUndergroundMaterials(gridEntryInfo.getGeneratedBlocks(definition, chunkX, chunkZ));
-            if(undergroundMaterials.isEmpty())
+            if (undergroundMaterials.isEmpty())
                 return;
 
             for (int i = 0; i < stonesCount; i++) {

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -78,6 +78,9 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
         int stonesCount = random.nextInt(2);
         if (world.getWorldType() != WorldType.FLAT && stonesCount > 0) {
             Set<Material> undergroundMaterials = findUndergroundMaterials(gridEntryInfo.getGeneratedBlocks(definition, chunkX, chunkZ));
+            if(undergroundMaterials.isEmpty())
+                return;
+
             for (int i = 0; i < stonesCount; i++) {
                 int randomX = chunkX * 16 + random.nextInt(16);
                 int randomZ = chunkZ * 16 + random.nextInt(16);

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -68,9 +68,13 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
     }
 
     private void setStoneBlock(World world, BlockPos blockPos, Collection<Material> undergroundMaterials) {
-        world.setBlockState(blockPos, MetaBlocks.SURFACE_ROCK_NEW.getDefaultState());
-        TileEntitySurfaceRock tileEntity = (TileEntitySurfaceRock) world.getTileEntity(blockPos);
-        tileEntity.setData(material, undergroundMaterials);
+        boolean surfaceRockPlaced = world.setBlockState(blockPos, MetaBlocks.SURFACE_ROCK_NEW.getDefaultState());
+        if(surfaceRockPlaced)
+        {
+            TileEntitySurfaceRock tileEntity = (TileEntitySurfaceRock) world.getTileEntity(blockPos);
+            if(tileEntity != null)
+                tileEntity.setData(material, undergroundMaterials);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/surfacerock/TileEntitySurfaceRock.java
+++ b/src/main/java/gregtech/common/blocks/surfacerock/TileEntitySurfaceRock.java
@@ -2,6 +2,7 @@ package gregtech.common.blocks.surfacerock;
 
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.Material;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
@@ -16,8 +17,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class TileEntitySurfaceRock extends TileEntity {
 
@@ -64,12 +63,10 @@ public class TileEntitySurfaceRock extends TileEntity {
         super.readFromNBT(compound);
         Material material = Material.MATERIAL_REGISTRY.getObject(compound.getString("Material"));
         this.material = material == null ? Materials.Aluminium : material;
-        this.undergroundMaterials =
-            compound.getTagList("UndergroundMaterials", NBT.TAG_STRING)
-            .tagList.stream()
-            .map(it -> ((NBTTagString) it).getString())
-            .map(Material.MATERIAL_REGISTRY::getObject)
-            .filter(Objects::nonNull).collect(Collectors.toList());
+
+        for (NBTBase undergroundMaterialNBTBase : compound.getTagList("UndergroundMaterials", NBT.TAG_STRING)) {
+            undergroundMaterials.add(Material.MATERIAL_REGISTRY.getObject(((NBTTagString) undergroundMaterialNBTBase).getString()));
+        }
     }
 
     @Override


### PR DESCRIPTION
**Problem:**
1) Surface rocks crashing game when placed on invalid terrain (terrain got changed after validating if surface rock can be placed).
2) NBT data loading for surface rocks not working correctly on latest Forge (version 14.23.5.2854). Cluttering log and resetting surface rocks to aluminium.

**Why:**
1) Missing check if surface rock was placed correctly before accessing it. 
2) NBT data list which GTCE is working with in this case is going to be private.

**How solved:**
1) Added missing check.
2) Used iterator instead of accessing list.

**Outcome:**
Fixes: #1092 
Fixes: #1088 
Fixes: #1086