### PR TITLE
Update Rotor Holder spinning status after world reload.

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -218,6 +218,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.receiveInitialSyncData(buf);
         this.isRotorLooping = buf.readBoolean();
         this.rotorColor = buf.readInt();
+        getHolder().scheduleChunkForRenderUpdate();
     }
 
     @Override
@@ -239,6 +240,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.readFromNBT(data);
         this.rotorInventory.deserializeNBT(data.getCompoundTag("RotorInventory"));
         this.currentRotorSpeed = data.getInteger("CurrentSpeed");
+        this.isRotorLooping = currentRotorSpeed > 0;
     }
 
     @Override


### PR DESCRIPTION
**What:**
As mentioned in #1200, the Rotor Holders will not damage the player after a world reload in some cases. In addition, when the multiblock was just starting, I never saw the rotor start spinning.

**How solved:**
As mentioned in the issue, adds an update to the read from NBT method which will manually set the fact that the rotor is spinning. Also adds an update method that I believe is missed which should fix Rotors not spinning after the Multiblock is formed.

**Outcome:**
Rotor Holders damage players after world reload.
Closes #1200 



