### PR TITLE
Bugfix/autoclave zh localization error

### DIFF
--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -1871,7 +1871,7 @@ gregtech.machine.autoclave.lv.name=基础高压釜
 gregtech.machine.autoclave.mv.name=进阶高压釜
 gregtech.machine.autoclave.hv.name=进阶高压釜 II
 gregtech.machine.autoclave.ev.name=进阶高压釜 III
-gregtech.machine.autoclave.ev.name=进阶高压釜 IV
+gregtech.machine.autoclave.iv.name=进阶高压釜 IV
 
 gregtech.machine.bender.tooltip=更高效地生产板材
 


### PR DESCRIPTION
**What:**
Fixes bus as described in #1207 

**Outcome:**
Fixes problem with Autoclave having two localization entries for EV and none for IV version in zh_cn lang file
Fixes: #1207 