### PR TITLE
Feature/fluid transfer decoupling

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -469,12 +469,12 @@ public abstract class MetaTileEntity implements ICoverable {
     public final boolean canConnectRedstone(@Nullable EnumFacing side) {
         //so far null side means either upwards or downwards redstone wire connection
         //so check both top cover and bottom cover
-        if(side == null) {
+        if (side == null) {
             return canConnectRedstone(EnumFacing.UP) ||
                 canConnectRedstone(EnumFacing.DOWN);
         }
         CoverBehavior coverBehavior = getCoverAtSide(side);
-        if(coverBehavior == null) {
+        if (coverBehavior == null) {
             return canMachineConnectRedstone(side);
         }
         return coverBehavior.canConnectRedstone();
@@ -486,15 +486,15 @@ public abstract class MetaTileEntity implements ICoverable {
 
     @Override
     public final int getInputRedstoneSignal(EnumFacing side, boolean ignoreCover) {
-        if(!ignoreCover && getCoverAtSide(side) != null) {
+        if (!ignoreCover && getCoverAtSide(side) != null) {
             return 0; //covers block input redstone signal for machine
         }
         return sidedRedstoneInput[side.getIndex()];
     }
 
     public final boolean isBlockRedstonePowered() {
-        for(EnumFacing side : EnumFacing.VALUES) {
-            if(getInputRedstoneSignal(side, false) > 0) {
+        for (EnumFacing side : EnumFacing.VALUES) {
+            if (getInputRedstoneSignal(side, false) > 0) {
                 return true;
             }
         }
@@ -508,10 +508,10 @@ public abstract class MetaTileEntity implements ICoverable {
         for (EnumFacing side : EnumFacing.VALUES) {
             int redstoneValue = GTUtility.getRedstonePower(getWorld(), getPos(), side);
             int currentValue = sidedRedstoneInput[side.getIndex()];
-            if(redstoneValue != currentValue) {
+            if (redstoneValue != currentValue) {
                 this.sidedRedstoneInput[side.getIndex()] = redstoneValue;
                 CoverBehavior coverBehavior = getCoverAtSide(side);
-                if(coverBehavior != null) {
+                if (coverBehavior != null) {
                     coverBehavior.onRedstoneInputSignalChange(redstoneValue);
                 }
             }
@@ -791,13 +791,13 @@ public abstract class MetaTileEntity implements ICoverable {
         T capabilityResult = null;
         for (MTETrait mteTrait : this.mteTraits) {
             capabilityResult = mteTrait.getCapability(capability);
-            if(capabilityResult != null) {
+            if (capabilityResult != null) {
                 break;
             }
         }
-        if(side != null && capabilityResult instanceof IEnergyContainer) {
+        if (side != null && capabilityResult instanceof IEnergyContainer) {
             IEnergyContainer energyContainer = (IEnergyContainer) capabilityResult;
-            if(!energyContainer.inputsEnergy(side) && !energyContainer.outputsEnergy(side)) {
+            if (!energyContainer.inputsEnergy(side) && !energyContainer.outputsEnergy(side)) {
                 return null; //do not provide energy container if it can't input or output energy at all
             }
         }
@@ -850,7 +850,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            GTFluidUtils.transferFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.transferFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE);
         }
         blockPos.release();
     }
@@ -869,7 +869,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            GTFluidUtils.transferFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.transferFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE);
         }
         blockPos.release();
     }
@@ -947,7 +947,7 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     public final int getOutputRedstoneSignal(@Nullable EnumFacing side) {
-        if(side == null) {
+        if (side == null) {
             return getHighestOutputRedstoneSignal();
         }
         CoverBehavior behavior = getCoverAtSide(side);
@@ -957,7 +957,7 @@ public abstract class MetaTileEntity implements ICoverable {
 
     public final int getHighestOutputRedstoneSignal() {
         int highestSignal = 0;
-        for(EnumFacing side : EnumFacing.VALUES) {
+        for (EnumFacing side : EnumFacing.VALUES) {
             CoverBehavior behavior = getCoverAtSide(side);
             int sidedOutput = sidedRedstoneOutput[side.getIndex()];
             int sideResult = behavior == null ? sidedOutput : behavior.getRedstoneSignalOutput();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -20,6 +20,7 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.render.Textures;
+import gregtech.api.util.GTFluidUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.common.covers.CoverPump;
 import net.minecraft.block.Block;
@@ -850,7 +851,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            CoverPump.moveHandlerFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.moveHandlerFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE, fluid -> true);
         }
         blockPos.release();
     }
@@ -869,7 +870,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            CoverPump.moveHandlerFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.moveHandlerFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE, fluid -> true);
         }
         blockPos.release();
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -22,7 +22,6 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.render.Textures;
 import gregtech.api.util.GTFluidUtils;
 import gregtech.api.util.GTUtility;
-import gregtech.common.covers.CoverPump;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -851,7 +850,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            GTFluidUtils.moveHandlerFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.transferFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE, fluid -> true);
         }
         blockPos.release();
     }
@@ -870,7 +869,7 @@ public abstract class MetaTileEntity implements ICoverable {
             if (fluidHandler == null || myFluidHandler == null) {
                 continue;
             }
-            GTFluidUtils.moveHandlerFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE, fluid -> true);
+            GTFluidUtils.transferFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE, fluid -> true);
         }
         blockPos.release();
     }

--- a/src/main/java/gregtech/api/util/GTFluidUtils.java
+++ b/src/main/java/gregtech/api/util/GTFluidUtils.java
@@ -7,7 +7,8 @@ import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import java.util.function.Predicate;
 
 public class GTFluidUtils {
-    public static int moveHandlerFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit, Predicate<FluidStack> fluidFilter) {
+    
+    public static int transferFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit, Predicate<FluidStack> fluidFilter) {
         int fluidLeftToTransfer = transferLimit;
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
             FluidStack currentFluid = tankProperties.getContents();

--- a/src/main/java/gregtech/api/util/GTFluidUtils.java
+++ b/src/main/java/gregtech/api/util/GTFluidUtils.java
@@ -15,12 +15,19 @@ public class GTFluidUtils {
 
     public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, int transferLimit, @Nonnull Predicate<FluidStack> fluidFilter) {
         int fluidLeftToTransfer = transferLimit;
+
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
             FluidStack currentFluid = tankProperties.getContents();
-            if (currentFluid == null || currentFluid.amount == 0 || !fluidFilter.test(currentFluid)) continue;
+            if (currentFluid == null || currentFluid.amount == 0 || !fluidFilter.test(currentFluid)) {
+                continue;
+            }
+
             currentFluid.amount = fluidLeftToTransfer;
             FluidStack fluidStack = sourceHandler.drain(currentFluid, false);
-            if (fluidStack == null || fluidStack.amount == 0) continue;
+            if (fluidStack == null || fluidStack.amount == 0) {
+                continue;
+            }
+
             int canInsertAmount = destHandler.fill(fluidStack, false);
             if (canInsertAmount > 0) {
                 fluidStack.amount = canInsertAmount;
@@ -29,7 +36,9 @@ public class GTFluidUtils {
                     destHandler.fill(fluidStack, true);
 
                     fluidLeftToTransfer -= fluidStack.amount;
-                    if (fluidLeftToTransfer == 0) break;
+                    if (fluidLeftToTransfer == 0) {
+                        break;
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/api/util/GTFluidUtils.java
+++ b/src/main/java/gregtech/api/util/GTFluidUtils.java
@@ -1,0 +1,32 @@
+package gregtech.api.util;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+
+import java.util.function.Predicate;
+
+public class GTFluidUtils {
+    public static int moveHandlerFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit, Predicate<FluidStack> fluidFilter) {
+        int fluidLeftToTransfer = transferLimit;
+        for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
+            FluidStack currentFluid = tankProperties.getContents();
+            if (currentFluid == null || currentFluid.amount == 0 || !fluidFilter.test(currentFluid)) continue;
+            currentFluid.amount = fluidLeftToTransfer;
+            FluidStack fluidStack = sourceHandler.drain(currentFluid, false);
+            if (fluidStack == null || fluidStack.amount == 0) continue;
+            int canInsertAmount = destHandler.fill(fluidStack, false);
+            if (canInsertAmount > 0) {
+                fluidStack.amount = canInsertAmount;
+                fluidStack = sourceHandler.drain(fluidStack, true);
+                if (fluidStack != null && fluidStack.amount > 0) {
+                    destHandler.fill(fluidStack, true);
+
+                    fluidLeftToTransfer -= fluidStack.amount;
+                    if (fluidLeftToTransfer == 0) break;
+                }
+            }
+        }
+        return transferLimit - fluidLeftToTransfer;
+    }
+}

--- a/src/main/java/gregtech/api/util/GTFluidUtils.java
+++ b/src/main/java/gregtech/api/util/GTFluidUtils.java
@@ -4,15 +4,16 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
+import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 public class GTFluidUtils {
 
-    public static int transferFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit) {
+    public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, int transferLimit) {
         return transferFluids(sourceHandler, destHandler, transferLimit, fluidStack -> true);
     }
 
-    public static int transferFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit, Predicate<FluidStack> fluidFilter) {
+    public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, int transferLimit, @Nonnull Predicate<FluidStack> fluidFilter) {
         int fluidLeftToTransfer = transferLimit;
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
             FluidStack currentFluid = tankProperties.getContents();

--- a/src/main/java/gregtech/api/util/GTFluidUtils.java
+++ b/src/main/java/gregtech/api/util/GTFluidUtils.java
@@ -7,7 +7,11 @@ import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import java.util.function.Predicate;
 
 public class GTFluidUtils {
-    
+
+    public static int transferFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit) {
+        return transferFluids(sourceHandler, destHandler, transferLimit, fluidStack -> true);
+    }
+
     public static int transferFluids(IFluidHandler sourceHandler, IFluidHandler destHandler, int transferLimit, Predicate<FluidStack> fluidFilter) {
         int fluidLeftToTransfer = transferLimit;
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -34,10 +34,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
 import javax.annotation.Nullable;
-import java.util.function.Predicate;
 
 public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
 
@@ -111,9 +109,9 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
 
     protected int doTransferFluidsInternal(IFluidHandler myFluidHandler, IFluidHandler fluidHandler, int transferLimit) {
         if (pumpMode == PumpMode.IMPORT) {
-            return GTFluidUtils.moveHandlerFluids(fluidHandler, myFluidHandler, transferLimit, fluidFilter::testFluidStack);
+            return GTFluidUtils.transferFluids(fluidHandler, myFluidHandler, transferLimit, fluidFilter::testFluidStack);
         } else if (pumpMode == PumpMode.EXPORT) {
-            return GTFluidUtils.moveHandlerFluids(myFluidHandler, fluidHandler, transferLimit, fluidFilter::testFluidStack);
+            return GTFluidUtils.transferFluids(myFluidHandler, fluidHandler, transferLimit, fluidFilter::testFluidStack);
         }
         return 0;
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -13,7 +13,6 @@ import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.Textures;
 import gregtech.api.util.GTFluidUtils;
-import gregtech.common.covers.CoverPump;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMultiblockPart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -51,7 +50,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {
-                GTFluidUtils.moveHandlerFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE, ALWAYS_TRUE);
+                GTFluidUtils.transferFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE, ALWAYS_TRUE);
             }
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -17,16 +17,11 @@ import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMu
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
-import java.util.function.Predicate;
-
 public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
-
-    private static final Predicate<FluidStack> ALWAYS_TRUE = fluidStack -> true;
 
     public MetaTileEntityCokeOvenHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, 0);
@@ -50,7 +45,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {
-                GTFluidUtils.transferFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE, ALWAYS_TRUE);
+                GTFluidUtils.transferFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE);
             }
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -12,6 +12,7 @@ import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.Textures;
+import gregtech.api.util.GTFluidUtils;
 import gregtech.common.covers.CoverPump;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMultiblockPart;
 import net.minecraft.entity.player.EntityPlayer;
@@ -50,7 +51,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {
-                CoverPump.moveHandlerFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE, ALWAYS_TRUE);
+                GTFluidUtils.moveHandlerFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE, ALWAYS_TRUE);
             }
         }
     }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -10,15 +10,11 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-import java.util.function.Predicate;
-
 public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements ITickable {
 
-    private static final Predicate<FluidStack> FLUID_FILTER_ALWAYS_TRUE = (fluid) -> true;
     private boolean isActive;
 
     public boolean isActive() {
@@ -74,7 +70,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
             IFluidHandler sourceHandler = pipeTile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
             IFluidHandler receiverHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
             if (sourceHandler != null && receiverHandler != null && blockFluidPipe.canPushIntoFluidHandler(pipeTile, tileEntity, sourceHandler, receiverHandler)) {
-                GTFluidUtils.transferFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE, FLUID_FILTER_ALWAYS_TRUE);
+                GTFluidUtils.transferFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE);
             }
         }
         blockPos.release();

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -2,7 +2,6 @@ package gregtech.common.pipelike.fluidpipe.tile;
 
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.util.GTFluidUtils;
-import gregtech.common.covers.CoverPump;
 import gregtech.common.pipelike.fluidpipe.BlockFluidPipe;
 import gregtech.common.pipelike.fluidpipe.FluidPipeProperties;
 import gregtech.common.pipelike.fluidpipe.FluidPipeType;
@@ -75,7 +74,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
             IFluidHandler sourceHandler = pipeTile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
             IFluidHandler receiverHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
             if (sourceHandler != null && receiverHandler != null && blockFluidPipe.canPushIntoFluidHandler(pipeTile, tileEntity, sourceHandler, receiverHandler)) {
-                GTFluidUtils.moveHandlerFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE, FLUID_FILTER_ALWAYS_TRUE);
+                GTFluidUtils.transferFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE, FLUID_FILTER_ALWAYS_TRUE);
             }
         }
         blockPos.release();

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -1,6 +1,7 @@
 package gregtech.common.pipelike.fluidpipe.tile;
 
 import gregtech.api.pipenet.tile.IPipeTile;
+import gregtech.api.util.GTFluidUtils;
 import gregtech.common.covers.CoverPump;
 import gregtech.common.pipelike.fluidpipe.BlockFluidPipe;
 import gregtech.common.pipelike.fluidpipe.FluidPipeProperties;
@@ -74,7 +75,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
             IFluidHandler sourceHandler = pipeTile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
             IFluidHandler receiverHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
             if (sourceHandler != null && receiverHandler != null && blockFluidPipe.canPushIntoFluidHandler(pipeTile, tileEntity, sourceHandler, receiverHandler)) {
-                CoverPump.moveHandlerFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE, FLUID_FILTER_ALWAYS_TRUE);
+                GTFluidUtils.moveHandlerFluids(sourceHandler, receiverHandler, Integer.MAX_VALUE, FLUID_FILTER_ALWAYS_TRUE);
             }
         }
         blockPos.release();


### PR DESCRIPTION
**What:**
There was unnecessary code coupling for fluid transfer which let to `PumpCover` being referenced by classes which did not really needed.

**How solved:**
`GTFluidsUtils` class introduced which will be responsible for handling fluid transfer.

**Outcome:**
Small refactor of fluid transfer.

**Possible compatibility issue:**
There were only additions to API. But someone may using `CoverPump.moveHandlerFluids` directly as it was public.