### PR TITLE
Modify Implosion Compressor CraftTweaker integration for the ability …

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -81,6 +81,10 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
         return false;
     }
 
+    public boolean applyProperty(String key, ItemStack item) {
+        return false;
+    }
+
     public R inputs(ItemStack... inputs) {
         return inputs(Arrays.asList(inputs));
     }

--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -16,6 +16,7 @@ import stanhebben.zenscript.annotations.ZenMethod;
 public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder> {
 
     protected int explosivesAmount;
+    protected ItemStack explosivesType;
 
     public ImplosionRecipeBuilder() {
     }
@@ -42,6 +43,16 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
         return false;
     }
 
+    @Override
+    public boolean applyProperty(String key, ItemStack exploType) {
+        if (key.equals("explosives")) {
+            explosivesAmount(exploType.getCount());
+            explosivesType = exploType;
+            return true;
+        }
+        return false;
+    }
+
     @ZenMethod
     public ImplosionRecipeBuilder explosivesAmount(int explosivesAmount) {
         if (!GTUtility.isBetweenInclusive(1, 64, explosivesAmount)) {
@@ -52,10 +63,22 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
         return this;
     }
 
+    @ZenMethod
+    public ImplosionRecipeBuilder explosivesType(ItemStack explosivesType) {
+        this.explosivesType = explosivesType;
+        return this;
+    }
+
     @Override
     public void buildAndRegister() {
-        int tntAmount = Math.max(1, explosivesAmount / 2);
-        recipeMap.addRecipe(this.copy().inputs(new ItemStack(Blocks.TNT, tntAmount)).build());
+        int amount  = Math.max(1, explosivesAmount / 2);
+        if(explosivesType == null) {
+            explosivesType = new ItemStack(Blocks.TNT, amount);
+        }
+        else {
+            explosivesType = new ItemStack(explosivesType.getItem(), amount, explosivesType.getMetadata());
+        }
+        recipeMap.addRecipe(this.copy().inputs(explosivesType).build());
     }
 
     public ValidationResult<Recipe> build() {

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -101,6 +101,17 @@ public class CTRecipeBuilder {
     }
 
     @ZenMethod
+    public CTRecipeBuilder property(String key, IItemStack item) {
+        boolean applied = this.backingBuilder.applyProperty(key, CraftTweakerMC.getItemStack(item));
+        if (!applied) {
+            throw new IllegalArgumentException("Property " +
+                key + " cannot be applied to recipe type " +
+                backingBuilder.getClass().getSimpleName() + " for Item " + CraftTweakerMC.getItemStack(item).getDisplayName());
+        }
+        return this;
+    }
+
+    @ZenMethod
     public void buildAndRegister() {
         this.backingBuilder.buildAndRegister();
     }


### PR DESCRIPTION
…to specify explosives types

This PR modifies the existing CraftTweaker support for the Implosion Compressor to add the ability to set the item designated as the "explosives" instead of hardcoding the explosives to only use TNT. This change was made in a fashion to keep compatibility with existing scripts, which will still default to using TNT if the old syntax is used.

An example script to test this is

` import mods.gregtech.recipe.RecipeMap;
import crafttweaker.item.IItemStack;


val implosion as RecipeMap = RecipeMap.getByName("implosion_compressor");


implosion.recipeBuilder()
	.inputs(<minecraft:cobblestone>)
	.outputs(<minecraft:stone>)
	.property("explosives", <gregtech:meta_item_1:32629> * 16)
	.duration(20).EUt(20).buildAndRegister();

implosion.recipeBuilder()
	.inputs(<minecraft:cobblestone>)
	.outputs(<minecraft:stone>)
	.property("explosives", 4)
	.duration(20).EUt(20).buildAndRegister(); `

This script results in the recipes

![implecompress](https://user-images.githubusercontent.com/31759736/87621290-4b301f00-c6d5-11ea-82ce-af615ec0ffb6.PNG)



As a note, the Implosion Compressor by default cuts the given amount of explosives in half, which is why the numbers are different from the script.