### PR TITLE
Bugfix/disabling rubber tree generation will also disable abandon base generation 

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -139,11 +139,13 @@ public class GregTechMod {
             GTLog.logger.info("TheOneProbe found. Enabling integration...");
             TheOneProbeCompatibility.registerCompatibility();
         }
+
         WorldGenRegistry.INSTANCE.initializeRegistry();
+        GameRegistry.registerWorldGenerator(new WorldGenAbandonedBase(), 20000);
         if (!ConfigHolder.disableRubberTreeGeneration) {
             GameRegistry.registerWorldGenerator(new WorldGenRubberTree(), 10000);
-            GameRegistry.registerWorldGenerator(new WorldGenAbandonedBase(), 20000);
         }
+
         LootTableHelper.initialize();
         FilterTypeRegistry.init();
         CoverBehaviors.init();


### PR DESCRIPTION
**Problem:**
As described in: #1201 

**Outcome:**
Disabling Rubber Tree generation will not disable Abandon base generation
Fixes: #1201 
