### PR TITLE
Fix crash when attempting to move items through Shutter Covers.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -885,7 +885,7 @@ public abstract class MetaTileEntity implements ICoverable {
             IItemHandler itemHandler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
             //use getCoverCapability so item/ore dictionary filter covers will work properly
             IItemHandler myItemHandler = getCoverCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing);
-            if (itemHandler == null) {
+            if (itemHandler == null || myItemHandler == null) {
                 continue;
             }
             moveInventoryItems(myItemHandler, itemHandler);
@@ -904,7 +904,7 @@ public abstract class MetaTileEntity implements ICoverable {
             IItemHandler itemHandler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
             //use getCoverCapability so item/ore dictionary filter covers will work properly
             IItemHandler myItemHandler = getCoverCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing);
-            if (itemHandler == null) {
+            if (itemHandler == null || myItemHandler == null) {
                 continue;
             }
             moveInventoryItems(itemHandler, myItemHandler);


### PR DESCRIPTION
**What:**
This PR fixes a crash when attempting to move items through a shutter cover by adding an additional null check for the null Capability of the shutter cover.

**How solved:**
Adds an additional null check for the null Capability of the shutter cover. This mimics the current null checking of the fluid movement methods

**Outcome:**
Closes #1246. Prevents crash when attempting to move items through a shutter cover.


**Possible compatibility issue:**
None
