### PR TITLE
Fixed block drops for Thermal Foundation hammers

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -240,6 +240,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
             }
             metaTileEntity.dropAllCovers();
             metaTileEntity.onRemoval();
+
+            tileEntities.set(metaTileEntity);
         }
         super.breakBlock(worldIn, pos, state);
     }
@@ -341,7 +343,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Override
     public void harvestBlock(World worldIn, EntityPlayer player, BlockPos pos, IBlockState state, @Nullable TileEntity te, ItemStack stack) {
-        tileEntities.set(te == null ? null : ((MetaTileEntityHolder) te).getMetaTileEntity());
+        tileEntities.set(te == null ? tileEntities.get() : ((MetaTileEntityHolder) te).getMetaTileEntity());
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -91,6 +91,8 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         if (pipeTile != null) {
             pipeTile.getCoverableImplementation().dropAllCovers();
+
+            tileEntities.set(pipeTile);
         }
         super.breakBlock(worldIn, pos, state);
         getWorldPipeNet(worldIn).removeNode(pos);
@@ -257,7 +259,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     @SuppressWarnings("unchecked")
     @Override
     public void harvestBlock(World worldIn, EntityPlayer player, BlockPos pos, IBlockState state, @Nullable TileEntity te, ItemStack stack) {
-        tileEntities.set(te == null ? null : (IPipeTile<PipeType, NodeDataType>) te);
+        tileEntities.set(te == null ? tileEntities.get() : (IPipeTile<PipeType, NodeDataType>) te);
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }

--- a/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRockNew.java
+++ b/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRockNew.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks.surfacerock;
 
 import gregtech.api.items.toolitem.IScannableBlock;
+import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.Material;
 import net.minecraft.block.ITileEntityProvider;
@@ -67,8 +68,18 @@ public class BlockSurfaceRockNew extends BlockSurfaceRock implements ITileEntity
     }
 
     @Override
+    public void breakBlock(World worldIn, BlockPos pos, IBlockState state) {
+        TileEntitySurfaceRock surfaceRockTileEntity = getTileEntity(worldIn, pos);
+        if (surfaceRockTileEntity != null) {
+            tileEntities.set(surfaceRockTileEntity);
+        }
+
+        super.breakBlock(worldIn, pos, state);
+    }
+
+    @Override
     public void harvestBlock(World worldIn, EntityPlayer player, BlockPos pos, IBlockState state, @Nullable TileEntity te, ItemStack stack) {
-        tileEntities.set((TileEntitySurfaceRock)te);
+        tileEntities.set(te == null ? tileEntities.get() : (TileEntitySurfaceRock) te);
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }

--- a/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRockNew.java
+++ b/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRockNew.java
@@ -1,7 +1,6 @@
 package gregtech.common.blocks.surfacerock;
 
 import gregtech.api.items.toolitem.IScannableBlock;
-import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.Material;
 import net.minecraft.block.ITileEntityProvider;


### PR DESCRIPTION
At breakBlock we still have access to the TileEntity so we can cache it there

breakBlock should always be called before harvestBlock

This is a "workaround" to Thermal Foundation hammers passing "null" as "te" in harvestBlock