### PR TITLE
Feature/facade output based on plate used

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/FacadeRegistryPlugin.java
+++ b/src/main/java/gregtech/integration/jei/recipe/FacadeRegistryPlugin.java
@@ -64,15 +64,16 @@ public class FacadeRegistryPlugin implements IRecipeRegistryPlugin {
 
     private static List<IRecipeWrapper> createFacadeRecipes(ItemStack itemStack) {
         return Lists.newArrayList(
-            createFacadeRecipe(itemStack, Materials.Aluminium, 4),
-            createFacadeRecipe(itemStack, Materials.WroughtIron, 4),
-            createFacadeRecipe(itemStack, Materials.Iron, 4));
+            createFacadeRecipe(itemStack, Materials.Aluminium, 5),
+            createFacadeRecipe(itemStack, Materials.WroughtIron, 3),
+            createFacadeRecipe(itemStack, Materials.Iron, 2));
     }
 
     private static IRecipeWrapper createFacadeRecipe(ItemStack itemStack, Material material, int facadeAmount) {
-        itemStack.setCount(facadeAmount);
+        ItemStack itemStackCopy = itemStack.copy();
+        itemStackCopy.setCount(facadeAmount);
         return new FacadeRecipeWrapper(new ResourceLocation(GTValues.MODID, "facade_" + material),
-            OreDictUnifier.get(OrePrefix.plate, material), itemStack);
+            OreDictUnifier.get(OrePrefix.plate, material), itemStackCopy);
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -38,9 +38,9 @@ public class CraftingRecipeLoader {
     }
 
     private static void loadCraftingRecipes() {
-        registerFacadeRecipe(Materials.Aluminium, 4);
-        registerFacadeRecipe(Materials.WroughtIron, 4);
-        registerFacadeRecipe(Materials.Iron, 4);
+        registerFacadeRecipe(Materials.Aluminium, 5);
+        registerFacadeRecipe(Materials.WroughtIron, 3);
+        registerFacadeRecipe(Materials.Iron, 2);
 
         ToolRecipeHandler.registerPowerUnitRecipes();
         ModHandler.addShapedRecipe("small_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeSmall, Materials.Wood, 4), "WWW", "h f", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));


### PR DESCRIPTION
**Problem:**
As mentioned in #1184 Facade recipes always provides same amount regardless used plate.

**How solved:**
Recipe adjusted to provide 2, 3, 5 for Iron, Wrought Iron, Aluminium respectively.
Updated JEI Facade plugin to show new values.

**Outcome:**
Updated Facade recipe to provide amount based on plates used.
Fixes: #1184 

**Additional Info:**
![2020-08-12_21 26 45](https://user-images.githubusercontent.com/3093101/90060219-a6f5c400-dce4-11ea-9446-39c0538d51d3.png)
![2020-08-12_21 26 53](https://user-images.githubusercontent.com/3093101/90060221-a78e5a80-dce4-11ea-91a8-1ad5496b1cd8.png)
