### PR TITLE
Display all bucket fluid recipes for the Fluid Canner Machine

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -107,7 +107,7 @@ public class ConfigHolder {
 
     @Config.Comment("Show all the cell and bucket recipes for the Fluid Canner Machine. Default false")
     @Config.RequiresMcRestart
-    public static boolean showAllBucketAndCellRecipesForFluidCannerMachine = true;
+    public static boolean showAllBucketAndCellRecipesForFluidCannerMachine = false;
 
     public static class VanillaRecipes {
 

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -105,6 +105,10 @@ public class ConfigHolder {
     @Config.Comment("If true, powered zero loss wires will damage the player. Default: false")
     public static boolean doLosslessWiresDamage = false;
 
+    @Config.Comment("Show all the cell and bucket recipes for the Fluid Canner Machine. Default false")
+    @Config.RequiresMcRestart
+    public static boolean showAllBucketAndCellRecipesForFluidCannerMachine = true;
+
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf the paper crafting recipe. Default: true")

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe;
 
+import codechicken.lib.util.ItemUtils;
 import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.recipes.CountableIngredient;
@@ -40,7 +41,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -1032,6 +1036,19 @@ public class MachineRecipeLoader {
         RecipeMaps.FLUID_CANNER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(MetaItems.BATTERY_HULL_LV.getStackForm()).fluidInputs(Materials.SulfuricAcid.getFluid(1000)).outputs(MetaItems.BATTERY_SU_LV_SULFURIC_ACID.getChargedStack(Long.MAX_VALUE)).buildAndRegister();
         RecipeMaps.FLUID_CANNER_RECIPES.recipeBuilder().duration(200).EUt(30).inputs(MetaItems.BATTERY_HULL_MV.getStackForm()).fluidInputs(Materials.SulfuricAcid.getFluid(4000)).outputs(MetaItems.BATTERY_SU_MV_SULFURIC_ACID.getChargedStack(Long.MAX_VALUE)).buildAndRegister();
         RecipeMaps.FLUID_CANNER_RECIPES.recipeBuilder().duration(400).EUt(30).inputs(MetaItems.BATTERY_HULL_HV.getStackForm()).fluidInputs(Materials.SulfuricAcid.getFluid(16000)).outputs(MetaItems.BATTERY_SU_HV_SULFURIC_ACID.getChargedStack(Long.MAX_VALUE)).buildAndRegister();
+
+        if (ConfigHolder.showAllBucketAndCellRecipesForFluidCannerMachine) {
+            FluidRegistry.getBucketFluids().forEach(fluid -> {
+                FluidStack fluidStack = new FluidStack(fluid, 1000);
+                RecipeMaps.FLUID_CANNER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(new ItemStack(Items.BUCKET)).fluidInputs(fluidStack).outputs(FluidUtil.getFilledBucket(fluidStack)).buildAndRegister();
+                ItemStack cellStack = FLUID_CELL.getStackForm().copy();
+                IFluidHandlerItem fluidHandler = FluidUtil.getFluidHandler(cellStack);
+                if (fluidHandler != null) {
+                    fluidHandler.fill(fluidStack, true);
+                    RecipeMaps.FLUID_CANNER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(FLUID_CELL.getStackForm()).fluidInputs(fluidStack).outputs(fluidHandler.getContainer()).buildAndRegister();
+                }
+            });
+        }
 
         RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(600).EUt(28).input(OrePrefix.dust, Materials.Quartzite, 1).fluidOutputs(Materials.Glass.getFluid(72)).buildAndRegister();
         RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(128).EUt(4).inputs(new ItemStack(Items.COAL, 1, 1)).chancedOutput(OreDictUnifier.get(OrePrefix.dust, Materials.Ash, 1), 1000, 200).fluidOutputs(Materials.Creosote.getFluid(100)).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe;
 
-import codechicken.lib.util.ItemUtils;
 import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.recipes.CountableIngredient;


### PR DESCRIPTION
What:
As mentioned in #1220, the Fluid Canner Machine only shows the recipes related to batteries. With the proper configuration setting, we would like to show all cell-capable and bucket-capable recipes.

How solved:
Iterates through all the bucket fluids from the FluidRegistry and add the proper recipe

Outcome:
Recipes described in this PR will become available if configured accordingly.
Closes #1220