### PR TITLE
Suggested fix for #1241

### DIFF
--- a/src/main/java/gregtech/common/inventory/itemsource/NetworkItemInfo.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/NetworkItemInfo.java
@@ -3,14 +3,14 @@ package gregtech.common.inventory.itemsource;
 import gregtech.api.util.ItemStackKey;
 import gregtech.common.inventory.IItemInfo;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NetworkItemInfo implements IItemInfo {
 
     private final ItemStackKey itemStackKey;
     private int totalItemAmount = 0;
-    private Map<ItemSource, Integer> inventories = new HashMap<>();
+    private Map<ItemSource, Integer> inventories = new ConcurrentHashMap<>();
 
     public NetworkItemInfo(ItemStackKey itemStackKey) {
         this.itemStackKey = itemStackKey;


### PR DESCRIPTION
This PR solves the concurrent modification exception when using the crafting station with a recipe that has its ingredients split in adjacent inventories.

How solved: Changed use of hashMap to concurrentHashMap to avoid concurrent modification exception caused by iterating the hashMap.

`consumeRecipeItems` method in 
gregtech/common/metatileentities/storage/CachedRecipeData.java
calls for the `extractItem` method in 
gregtech/common/inventory/itemsource/NetworkItemInfo.java
that iterates the hashMap `inventories` on `extractItem `and `recomputeItemAmount` methods.

Outcome: Fixes: #1241 

Possible compatibility issue: its said that concurrentHashMap is slower than hashMap, but the functions of the crafting station are all manual, so they shouldn't hurt much ?

Please fill in as much useful information as possible. Also please remove all unused sections.