### PR TITLE
Add support custom chance functions.

### DIFF
--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -176,7 +176,7 @@ public class Recipe {
             chancedOutputsList = chancedOutputsList.subList(0, Math.max(0, maxChancedSlots));
         }
         for (ChanceEntry chancedOutput : chancedOutputsList) {
-            int outputChance = chancedOutput.getChance() + (chancedOutput.getBoostPerTier() * tier);
+            int outputChance = RecipeMap.getChanceFunction().chanceFor(chancedOutput.getChance(),chancedOutput.getBoostPerTier(), tier);
             if (random.nextInt(Recipe.getMaxChancedValue()) <= outputChance) {
                 outputs.add(chancedOutput.getItemStack().copy());
             }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -33,10 +33,8 @@ import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import stanhebben.zenscript.annotations.*;
 import stanhebben.zenscript.annotations.Optional;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -48,6 +46,8 @@ import java.util.stream.Collectors;
 public class RecipeMap<R extends RecipeBuilder<R>> {
 
     private static final List<RecipeMap<?>> RECIPE_MAPS = new ArrayList<>();
+    @ZenProperty
+    public static IChanceFunction chanceFunction = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
 
     public final String unlocalizedName;
 
@@ -97,6 +97,10 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return RECIPE_MAPS.stream()
             .filter(map -> map.unlocalizedName.equals(unlocalizedName))
             .findFirst().orElse(null);
+    }
+
+    public static IChanceFunction getChanceFunction() {
+        return chanceFunction;
     }
 
     public static boolean isFoundInvalidRecipe() {
@@ -451,5 +455,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return "RecipeMap{" +
             "unlocalizedName='" + unlocalizedName + '\'' +
             '}';
+    }
+
+    @FunctionalInterface
+    @ZenClass("mods.gregtech.recipe.IChanceFunction")
+    @ZenRegister
+    public interface IChanceFunction {
+        int chanceFor(int chance, int boostPerTier, int boostTier);
     }
 }


### PR DESCRIPTION
A custom chance function can now be set, which is given the base chance, the increase per tier, and the byproduct increase tier, and returns the true chance with which the chance entry will be dropped.

This allows for reverting to old byproduct chances, for example, which is one of the main reasons Omnifactory is still running and outdated version.

The function is global, and can be defined in CraftTweaker at any time.
The benefit of it being global is that the localization value can just be changed by the modpack author to reflect the changed byproduct scalings.