### PR TITLE
Better interaction with non-extractable neighbour inventories

### DIFF
--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
@@ -40,12 +40,7 @@ public class ItemSourceList implements IItemList, ITickable {
 
     @Override
     public Set<ItemStackKey> getStoredItems() {
-        return storedItemsView.stream()
-            .filter(storedItem -> {
-                ItemStack itemStack = storedItem.getItemStack();
-                int extractedCount = extractItem(storedItem, itemStack.getCount(), true);
-                return extractedCount > 0;
-            }).collect(Collectors.toSet());
+        return storedItemsView;
     }
 
     @Nullable

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
@@ -5,12 +5,14 @@ import gregtech.api.util.ItemStackKey;
 import gregtech.common.inventory.IItemInfo;
 import gregtech.common.inventory.IItemList;
 import gregtech.common.pipelike.inventory.network.UpdateResult;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ITickable;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 public class ItemSourceList implements IItemList, ITickable {
 
@@ -38,7 +40,12 @@ public class ItemSourceList implements IItemList, ITickable {
 
     @Override
     public Set<ItemStackKey> getStoredItems() {
-        return storedItemsView;
+        return storedItemsView.stream()
+            .map(storedItem -> {
+                ItemStack itemStack = storedItem.getItemStack();
+                int extractedCount = extractItem(storedItem, itemStack.getCount(), true);
+                return new ItemStackKey(new ItemStack(itemStack.getItem(), extractedCount));
+            }).collect(Collectors.toSet());
     }
 
     @Nullable

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
@@ -41,10 +41,10 @@ public class ItemSourceList implements IItemList, ITickable {
     @Override
     public Set<ItemStackKey> getStoredItems() {
         return storedItemsView.stream()
-            .map(storedItem -> {
+            .filter(storedItem -> {
                 ItemStack itemStack = storedItem.getItemStack();
                 int extractedCount = extractItem(storedItem, itemStack.getCount(), true);
-                return new ItemStackKey(new ItemStack(itemStack.getItem(), extractedCount));
+                return extractedCount > 0;
             }).collect(Collectors.toSet());
     }
 

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
@@ -139,12 +139,15 @@ public class ItemSourceList implements IItemList, ITickable {
     void updateStoredItems(ItemSource handlerInfo, Map<ItemStackKey, Integer> itemAmount, Set<ItemStackKey> removedItems) {
         boolean updatedItemAmount = false;
         for (ItemStackKey itemStackKey : itemAmount.keySet()) {
-            NetworkItemInfo itemInfo = itemInfoMap.get(itemStackKey);
-            if (itemInfo == null) {
-                itemInfo = new NetworkItemInfo(itemStackKey);
-                this.itemInfoMap.put(itemStackKey, itemInfo);
+            int extractedAmount = handlerInfo.extractItem(itemStackKey, 1, true);
+            if (extractedAmount > 0) {
+                NetworkItemInfo itemInfo = itemInfoMap.get(itemStackKey);
+                if (itemInfo == null) {
+                    itemInfo = new NetworkItemInfo(itemStackKey);
+                    this.itemInfoMap.put(itemStackKey, itemInfo);
+                }
+                updatedItemAmount |= itemInfo.addInventory(handlerInfo, itemAmount.get(itemStackKey));
             }
-            updatedItemAmount |= itemInfo.addInventory(handlerInfo, itemAmount.get(itemStackKey));
         }
         for (ItemStackKey removedItem : removedItems) {
             NetworkItemInfo itemInfo = itemInfoMap.get(removedItem);

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSourceList.java
@@ -5,14 +5,12 @@ import gregtech.api.util.ItemStackKey;
 import gregtech.common.inventory.IItemInfo;
 import gregtech.common.inventory.IItemList;
 import gregtech.common.pipelike.inventory.network.UpdateResult;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ITickable;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
 public class ItemSourceList implements IItemList, ITickable {
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -209,9 +209,11 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
 
     private AbstractWidgetGroup createItemListTab() {
         WidgetGroup widgetGroup = new WidgetGroup();
+        widgetGroup.addWidget(new LabelWidget(5, 20, "(Available items from connected"));
+        widgetGroup.addWidget(new LabelWidget(5, 30, "inventories usable for crafting)"));
         CraftingRecipeResolver recipeResolver = getRecipeResolver();
         IItemList itemList = recipeResolver == null ? null : recipeResolver.getItemSourceList();
-        widgetGroup.addWidget(new ItemListGridWidget(2, 17, 9, 6, itemList));
+        widgetGroup.addWidget(new ItemListGridWidget(2, 47, 9, 5, itemList));
         return widgetGroup;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -213,7 +213,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
         widgetGroup.addWidget(new LabelWidget(5, 30, "gregtech.machine.workbench.storage_note_2"));
         CraftingRecipeResolver recipeResolver = getRecipeResolver();
         IItemList itemList = recipeResolver == null ? null : recipeResolver.getItemSourceList();
-        widgetGroup.addWidget(new ItemListGridWidget(2, 47, 9, 5, itemList));
+        widgetGroup.addWidget(new ItemListGridWidget(2, 45, 9, 5, itemList));
         return widgetGroup;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -209,8 +209,8 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
 
     private AbstractWidgetGroup createItemListTab() {
         WidgetGroup widgetGroup = new WidgetGroup();
-        widgetGroup.addWidget(new LabelWidget(5, 20, "(Available items from connected"));
-        widgetGroup.addWidget(new LabelWidget(5, 30, "inventories usable for crafting)"));
+        widgetGroup.addWidget(new LabelWidget(5, 20, "gregtech.machine.workbench.storage_note_1"));
+        widgetGroup.addWidget(new LabelWidget(5, 30, "gregtech.machine.workbench.storage_note_2"));
         CraftingRecipeResolver recipeResolver = getRecipeResolver();
         IItemList itemList = recipeResolver == null ? null : recipeResolver.getItemSourceList();
         widgetGroup.addWidget(new ItemListGridWidget(2, 47, 9, 5, itemList));

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1757,6 +1757,8 @@ gregtech.machine.locked_safe.requirements=§7Replacements required:
 gregtech.machine.workbench.name=Crafting Station
 gregtech.machine.workbench.tab.workbench=Crafting
 gregtech.machine.workbench.tab.item_list=Storage
+gregtech.machine.workbench.storage_note_1=(Available items from connected
+gregtech.machine.workbench.storage_note_2=inventories usable for crafting)
 gregtech.item_list.items_stored=§7Stored: %d
 
 gregtech.machine.workbench.tab.crafting=Crafting


### PR DESCRIPTION
What:
Based on #1239, implements items 1 and 2 from recommended steps from @LAGIdiot.

Outcome:
Added label in Storage Tab of the Crafting Station to better inform the player
Non-extractable items won't appear in the inventory list of the Crafting Storage's Storage Tab

Note: this is not closing the issue as an upcoming PR will be required to do so