### PR TITLE
Bugfix/unification concurrent modification exception

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -63,6 +63,7 @@ public class ConfigHolder {
 
     @Config.Comment("Whether to use modPriorities setting in config for prioritizing ore dictionary item registrations. " +
         "By default, GTCE will sort ore dictionary registrations alphabetically comparing their owner ModIDs.")
+    @Config.RequiresMcRestart
     public static boolean useCustomModPriorities = false;
 
     @Config.Comment("Specifies priorities of mods in ore dictionary item registration. First ModID has highest priority, last - lowest. " +


### PR DESCRIPTION
**Problem:**
In specific cases `OreDictUnifier` could throw `ConcurrentModificationExceptions` on get from sorting ArrayList.

**How solved:**
Sorting is done on add and it is thread safe.

**Outcome:**
Fixes: #1170 
There will also be little bit performance gain as sorting will not be performed that many times.