### PR TITLE
Feature/extend comment for config option modPriorities

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -67,7 +67,8 @@ public class ConfigHolder {
     public static boolean useCustomModPriorities = false;
 
     @Config.Comment("Specifies priorities of mods in ore dictionary item registration. First ModID has highest priority, last - lowest. " +
-        "Unspecified ModIDs follow standard sorting, but always have lower priority than last specified ModID.")
+        "Unspecified ModIDs follow standard sorting, but always have lower priority than last specified ModID." +
+        "\nFor this to work \"useCustomModPriorities\" has to be set to true.")
     @Config.RequiresMcRestart
     public static String[] modPriorities = new String[0];
 


### PR DESCRIPTION
**What:**
Implements solution for #1252 

**Outcome:**
Added additional comment to modPriorities config option to inform of need to set useCustomModPriorities to true for it to work
Closes: #1252 

**Additional info:**
![GTCE-mod-priorities-additional-comment](https://user-images.githubusercontent.com/3093101/94360366-f5043280-00ac-11eb-9a4b-fc718620a833.png)
