### PR TITLE
Add Config Option for lossless wires damaging player

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -97,6 +97,9 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static int gasTurbineBonusOutput = 6144;
 
+    @Config.Comment("If true, zero loss wires will damage the player.")
+    public static boolean doesLosslessDamage = false;
+
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf paper crafting recipe. Default is true.")

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -97,8 +97,8 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static int gasTurbineBonusOutput = 6144;
 
-    @Config.Comment("If true, zero loss wires will damage the player.")
-    public static boolean doesLosslessDamage = false;
+    @Config.Comment("If true, powered zero loss wires will damage the player. Default: false.")
+    public static boolean doLosslessWiresDamage = false;
 
     public static class VanillaRecipes {
 

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -106,11 +106,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     @Override
     public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
-        boolean damageOnLossless = ConfigHolder.doesLosslessDamage;
+        boolean damageOnLossless = ConfigHolder.doLosslessWiresDamage;
         if (!worldIn.isRemote && insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {
             EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
             EnergyNet energyNet = getWorldPipeNet(worldIn).getNetFromPos(pos);
-            if (energyNet != null && (energyNet.getAllNodes().get(pos).data.lossPerBlock > 0 || damageOnLossless)) {
+            if (energyNet != null && (damageOnLossless || energyNet.getAllNodes().get(pos).data.lossPerBlock > 0)) {
                 long voltage = energyNet.getLastMaxVoltage();
                 long amperage = energyNet.getLastAmperage();
                 if (voltage > 0L && amperage > 0L) {

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -9,6 +9,7 @@ import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 import gregtech.common.pipelike.cable.net.EnergyNet;
 import gregtech.common.pipelike.cable.net.WorldENet;
 import gregtech.common.pipelike.cable.tile.TileEntityCable;
@@ -105,10 +106,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     @Override
     public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
+        boolean damageOnLossless = ConfigHolder.doesLosslessDamage;
         if (!worldIn.isRemote && insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {
             EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
             EnergyNet energyNet = getWorldPipeNet(worldIn).getNetFromPos(pos);
-            if (energyNet != null && energyNet.getAllNodes().get(pos).data.lossPerBlock > 0) {
+            if (energyNet != null && (energyNet.getAllNodes().get(pos).data.lossPerBlock > 0 || damageOnLossless)) {
                 long voltage = energyNet.getLastMaxVoltage();
                 long amperage = energyNet.getLastAmperage();
                 if (voltage > 0L && amperage > 0L) {


### PR DESCRIPTION
This PR adds a config option to re-implement the powered lossless wires damaging the player. This defaults to false to mimic current behavior.