### PR TITLE
Bugfix/nether-quartz-block-to-nether-quartz-recipe-restoration

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -47,6 +47,7 @@ public class CraftingRecipeLoader {
         ModHandler.addShapedRecipe("small_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeSmall, Materials.Wood, 4), "WWW", "h f", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));
         ModHandler.addShapedRecipe("medium_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeMedium, Materials.Wood, 2), "WWW", "f h", "WWW", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));
 
+        ModHandler.addShapelessRecipe("nether_quartz_block_to_nether_quartz", new ItemStack(Items.QUARTZ, 4), Blocks.QUARTZ_BLOCK);
         ModHandler.addShapelessRecipe("clay_block_to_dust", OreDictUnifier.get(OrePrefix.dust, Materials.Clay, 4), 'm', Blocks.CLAY);
         ModHandler.addShapelessRecipe("clay_ball_to_dust", OreDictUnifier.get(OrePrefix.dust, Materials.Clay), 'm', Items.CLAY_BALL);
         ModHandler.addShapelessRecipe("brick_block_to_dust", OreDictUnifier.get(OrePrefix.dust, Materials.Brick, 4), 'm', Blocks.BRICK_BLOCK);


### PR DESCRIPTION
**What:**
Fixed issue described in #1292 

**How solved:**
Added recipe for converting Block of Quartz to 4 Nether Quartz as removing EXCLUDE_BLOCK_CRAFTING_RECIPES flag is not option as it will duplicate other recipes.

**Outcome:**
Recipe for converting Block of Quartz to 4 Nether Quartz restored
Fixes #1292 

**Additional info:**
![2020-11-01_10 13 48](https://user-images.githubusercontent.com/3093101/97798942-fafcae80-1c2a-11eb-905b-7ee9f1fa9aec.png)