### PR TITLE
Fixed recipe validation logging data from builder chance instead of recipe chance  #1294

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -188,7 +188,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (!GTUtility.isBetweenInclusive(getMinOutputs(), getMaxOutputs(), recipe.getOutputs().size() + recipe.getChancedOutputs().size())) {
-            GTLog.logger.error("Invalid amount of recipe outputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getOutputs().size() + recipeBuilder().getChancedOutputs().size(), getMinOutputs(), getMaxOutputs());
+            GTLog.logger.error("Invalid amount of recipe outputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getOutputs().size() + recipe.getChancedOutputs().size(), getMinOutputs(), getMaxOutputs());
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
             recipeStatus = EnumValidationResult.INVALID;
         }


### PR DESCRIPTION
**Bugfix ?**
Fixed issue #1294 : an error in the code lead to wrong error information mostly annoying when debugging  messed code.

**How solved:**
replace `recipeBuilder()` by `recipe`

**Outcome:**
Fixes : #1294 
