### PR TITLE
Feature/ct material casting

### DIFF
--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialCasting.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialCasting.java
@@ -1,0 +1,59 @@
+package gregtech.api.unification.crafttweaker;
+
+import crafttweaker.annotations.ZenRegister;
+import gregtech.api.unification.material.type.*;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nullable;
+
+@ZenClass("mods.gregtech.material.MaterialCasting")
+@ZenRegister
+public class CTMaterialCasting {
+
+    @ZenMethod
+    @Nullable
+    public static FluidMaterial toFluid(Material material) {
+        return cast(material, FluidMaterial.class);
+    }
+
+    @ZenMethod
+    @Nullable
+    public static DustMaterial toDust(Material material) {
+        return cast(material, DustMaterial.class);
+    }
+
+    @ZenMethod
+    @Nullable
+    public static SolidMaterial toSolid(Material material) {
+        return cast(material, SolidMaterial.class);
+    }
+
+    @ZenMethod
+    @Nullable
+    public static GemMaterial toGem(Material material) {
+        return cast(material, GemMaterial.class);
+    }
+
+    @ZenMethod
+    @Nullable
+    public static IngotMaterial toIngot(Material material) {
+        return cast(material, IngotMaterial.class);
+    }
+
+    @ZenMethod
+    @Nullable
+    public static RoughSolidMaterial toRoughSolid(Material material) {
+        return cast(material, RoughSolidMaterial.class);
+    }
+
+    private static <T, S extends Material> S cast(T material, Class<S> to) {
+        if (material == null)
+            return null;
+
+        if (to.isAssignableFrom(material.getClass()))
+            return to.cast(material);
+
+        return null;
+    }
+}


### PR DESCRIPTION
**What:**
This is implementation of requested feature in: #1224 

**How solved:**
I choose to implement it as standalone class for this purpose. As I don't want to bloat up `Material` class to much.

**Outcome:**
Added way for CT to be able to cast Material to it's other forms
Resolves: #1224 

**Additional info:**
This class is supposed to be used only by CT.
Usage:
```
#loader gregtech
import mods.gregtech.material.MaterialCasting;

//get iron as dust material (form)
var dustMaterial = MaterialCasting.toDust(<material:iron>);

//do dust material related stuff with it
dustMaterial.oreMultiplier = 10;

//cast it to ingot material (form)
var ironIngot = MaterialCasting.toIngot(dustMaterial);

//do ingot material related stuff with it
ironIngot.setCableProperties(128, 0, 0);

//this one will return null because Bone is not IngotMaterial
var badCastMaterial = MaterialCasting.toIngot(<material:bone>);
```