### PR TITLE
Allow for filling and emptying Fluid Hatches through the GUI

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
@@ -126,7 +126,8 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
         Builder builder = ModularUI.defaultBuilder();
         builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
         TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
-            .setHideTooltip(true).setAlwaysShowFull(true);
+            .setHideTooltip(true).setAlwaysShowFull(true)
+            .setContainerClicking(!isExportHatch, true);
         builder.widget(tankWidget);
         builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);


### PR DESCRIPTION
**What:**
Based on #1277, this PR allows for filling and emptying Fluid Hatches.

**How solved:**
The TankWidget which Fluid Hatches are relying on already has that feature, I only had to enable it.

**Outcome:**
Closes #1227 

**Additional info:**
Please note that it is not allowed to fill an Output Fluid Hatch with a fluid container, only input hatches are supported to that regard.