### PR TITLE
Bugfix/slider not working on click

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
@@ -143,6 +143,7 @@ public class SliderWidget extends Widget {
                 this.sliderPosition = 1.0F;
             }
             this.displayString = this.getDisplayString();
+            writeClientAction(1, buffer -> buffer.writeFloat(sliderPosition));
             this.isMouseDown = true;
             return true;
         }


### PR DESCRIPTION
**Problem:**
Slider Widget is not propagating/saving it's state when clicked.

**Why:**
Missing call for slider position propagation on click.

**How solved:**
Missing call added.

**Outcome:**
Slider now correctly propagates/saves it's state when clicked.
Fixes: #1109 