### PR TITLE
Add NanoSaber configuration options

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -86,6 +86,9 @@ public class ConfigHolder {
     @Config.Comment("Category that contains configs for machines with specific behavior")
     public static MachineSpecificConfiguration machineSpecific = new MachineSpecificConfiguration();
 
+    @Config.Comment("Category that contains configs for the NanoSaber")
+    public static NanoSaberConfiguration nanoSaberConfiguration = new NanoSaberConfiguration();
+
     @Config.Comment("Sets the bonus EU output of Steam Turbines. Default: 6144")
     @Config.RequiresMcRestart
     public static int steamTurbineBonusOutput = 6144;
@@ -128,5 +131,26 @@ public class ConfigHolder {
     public static class MachineSpecificConfiguration {
         @Config.Comment("Array of blacklisted dimension IDs in which Air Collector does not work.")
         public int[] airCollectorDimensionBlacklist = new int[]{};
+    }
+
+    public static class NanoSaberConfiguration {
+
+        @Config.RangeDouble(min = 0, max = 100)
+        @Config.Comment("The additional damage added when the NanoSaber is powered. Default: 20f")
+        @Config.RequiresMcRestart
+        public double nanoSaberDamageBoost = 20;
+
+        @Config.RangeDouble(min = 0, max = 100)
+        @Config.Comment("The base damage of the NanoSaber. Default: 5f")
+        @Config.RequiresMcRestart
+        public double nanoSaberBaseDamage = 5;
+
+        @Config.Comment("Should Zombies spawn with NanoSabers? Default: true")
+        public boolean zombieSpawnWithSabers = true;
+
+        @Config.RangeInt(min = 1, max = 512)
+        @Config.Comment("The EU/t consumption of the NanoSaber. Default: 64")
+        @Config.RequiresMcRestart
+        public int energyConsumption = 64;
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -136,16 +136,16 @@ public class ConfigHolder {
     public static class NanoSaberConfiguration {
 
         @Config.RangeDouble(min = 0, max = 100)
-        @Config.Comment("The additional damage added when the NanoSaber is powered. Default: 20f")
+        @Config.Comment("The additional damage added when the NanoSaber is powered. Default: 20.0")
         @Config.RequiresMcRestart
         public double nanoSaberDamageBoost = 20;
 
         @Config.RangeDouble(min = 0, max = 100)
-        @Config.Comment("The base damage of the NanoSaber. Default: 5f")
+        @Config.Comment("The base damage of the NanoSaber. Default: 5.0")
         @Config.RequiresMcRestart
         public double nanoSaberBaseDamage = 5;
 
-        @Config.Comment("Should Zombies spawn with NanoSabers? Default: true")
+        @Config.Comment("Should Zombies spawn with charged, active NanoSabers on hard difficulty? Default: true")
         public boolean zombieSpawnWithSabers = true;
 
         @Config.RangeInt(min = 1, max = 512)

--- a/src/main/java/gregtech/common/entities/EntitySpawnHandler.java
+++ b/src/main/java/gregtech/common/entities/EntitySpawnHandler.java
@@ -1,6 +1,7 @@
 package gregtech.common.entities;
 
 import gregtech.api.GTValues;
+import gregtech.common.ConfigHolder;
 import gregtech.common.items.MetaItems;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import net.minecraft.entity.EntityLivingBase;
@@ -20,7 +21,7 @@ public class EntitySpawnHandler {
         EntityLivingBase entity = event.getEntityLiving();
         EnumDifficulty difficulty = entity.world.getDifficulty();
         if (difficulty == EnumDifficulty.HARD && entity.getRNG().nextFloat() <= 0.03f) {
-            if (entity instanceof EntityZombie) {
+            if (entity instanceof EntityZombie && ConfigHolder.nanoSaberConfiguration.zombieSpawnWithSabers) {
                 ItemStack itemStack = MetaItems.NANO_SABER.getInfiniteChargedStack();
                 ToggleEnergyConsumerBehavior.setItemActive(itemStack, true);
                 entity.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, itemStack);

--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -70,7 +70,7 @@ public class MetaItem2 extends MaterialMetaItem {
         POWER_UNIT_HV = addItem(575, "power_unit.hv") .addComponents(ElectricStats.createElectricItem(1600000L, GTValues.HV)).setMaxStackSize(8);
         JACKHAMMER_BASE = addItem(576, "jackhammer_base").addComponents(ElectricStats.createElectricItem(1600000L, GTValues.HV)).setMaxStackSize(4);
 
-        NANO_SABER = addItem(577, "nano_saber").addComponents(ElectricStats.createElectricItem(4000000L, GTValues.HV)).addComponents(new NanoSaberBehavior((float)ConfigHolder.nanoSaberConfiguration.nanoSaberBaseDamage, (float)ConfigHolder.nanoSaberConfiguration.nanoSaberDamageBoost, ConfigHolder.nanoSaberConfiguration.energyConsumption)).setMaxStackSize(1);
+        NANO_SABER = addItem(577, "nano_saber").addComponents(ElectricStats.createElectricItem(4000000L, GTValues.HV)).addComponents(new NanoSaberBehavior()).setMaxStackSize(1);
         ENERGY_FIELD_PROJECTOR = addItem(578, "energy_field_projector").addComponents(ElectricStats.createElectricItem(16000000L, GTValues.EV)).setMaxStackSize(1);
         SCANNER = addItem(579, "scanner").addComponents(ElectricStats.createElectricItem(200_000L, GTValues.LV), new ScannerBehavior(50));
 

--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -12,6 +12,7 @@ import gregtech.api.unification.material.MarkerMaterials.Tier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.RandomPotionEffect;
+import gregtech.common.ConfigHolder;
 import gregtech.common.items.behaviors.FacadeItem;
 import gregtech.common.items.behaviors.ScannerBehavior;
 import gregtech.common.items.behaviors.NanoSaberBehavior;
@@ -69,7 +70,7 @@ public class MetaItem2 extends MaterialMetaItem {
         POWER_UNIT_HV = addItem(575, "power_unit.hv") .addComponents(ElectricStats.createElectricItem(1600000L, GTValues.HV)).setMaxStackSize(8);
         JACKHAMMER_BASE = addItem(576, "jackhammer_base").addComponents(ElectricStats.createElectricItem(1600000L, GTValues.HV)).setMaxStackSize(4);
 
-        NANO_SABER = addItem(577, "nano_saber").addComponents(ElectricStats.createElectricItem(4000000L, GTValues.HV)).addComponents(new NanoSaberBehavior(5.0f, 20.0f, 64)).setMaxStackSize(1);
+        NANO_SABER = addItem(577, "nano_saber").addComponents(ElectricStats.createElectricItem(4000000L, GTValues.HV)).addComponents(new NanoSaberBehavior((float)ConfigHolder.nanoSaberConfiguration.nanoSaberBaseDamage, (float)ConfigHolder.nanoSaberConfiguration.nanoSaberDamageBoost, ConfigHolder.nanoSaberConfiguration.energyConsumption)).setMaxStackSize(1);
         ENERGY_FIELD_PROJECTOR = addItem(578, "energy_field_projector").addComponents(ElectricStats.createElectricItem(16000000L, GTValues.EV)).setMaxStackSize(1);
         SCANNER = addItem(579, "scanner").addComponents(ElectricStats.createElectricItem(200_000L, GTValues.LV), new ScannerBehavior(50));
 

--- a/src/main/java/gregtech/common/items/behaviors/NanoSaberBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/NanoSaberBehavior.java
@@ -7,6 +7,7 @@ import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.items.metaitem.stats.IEnchantabilityHelper;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.unification.material.Materials;
+import gregtech.common.ConfigHolder;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
@@ -24,13 +25,13 @@ public class NanoSaberBehavior extends ToggleEnergyConsumerBehavior implements I
     protected static final UUID ATTACK_DAMAGE_MODIFIER = UUID.fromString("CB3F55D3-645C-4F38-A288-9C13A33DB5CF");
     protected static final UUID ATTACK_SPEED_MODIFIER = UUID.fromString("FA233E1C-4180-4288-B01B-BCCE9785ACA3");
 
-    private final float baseAttackDamage;
-    private final float additionalAttackDamage;
+    private final double baseAttackDamage;
+    private final double additionalAttackDamage;
 
-    public NanoSaberBehavior(float baseAttackDamage, float additionalAttackDamage, int energyUsagePerTick) {
-        super(energyUsagePerTick);
-        this.baseAttackDamage = baseAttackDamage;
-        this.additionalAttackDamage = additionalAttackDamage;
+    public NanoSaberBehavior() {
+        super(ConfigHolder.nanoSaberConfiguration.energyConsumption);
+        this.baseAttackDamage = ConfigHolder.nanoSaberConfiguration.nanoSaberBaseDamage;
+        this.additionalAttackDamage = ConfigHolder.nanoSaberConfiguration.nanoSaberDamageBoost;
     }
 
     @Override
@@ -42,7 +43,7 @@ public class NanoSaberBehavior extends ToggleEnergyConsumerBehavior implements I
     public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack) {
         HashMultimap<String, AttributeModifier> modifiers = HashMultimap.create();
         if(slot == EntityEquipmentSlot.MAINHAND) {
-            float attackDamage = baseAttackDamage + (isItemActive(stack) ? additionalAttackDamage : 0.0f);
+            double attackDamage = baseAttackDamage + (isItemActive(stack) ? additionalAttackDamage : 0.0D);
             modifiers.put(SharedMonsterAttributes.ATTACK_SPEED.getName(), new AttributeModifier(ATTACK_SPEED_MODIFIER, "Weapon modifier", -2.0, 0));
             modifiers.put(SharedMonsterAttributes.ATTACK_DAMAGE.getName(), new AttributeModifier(ATTACK_DAMAGE_MODIFIER, "Weapon Modifier", attackDamage, 0));
         }


### PR DESCRIPTION
**What:**
This PR adds configuration options for the NanoSaber, so it would be possible to buff it, as mentioned in #1242. Does not implement the armor penetration due to the fact that there is no clean way to implement it, without going outside the scope of the mod.

**How solved:**
Adds a config category for the NanoSaber configuration options, which contains entries for the NanoSaber's base damage, additional attack damage when powered, EU/t consumption, and if Zombies should be able to spawn with the NanoSabers.

**Outcome:**
Closes #1242. Adds configuration options for the NanoSaber's base damage, additional damage, EU/t consumption, and if Zombies should be able to spawn with it.

**Possible compatibility issue:**
None expected

