### PR TITLE
Bugfix/item filter not persisting items if size over 127

### DIFF
--- a/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
+++ b/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
@@ -7,16 +7,14 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.items.ItemStackHandler;
 
 /**
- * This is facade for ItemStackHandler which supports stack sizes > 127
+ * This is facade for ItemStackHandler which supports NBT handling of stack sizes > 127
  */
 public class LargeStackSizeItemStackHandler extends ItemStackHandler {
 
-    private static final String BigStackSizeTagKey = "BigStackSize";
-    private static final Byte FakeStackSize = new Byte("1");
-
-    public LargeStackSizeItemStackHandler() {
-        super();
-    }
+    private static final String ITEM_LIST_TAG_KEY = "Items";
+    private static final String ITEM_COUNT_TAG_KEY = "Count";
+    private static final String BIG_STACK_SIZE_TAG_KEY = "BigStackSize";
+    private static final Byte FAKE_STACK_SIZE = new Byte("1");
 
     public LargeStackSizeItemStackHandler(int maxMatchSlots) {
         super(maxMatchSlots);
@@ -28,24 +26,25 @@ public class LargeStackSizeItemStackHandler extends ItemStackHandler {
 
         if (stacks.stream().anyMatch(x -> x.getCount() > Byte.MAX_VALUE)) {
             NBTTagCompound stackSizes = new NBTTagCompound();
-            NBTTagList items = tagCompound.getTagList("Items", 10);
+            NBTTagList items = tagCompound.getTagList(ITEM_LIST_TAG_KEY, 10);
 
             //save big stack size data
             for (int i = 0; i < stacks.size(); i++) {
                 ItemStack itemStack = stacks.get(i);
+
                 if (itemStack != ItemStack.EMPTY && itemStack.getCount() > Byte.MAX_VALUE) {
                     stackSizes.setInteger(String.valueOf(i), itemStack.getCount());
                 }
             }
-            tagCompound.setTag(BigStackSizeTagKey, stackSizes);
+            tagCompound.setTag(BIG_STACK_SIZE_TAG_KEY, stackSizes);
 
             //fix size overflow of existing item tags
             for (NBTBase itemBase : items.tagList) {
                 NBTTagCompound item = (NBTTagCompound) itemBase;
 
-                byte size = item.getByte("Count");
+                byte size = item.getByte(ITEM_COUNT_TAG_KEY);
                 if (size < 0)
-                    item.setByte("Count", FakeStackSize);
+                    item.setByte(ITEM_COUNT_TAG_KEY, FAKE_STACK_SIZE);
             }
         }
 
@@ -56,8 +55,8 @@ public class LargeStackSizeItemStackHandler extends ItemStackHandler {
     public void deserializeNBT(NBTTagCompound tagCompound) {
         super.deserializeNBT(tagCompound);
 
-        if (tagCompound.hasKey(BigStackSizeTagKey)) {
-            NBTTagCompound stackSizes = tagCompound.getCompoundTag(BigStackSizeTagKey);
+        if (tagCompound.hasKey(BIG_STACK_SIZE_TAG_KEY)) {
+            NBTTagCompound stackSizes = tagCompound.getCompoundTag(BIG_STACK_SIZE_TAG_KEY);
 
             for (String tagKey : stackSizes.getKeySet()) {
                 int size = stackSizes.getInteger(tagKey);

--- a/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
+++ b/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
@@ -1,0 +1,69 @@
+package gregtech.api.util;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.items.ItemStackHandler;
+
+/**
+ * This is facade for ItemStackHandler which supports stack sizes > 127
+ */
+public class LargeStackSizeItemStackHandler extends ItemStackHandler {
+
+    private static final String BigStackSizeTagKey = "BigStackSize";
+    private static final Byte FakeStackSize = new Byte("1");
+
+    public LargeStackSizeItemStackHandler() {
+        super();
+    }
+
+    public LargeStackSizeItemStackHandler(int maxMatchSlots) {
+        super(maxMatchSlots);
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        NBTTagCompound tagCompound = super.serializeNBT();
+
+        if (stacks.stream().anyMatch(x -> x.getCount() > Byte.MAX_VALUE)) {
+            NBTTagCompound stackSizes = new NBTTagCompound();
+            NBTTagList items = tagCompound.getTagList("Items", 10);
+
+            //save big stack size data
+            for (int i = 0; i < stacks.size(); i++) {
+                ItemStack itemStack = stacks.get(i);
+                if (itemStack != ItemStack.EMPTY && itemStack.getCount() > Byte.MAX_VALUE) {
+                    stackSizes.setInteger(String.valueOf(i), itemStack.getCount());
+                }
+            }
+            tagCompound.setTag(BigStackSizeTagKey, stackSizes);
+
+            //fix size overflow of existing item tags
+            for (NBTBase itemBase : items.tagList) {
+                NBTTagCompound item = (NBTTagCompound) itemBase;
+
+                byte size = item.getByte("Count");
+                if (size < 0)
+                    item.setByte("Count", FakeStackSize);
+            }
+        }
+
+        return tagCompound;
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound tagCompound) {
+        super.deserializeNBT(tagCompound);
+
+        if (tagCompound.hasKey(BigStackSizeTagKey)) {
+            NBTTagCompound stackSizes = tagCompound.getCompoundTag(BigStackSizeTagKey);
+
+            for (String tagKey : stackSizes.getKeySet()) {
+                int size = stackSizes.getInteger(tagKey);
+                int slot = Integer.parseInt(tagKey);
+                stacks.get(slot).setCount(size);
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
@@ -4,6 +4,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.PhantomSlotWidget;
 import gregtech.api.gui.widgets.ToggleButtonWidget;
+import gregtech.api.util.LargeStackSizeItemStackHandler;
 import gregtech.api.util.ItemStackKey;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -22,7 +23,7 @@ public class SimpleItemFilter extends ItemFilter {
     protected boolean ignoreNBT = true;
 
     public SimpleItemFilter() {
-        this.itemFilterSlots = new ItemStackHandler(MAX_MATCH_SLOTS) {
+        this.itemFilterSlots = new LargeStackSizeItemStackHandler(MAX_MATCH_SLOTS) {
             @Override
             public int getSlotLimit(int slot) {
                 return getMaxStackSize();


### PR DESCRIPTION
**What:**
Fix for problem described in #1280 

**How solved:**
Added `LargeStackSizeItemStackHandler` which is facade over `ItemStackHandler` and handles correct saving and loading of NBT for `ItemStack` with size > 127

**Outcome:**
API extended of `LargeStackSizeItemStackHandler`
Fixes problem with Item Filter not persisting items with size > 127
Fixes: #1280 

**Possible compatibility issue:**
None - API was only extended and update from previous version tested.
