### PR TITLE
Feature/crystal battery boost

### DIFF
--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -52,8 +52,8 @@ public class MetaItem2 extends MaterialMetaItem {
 
         BOTTLE_PURPLE_DRINK = addItem(100, "bottle.purple.drink").addComponents(new FoodStats(8, 0.2F, true, true, new ItemStack(Items.GLASS_BOTTLE), new RandomPotionEffect(MobEffects.HASTE, 800, 1, 90)));
 
-        ENERGY_CRYSTAL = addItem(212, "energy_crystal").addComponents(ElectricStats.createRechargeableBattery(1000000L, GTValues.HV)).setModelAmount(8).setMaxStackSize(1);
-        LAPOTRON_CRYSTAL = addItem(213, "lapotron_crystal").addComponents(ElectricStats.createRechargeableBattery(4000000L, GTValues.EV)).setModelAmount(8).setMaxStackSize(1);
+        ENERGY_CRYSTAL = addItem(212, "energy_crystal").addComponents(ElectricStats.createRechargeableBattery(4000000L, GTValues.HV)).setModelAmount(8).setMaxStackSize(1);
+        LAPOTRON_CRYSTAL = addItem(213, "lapotron_crystal").addComponents(ElectricStats.createRechargeableBattery(10000000L, GTValues.EV)).setModelAmount(8).setMaxStackSize(1);
 
         DYE_INDIGO = addItem(410, "dye.indigo").addOreDict("dyeBlue").setInvisible();
         for (int i = 0; i < EnumDyeColor.values().length; i++) {

--- a/src/main/resources/assets/gregtech/recipes/nano_saber.json
+++ b/src/main/resources/assets/gregtech/recipes/nano_saber.json
@@ -16,7 +16,7 @@
     },
     "B": {
       "type": "gregtech:metaitem",
-      "name": "lapotron_crystal"
+      "name": "energy_crystal"
     },
     "C": {
       "type": "forge:ore_dict",


### PR DESCRIPTION
**Problem:**
As requested in #1174 crystal batteries are not that useful as theirs capacity is low.

**How solved:**
Energy Crystal capacity boosted to 4 000 000 EU.
![2020-08-09_12 28 07](https://user-images.githubusercontent.com/3093101/89730085-d33ae780-da3b-11ea-9ffe-66ad4e8261cd.png)

Lapotron Crystal capacity boosted to 10 000 000 EU.
![2020-08-09_12 28 09](https://user-images.githubusercontent.com/3093101/89730086-d8983200-da3b-11ea-8625-9147fe63e31a.png)

Nano Saber recipe changed to use Energy Crystal instead of Lapotron Crystal. This is mainly because of Nano Saber has capacity 4 000 000 EU and is HV tier which right now corresponds more to Energy Crystal then Lapotron Crystal. This change does not affect how early it can be crafted as Circuit Tier is capped by Nano Saber recipe it self (you can craft Lapotron on tier earlier then Nano Saber).
![2020-08-09_12 15 13](https://user-images.githubusercontent.com/3093101/89730071-bb636380-da3b-11ea-910c-ce3b88332ece.png)

**Outcome:**
Energy Crystal and Lapotron Crystal energy capacity boosted.
Nano Saber recipe modified.
Fixes: #1174 
Fixes: #1027 

**Possible compatibility issue:**
Recipe changed - Nano Saber is not widely used and this change did not affected it's position in Circuit Tiers