### PR TITLE
JEI fix for getting fluids as ingredients

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIGuiHandler.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGuiHandler.java
@@ -61,8 +61,6 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
     @Override
     public Object getIngredientUnderMouse(ModularUIGui gui, int mouseX, int mouseY) {
         Collection<Widget> widgets = gui.getModularUI().guiWidgets.values();
-        mouseX -= gui.getGuiLeft();
-        mouseY -= gui.getGuiTop();
         for (Widget widget : widgets) {
             if (widget instanceof IIngredientSlot) {
                 Object result = ((IIngredientSlot) widget).getIngredientOverMouse(mouseX, mouseY);


### PR DESCRIPTION
Fixes #1234
I think this was a leftover offset for the widget changes that quite didnt make it.
clicking 'R' and 'U' on fluids in machines will properly open JEI Recipes/Usages