### PR TITLE
Bugfix/Light gray dye bad oredict

### DIFF
--- a/src/main/java/gregtech/api/util/DyeUtil.java
+++ b/src/main/java/gregtech/api/util/DyeUtil.java
@@ -1,0 +1,48 @@
+package gregtech.api.util;
+
+import com.google.common.base.CaseFormat;
+import net.minecraft.item.EnumDyeColor;
+
+import java.awt.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DyeUtil {
+
+    /**
+     * Determines dye color nearest to specified RGB color
+     */
+    public static EnumDyeColor determineDyeColor(int rgbColor) {
+        Color c = new Color(rgbColor);
+
+        Map<Double, EnumDyeColor> distances = new HashMap<>();
+        for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
+            Color c2 = new Color(dyeColor.colorValue);
+
+            double distance = (c.getRed() - c2.getRed()) * (c.getRed() - c2.getRed())
+                + (c.getGreen() - c2.getGreen()) * (c.getGreen() - c2.getGreen())
+                + (c.getBlue() - c2.getBlue()) * (c.getBlue() - c2.getBlue());
+
+            distances.put(distance, dyeColor);
+        }
+
+        double min = Collections.min(distances.keySet());
+        return distances.get(min);
+    }
+
+    public static String getColorName(EnumDyeColor dyeColor) {
+        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, dyeColor.getName());
+    }
+
+    public static String getOrdictColorName(EnumDyeColor dyeColor) {
+        String colorName;
+
+        if (dyeColor == EnumDyeColor.SILVER)
+            colorName = "LightGray";
+        else
+            colorName = getColorName(dyeColor);
+
+        return "dye" + colorName;
+    }
+}

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1,6 +1,5 @@
 package gregtech.api.util;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Lists;
@@ -24,7 +23,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Slot;
-import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -52,7 +50,6 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
-import java.awt.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -124,27 +121,6 @@ public class GTUtility {
         PotionEffect potionEffect = new PotionEffect(sample.getPotion(), sample.getDuration(), sample.getAmplifier(), sample.getIsAmbient(), sample.doesShowParticles());
         potionEffect.setCurativeItems(sample.getCurativeItems());
         return potionEffect;
-    }
-
-    /**
-     * Determines dye color nearest to specified RGB color
-     */
-    public static EnumDyeColor determineDyeColor(int rgbColor) {
-        Color c = new Color(rgbColor);
-
-        Map<Double, EnumDyeColor> distances = new HashMap<>();
-        for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
-            Color c2 = new Color(dyeColor.colorValue);
-
-            double distance = (c.getRed() - c2.getRed()) * (c.getRed() - c2.getRed())
-                + (c.getGreen() - c2.getGreen()) * (c.getGreen() - c2.getGreen())
-                + (c.getBlue() - c2.getBlue()) * (c.getBlue() - c2.getBlue());
-
-            distances.put(distance, dyeColor);
-        }
-
-        double min = Collections.min(distances.keySet());
-        return distances.get(min);
     }
 
     //just because CCL uses a different color format

--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -1,6 +1,5 @@
 package gregtech.common.items;
 
-import com.google.common.base.CaseFormat;
 import gregtech.api.GTValues;
 import gregtech.api.items.materialitem.MaterialMetaItem;
 import gregtech.api.items.metaitem.ElectricStats;
@@ -23,6 +22,7 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.util.DyeUtil.getOrdictColorName;
 import static gregtech.common.items.MetaItems.*;
 
 public class MetaItem2 extends MaterialMetaItem {
@@ -58,8 +58,7 @@ public class MetaItem2 extends MaterialMetaItem {
         DYE_INDIGO = addItem(410, "dye.indigo").addOreDict("dyeBlue").setInvisible();
         for (int i = 0; i < EnumDyeColor.values().length; i++) {
             EnumDyeColor dyeColor = EnumDyeColor.values()[i];
-            String colorName = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, dyeColor.getName());
-            DYE_ONLY_ITEMS[i] = addItem(414 + i, "dye." + dyeColor.getName()).addOreDict("dye" + colorName);
+            DYE_ONLY_ITEMS[i] = addItem(414 + i, "dye." + dyeColor.getName()).addOreDict(getOrdictColorName(dyeColor));
         }
 
         PLANT_BALL = addItem(570, "plant_ball").setBurnValue(75);

--- a/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
@@ -22,6 +22,7 @@ import static gregtech.api.unification.material.type.IngotMaterial.MatFlags.GENE
 import static gregtech.api.unification.material.type.IngotMaterial.MatFlags.GENERATE_SPRING;
 import static gregtech.api.unification.material.type.SolidMaterial.MatFlags.GENERATE_ROD;
 import static gregtech.api.unification.material.type.SolidMaterial.MatFlags.MORTAR_GRINDABLE;
+import static gregtech.api.util.DyeUtil.determineDyeColor;
 
 public class PartsRecipeHandler {
 
@@ -172,7 +173,7 @@ public class PartsRecipeHandler {
             .EUt(16)
             .buildAndRegister();
 
-        EnumDyeColor dyeColor = GTUtility.determineDyeColor(material.materialRGB);
+        EnumDyeColor dyeColor = determineDyeColor(material.materialRGB);
         MarkerMaterial colorMaterial = MarkerMaterials.Color.COLORS.get(dyeColor);
         OreDictUnifier.registerOre(stack, OrePrefix.craftingLens, colorMaterial);
     }
@@ -370,5 +371,4 @@ public class PartsRecipeHandler {
         return material instanceof IngotMaterial && ((IngotMaterial) material)
             .blastFurnaceTemperature >= 2800 ? 32 : 8;
     }
-
 }

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe;
 
-import com.google.common.base.CaseFormat;
 import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.recipes.ModHandler;
@@ -29,6 +28,8 @@ import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreIngredient;
+
+import static gregtech.api.util.DyeUtil.*;
 
 public class CraftingRecipeLoader {
 
@@ -234,11 +235,9 @@ public class CraftingRecipeLoader {
 
     private static void registerColoringRecipes(BlockColored block) {
         for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
-            String colorName = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, dyeColor.getName());
-            String recipeName = String.format("%s_color_%s", block.getRegistryName().getResourcePath(), colorName);
+            String recipeName = String.format("%s_color_%s", block.getRegistryName().getResourcePath(), getColorName(dyeColor));
             ModHandler.addShapedRecipe(recipeName, new ItemStack(block, 8, dyeColor.getMetadata()), "XXX", "XDX", "XXX",
-                'X', new ItemStack(block, 1, GTValues.W), 'D', "dye" + colorName);
+                'X', new ItemStack(block, 1, GTValues.W), 'D', getOrdictColorName(dyeColor));
         }
     }
-
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe;
 
-import com.google.common.base.CaseFormat;
 import gregtech.api.GTValues;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.ModHandler;
@@ -49,6 +48,7 @@ import java.util.Collection;
 
 import static gregtech.api.GTValues.L;
 import static gregtech.api.GTValues.M;
+import static gregtech.api.util.DyeUtil.getOrdictColorName;
 import static gregtech.common.items.MetaItems.RUBBER_DROP;
 
 public class MachineRecipeLoader {
@@ -552,10 +552,9 @@ public class MachineRecipeLoader {
 
     private static void registerAssemblerRecipes() {
         for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
-            String colorName = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, dyeColor.getName());
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(MetaItems.SPRAY_EMPTY.getStackForm())
-                .input("dye" + colorName, 1)
+                .input(getOrdictColorName(dyeColor), 1)
                 .outputs(MetaItems.SPRAY_CAN_DYES[dyeColor.getMetadata()].getStackForm())
                 .EUt(8).duration(200)
                 .buildAndRegister();
@@ -1081,5 +1080,4 @@ public class MachineRecipeLoader {
                 stoneBlock.getItemVariant(variant, ChiselingVariant.NORMAL));
         }
     }
-
 }


### PR DESCRIPTION
**Problem:**
GTCE Light Gray Dye was registered under bad oredict name.
All GTCE recipes using Light Gray Dye were compatible only with GTCE Light Gray Dye not others (Vanilla MC included).

**Why:**
Light Gray Dye was originally named and registered in Vanilla MC as Silver. Right now it is localized to Light Gray Dye but registration stayed same. Then Forge registered this dye in ore dictionary as dye + LightGray which is different then others which are using dye + original color name.

**How solved:**
By adding DyeUtil class which procures all dye related name and oredict conversions.
All places working dyes are wired through DyeUtil class.

**Outcome:**
GTCE Light Gray Dye is compatible with other Light Gray Dyes.
All GTCE recipes which are using Light Gray Dye are correctly accepting all other Light Gray Dyes.
Fixes: #1096 
