### PR TITLE
Feature/hide containers

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/DefaultSubItemHandler.java
+++ b/src/main/java/gregtech/api/items/metaitem/DefaultSubItemHandler.java
@@ -33,7 +33,7 @@ public class DefaultSubItemHandler implements ISubItemHandler {
         }
         if (creativeTab == CreativeTabs.SEARCH) {
             if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
-                if (!ConfigHolder.hideFilledCells) {
+                if (!ConfigHolder.hideFilledCellsInJEI) {
                     addFluidContainerVariants(itemStack, subItems);
                 }
             }

--- a/src/main/java/gregtech/api/items/metaitem/DefaultSubItemHandler.java
+++ b/src/main/java/gregtech/api/items/metaitem/DefaultSubItemHandler.java
@@ -3,6 +3,7 @@ package gregtech.api.items.metaitem;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.metaitem.stats.ISubItemHandler;
+import gregtech.common.ConfigHolder;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
@@ -32,7 +33,9 @@ public class DefaultSubItemHandler implements ISubItemHandler {
         }
         if (creativeTab == CreativeTabs.SEARCH) {
             if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
-                addFluidContainerVariants(itemStack, subItems);
+                if (!ConfigHolder.hideFilledCells) {
+                    addFluidContainerVariants(itemStack, subItems);
+                }
             }
         }
     }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -15,6 +15,9 @@ public class ConfigHolder {
     @Config.Comment("Whether to hide facades of all blocks in JEI and creative search menu")
     public static boolean hideFacadesInJEI = true;
 
+    @Config.Comment("Whether to hide filled cells. Default is false.")
+    public static boolean hideFilledCells = false;
+
     @Config.Comment("Specifies min amount of veins in section")
     public static int minVeinsInSection = 0;
 
@@ -80,7 +83,7 @@ public class ConfigHolder {
 
     @Config.Comment("Sets the bonus EU output of Gas Turbines.")
     @Config.RequiresMcRestart
-    public static int gasTurbineBonusOutput = 6144;    
+    public static int gasTurbineBonusOutput = 6144;
     
     public static class VanillaRecipes {
 

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -13,12 +13,15 @@ public class ConfigHolder {
     public static boolean increaseDungeonLoot = true;
 
     @Config.Comment("Whether to hide facades of all blocks in JEI and creative search menu")
+    @Config.RequiresMcRestart
     public static boolean hideFacadesInJEI = true;
 
     @Config.Comment("Whether to hide filled cells. Default is false.")
+    @Config.RequiresMcRestart
     public static boolean hideFilledCells = false;
 
     @Config.Comment("Whether to hide filled tanks. Default is false.")
+    @Config.RequiresMcRestart
     public static boolean hideFilledTanks = false;
 
     @Config.Comment("Specifies min amount of veins in section")

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -16,13 +16,13 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static boolean hideFacadesInJEI = true;
 
-    @Config.Comment("Whether to hide filled cells in JEI and creative search menu. Default is false.")
+    @Config.Comment("Whether to hide filled cells in JEI and creative search menu. Default is true.")
     @Config.RequiresMcRestart
-    public static boolean hideFilledCellsInJEI = false;
+    public static boolean hideFilledCellsInJEI = true;
 
-    @Config.Comment("Whether to hide filled tanks in JEI and creative search menu. Default is false.")
+    @Config.Comment("Whether to hide filled tanks in JEI and creative search menu. Default is true.")
     @Config.RequiresMcRestart
-    public static boolean hideFilledTanksInJEI = false;
+    public static boolean hideFilledTanksInJEI = true;
 
     @Config.Comment("Specifies min amount of veins in section")
     public static int minVeinsInSection = 0;

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -12,17 +12,17 @@ public class ConfigHolder {
     @Config.Comment("Whether to increase number of rolls for dungeon chests. Increases dungeon loot drastically.")
     public static boolean increaseDungeonLoot = true;
 
-    @Config.Comment("Whether to hide facades of all blocks in JEI and creative search menu")
+    @Config.Comment("Whether to hide facades of all blocks in JEI and creative search menu. Default is true.")
     @Config.RequiresMcRestart
     public static boolean hideFacadesInJEI = true;
 
-    @Config.Comment("Whether to hide filled cells. Default is false.")
+    @Config.Comment("Whether to hide filled cells in JEI and creative search menu. Default is false.")
     @Config.RequiresMcRestart
-    public static boolean hideFilledCells = false;
+    public static boolean hideFilledCellsInJEI = false;
 
-    @Config.Comment("Whether to hide filled tanks. Default is false.")
+    @Config.Comment("Whether to hide filled tanks in JEI and creative search menu. Default is false.")
     @Config.RequiresMcRestart
-    public static boolean hideFilledTanks = false;
+    public static boolean hideFilledTanksInJEI = false;
 
     @Config.Comment("Specifies min amount of veins in section")
     public static int minVeinsInSection = 0;

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -18,6 +18,9 @@ public class ConfigHolder {
     @Config.Comment("Whether to hide filled cells. Default is false.")
     public static boolean hideFilledCells = false;
 
+    @Config.Comment("Whether to hide filled tanks. Default is false.")
+    public static boolean hideFilledTanks = false;
+
     @Config.Comment("Specifies min amount of veins in section")
     public static int minVeinsInSection = 0;
 
@@ -79,12 +82,12 @@ public class ConfigHolder {
 
     @Config.Comment("Sets the bonus EU output of Plasma Turbines.")
     @Config.RequiresMcRestart
-    public static int plasmaTurbineBonusOutput = 6144;    
+    public static int plasmaTurbineBonusOutput = 6144;
 
     @Config.Comment("Sets the bonus EU output of Gas Turbines.")
     @Config.RequiresMcRestart
     public static int gasTurbineBonusOutput = 6144;
-    
+
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf paper crafting recipe. Default is true.")
@@ -107,7 +110,5 @@ public class ConfigHolder {
 
         @Config.Comment("Require a knife for bowl crafting instead of only plank? Default is true.")
         public boolean bowlRequireKnife = true;
-
     }
-
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -22,6 +22,7 @@ import gregtech.api.unification.material.type.SolidMaterial;
 import gregtech.api.util.ByteBufUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.WatchedFluidTank;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
@@ -468,7 +469,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
     @Override
     public void getSubItems(CreativeTabs creativeTab, NonNullList<ItemStack> subItems) {
         super.getSubItems(creativeTab, subItems);
-        if (creativeTab == CreativeTabs.SEARCH) {
+        if (creativeTab == CreativeTabs.SEARCH && !ConfigHolder.hideFilledTanks) {
             DefaultSubItemHandler.addFluidContainerVariants(getStackForm(), subItems);
         }
     }
@@ -575,7 +576,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
 
     @SideOnly(Side.CLIENT)
     private TankRenderer getTankRenderer() {
-        if(ModHandler.isMaterialWood(material)) {
+        if (ModHandler.isMaterialWood(material)) {
             return Textures.WOODEN_TANK;
         } else return Textures.METAL_TANK;
     }
@@ -714,7 +715,8 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
             this.needsShapeResync = false;
         }
         if (networkStatus == NetworkStatus.DETACHED_FROM_MULTIBLOCK) {
-            writeCustomData(2, buf -> {});
+            writeCustomData(2, buf -> {
+            });
             this.networkStatus = null;
         }
         if (isTankController() && needsShapeResync) {
@@ -748,7 +750,8 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         Stack<EnumFacing> moveStack = new Stack<>();
         int currentAmount = 0;
         int scanSizeLimit = tank.maxSizeHorizontal * tank.maxSizeHorizontal * tank.maxSizeVertical * 4;
-        main: while (true) {
+        main:
+        while (true) {
             if (currentAmount >= scanSizeLimit) {
                 break;
             }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -469,7 +469,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
     @Override
     public void getSubItems(CreativeTabs creativeTab, NonNullList<ItemStack> subItems) {
         super.getSubItems(creativeTab, subItems);
-        if (creativeTab == CreativeTabs.SEARCH && !ConfigHolder.hideFilledTanks) {
+        if (creativeTab == CreativeTabs.SEARCH && !ConfigHolder.hideFilledTanksInJEI) {
             DefaultSubItemHandler.addFluidContainerVariants(getStackForm(), subItems);
         }
     }


### PR DESCRIPTION
**Problem:**
JEI has many pages filled with our cells and tanks with all fluids. And they are not that useful if not in creative.

**Why:**
For all our cells (Cell, Steel Cell, Tungstensteel Cell) and tanks (Wood Tank, Bronze Tank, Steel Tank, Stainless Steel Tank, Titanium Tank, Tunstensteel Tank) we generate JEI entry for every fluid which we alone have about 300 of them.

**How solved:**
Now there are config options _hideFilledCellsInJEI_ and _hideFilledTanksInJEI_ which are set to true by default.

**Outcome:**
Filled cells and tanks are hidden from JEI by default. It is possible to turn it off in config.
Fixes: #1084 