### PR TITLE
Feature/make granite its own material

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -431,6 +431,7 @@ public class Materials {
     public static DustMaterial Basalt = new DustMaterial(240, "basalt", 0x1E1414, MaterialIconSet.ROUGH, 1, of(new MaterialStack(Olivine, 1), new MaterialStack(Calcite, 3), new MaterialStack(Flint, 8), new MaterialStack(DarkAsh, 4)), NO_SMASHING);
     public static DustMaterial Andesite = new DustMaterial(241, "andesite", 0xBEBEBE, MaterialIconSet.ROUGH, 2, of(), NO_SMASHING);
     public static DustMaterial Diorite = new DustMaterial(242, "diorite", 0xFFFFFF, MaterialIconSet.ROUGH, 2, of(), NO_SMASHING);
+    public static DustMaterial Granite = new DustMaterial(449, "granite", 0xCFA18C, MaterialIconSet.ROUGH, 2, of(), NO_SMASHING);
     public static GemMaterial GarnetRed = new GemMaterial(243, "garnet_red", 0xC85050, MaterialIconSet.RUBY, 2, of(new MaterialStack(Pyrope, 3), new MaterialStack(Almandine, 5), new MaterialStack(Spessartine, 8)), STD_SOLID | GENERATE_LENSE | NO_SMASHING | NO_SMELTING | HIGH_SIFTER_OUTPUT | GENERATE_ORE, null, 7.5F, 3.0f, 156);
     public static GemMaterial GarnetYellow = new GemMaterial(244, "garnet_yellow", 0xC8C850, MaterialIconSet.RUBY, 2, of(new MaterialStack(Andradite, 5), new MaterialStack(Grossular, 8), new MaterialStack(Uvarovite, 3)), STD_SOLID | GENERATE_LENSE | NO_SMASHING | NO_SMELTING | HIGH_SIFTER_OUTPUT | GENERATE_ORE, null, 7.5F, 3.0f, 156);
     public static DustMaterial Marble = new DustMaterial(245, "marble", 0xC8C8C8, MaterialIconSet.FINE, 1, of(new MaterialStack(Magnesium, 1), new MaterialStack(Calcite, 7)), NO_SMASHING);

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -88,8 +88,8 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.GLASS), OrePrefix.block, Materials.Glass);
         OreDictUnifier.registerOre(MetaBlocks.CONCRETE.getItemVariant(BlockConcrete.ConcreteVariant.LIGHT_CONCRETE, StoneBlock.ChiselingVariant.NORMAL), OrePrefix.block, Materials.Concrete);
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 1), OrePrefix.stone, Materials.GraniteBlack);
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 2), OrePrefix.stone, Materials.GraniteBlack);
+        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 1), OrePrefix.stone, Materials.Granite);
+        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 2), OrePrefix.stone, Materials.Granite);
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 5), OrePrefix.stone, Materials.Andesite);
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 6), OrePrefix.stone, Materials.Andesite);
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 3), OrePrefix.stone, Materials.Diorite);

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1015,6 +1015,12 @@ public class MachineRecipeLoader {
             .outputs(OreDictUnifier.get(OrePrefix.dust, Materials.Diorite, 1))
             .chancedOutput(OreDictUnifier.get(OrePrefix.dustSmall, Materials.Stone, 1), 100, 40)
             .buildAndRegister();
+
+        RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
+            .input(OrePrefix.stone, Materials.Granite)
+            .outputs(OreDictUnifier.get(OrePrefix.dust, Materials.Granite, 1))
+            .chancedOutput(OreDictUnifier.get(OrePrefix.dustSmall, Materials.Stone, 1), 100, 40)
+            .buildAndRegister();
     }
 
     private static void registerFluidRecipes() {

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1299,6 +1299,7 @@ material.phosphor=Phosphor
 material.basalt=Basalt
 material.andesite=Andesite
 material.diorite=Diorite
+material.granite=Granite
 material.garnet_red=Red Garnet
 material.garnet_yellow=Yellow Garnet
 material.marble=Marble


### PR DESCRIPTION
**What:**
Implemented Vanilla MC Granite as it's own material based on #1286 

**Outcome:**
Granite from Vanilla MC is it's own material
Recipes for macerating Granite changed
Resolves: #1286 

**Additional info:**
Change in Macerating recipes and Oredict entries
Before:
![2020-10-29_09 35 26](https://user-images.githubusercontent.com/3093101/97554996-dc52a980-19d7-11eb-8283-7d2b99f1a5a2.png)
![2020-10-29_09 35 18](https://user-images.githubusercontent.com/3093101/97554994-db217c80-19d7-11eb-965a-d48f4ea969f6.png)

After:
![2020-10-29_10 40 13](https://user-images.githubusercontent.com/3093101/97555080-f4c2c400-19d7-11eb-9d08-621727ac15b4.png)
![2020-10-29_10 40 22](https://user-images.githubusercontent.com/3093101/97555083-f5f3f100-19d7-11eb-9d14-48d37d534b65.png)

New compressed block and dust for Granite with Diorite for comparison:
![2020-10-29_10 39 45](https://user-images.githubusercontent.com/3093101/97555203-1c199100-19d8-11eb-8bf2-2077d47c0ed9.png)

**Possible compatibility issue:**
Nothing major expected as material is withing GTCE material ID range, items from changed recipes are still obtainable (and this was not even best source), removed oredict entries does not make sense for given blocks

New material granite (id=449) added
Macerating recipe changed for Granite and Polished Granite as shown in screenshots from previous block
Oredict entry changed for Granite and Polished Granite as shown in screenshots from previous block