### PR TITLE
Tickness of wires udjusted

### DIFF
--- a/src/main/java/gregtech/common/pipelike/cable/Insulation.java
+++ b/src/main/java/gregtech/common/pipelike/cable/Insulation.java
@@ -5,11 +5,11 @@ import gregtech.api.unification.ore.OrePrefix;
 
 public enum Insulation implements IMaterialPipeType<WireProperties> {
 
-    WIRE_SINGLE("wire_single", 0.2f, 1, 2, OrePrefix.wireGtSingle, -1),
-    WIRE_DOUBLE("wire_double", 0.3f, 2, 2, OrePrefix.wireGtDouble, -1),
-    WIRE_QUADRUPLE("wire_quadruple", 0.4f, 4, 3, OrePrefix.wireGtQuadruple, -1),
-    WIRE_OCTAL("wire_octal", 0.6f, 8, 3, OrePrefix.wireGtOctal, -1),
-    WIRE_HEX("wire_hex", 1.0f, 16, 3, OrePrefix.wireGtHex, -1),
+    WIRE_SINGLE("wire_single", 0.1f, 1, 2, OrePrefix.wireGtSingle, -1),
+    WIRE_DOUBLE("wire_double", 0.2f, 2, 2, OrePrefix.wireGtDouble, -1),
+    WIRE_QUADRUPLE("wire_quadruple", 0.3f, 4, 3, OrePrefix.wireGtQuadruple, -1),
+    WIRE_OCTAL("wire_octal", 0.5f, 8, 3, OrePrefix.wireGtOctal, -1),
+    WIRE_HEX("wire_hex", 0.8f, 16, 3, OrePrefix.wireGtHex, -1),
 
     CABLE_SINGLE("cable_single", 0.2f, 1, 1, OrePrefix.cableGtSingle, 0),
     CABLE_DOUBLE("cable_double", 0.3f, 2, 1, OrePrefix.cableGtDouble, 1),


### PR DESCRIPTION
**Problem:**
As mentioned in #1132 16x wire does not damages players when they run in to it.

**How solved:**
All wires were made thinner. That means that 16x wire does not take whole block anymore and event which handles hurting players on running into it works. I decided to thin out all wires for more "real look" as in when wire gets insulated it becomes thicker.

**Outcome:**
16x wires now hurts players on collision. And wire to cable transformations looks more realistic.
Fixes: #1132 

**Additional Notes:**
Comparison between machine and wires/cables:
![2020-07-25_19 15 28](https://user-images.githubusercontent.com/3093101/88462603-ddda7600-ceac-11ea-9577-2278f3391afc.png)
