### PR TITLE
[Bugfix] : Machine controllers wrong display/config ignored

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -182,17 +182,30 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     private void resetCurrentControllable() {
         IControllable controllable = getControllable();
         if(controllable != null) {
-            controllable.setWorkingEnabled(true);
+            controllable.setWorkingEnabled(isOtherAllowingWork());
         }
     }
 
     private void updateRedstoneStatus() {
-        boolean shouldAllowWorking = getRedstoneSignalInput() < minRedstoneStrength;
-        if(isInverted) shouldAllowWorking = !shouldAllowWorking;
         IControllable controllable = getControllable();
         if(controllable != null) {
-            controllable.setWorkingEnabled(shouldAllowWorking);
+            controllable.setWorkingEnabled(shouldAllowWorking() && isOtherAllowingWork());
         }
+    }
+
+    private boolean shouldAllowWorking(){
+        boolean shouldAllowWorking = getRedstoneSignalInput() < minRedstoneStrength;
+        return  isInverted != shouldAllowWorking ;// equivalent to isInverted ? !shouldAllowWorking: shouldAllowWorking
+    }
+
+    private boolean isOtherAllowingWork(){
+        boolean otherAllow = true;
+        for (EnumFacing side : EnumFacing.values()){
+            if(side != attachedSide && coverHolder.getCoverAtSide(side) instanceof  CoverMachineController ){
+                otherAllow = otherAllow && ((CoverMachineController)coverHolder.getCoverAtSide(side)).shouldAllowWorking();
+            }
+        }
+        return otherAllow;
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -223,7 +223,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     public void readFromNBT(NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         this.minRedstoneStrength = tagCompound.getInteger("MinRedstoneStrength");
-        if (minRedstoneStrength > 15) minRedstoneStrength = 15;
+        if (minRedstoneStrength > 15) this.minRedstoneStrength = 15;
         this.isInverted = tagCompound.getBoolean("Inverted");
         this.controllerMode = ControllerMode.values()[tagCompound.getInteger("ControllerMode")];
     }

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -14,7 +14,6 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.render.Textures;
-import gregtech.api.util.GTLog;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -34,7 +33,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
 
     public CoverMachineController(ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);
-        this.minRedstoneStrength = 0;
+        this.minRedstoneStrength = 1;
         this.isInverted = false;
         this.controllerMode = ControllerMode.MACHINE;
     }
@@ -116,7 +115,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         updateDisplayInventory();
         return ModularUI.defaultBuilder()
             .label(10, 5, "cover.machine_controller.name")
-            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 0f, 15.0f,
+            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 1f, 15.0f,
                 minRedstoneStrength, it -> setMinRedstoneStrength((int) it)))
             .widget(new ClickButtonWidget(10, 45, 126, 20, "", data -> cycleNextControllerMode()))
             .widget(new SimpleTextWidget(68, 55, "", 0xFFFFFF, () -> getControllerMode().getName()))
@@ -183,14 +182,14 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     private void resetCurrentControllable() {
         IControllable controllable = getControllable();
         if(controllable != null) {
-            controllable.setWorkingEnabled(isOtherAllowingWork());
+            controllable.setWorkingEnabled(doesOtherAllowingWork());
         }
     }
 
     private void updateRedstoneStatus() {
         IControllable controllable = getControllable();
         if(controllable != null) {
-            controllable.setWorkingEnabled(shouldAllowWorking() && isOtherAllowingWork());
+            controllable.setWorkingEnabled(shouldAllowWorking() && doesOtherAllowingWork());
         }
     }
 
@@ -200,11 +199,13 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         return isInverted ? !shouldAllowWorking : shouldAllowWorking;
     }
 
-    private boolean isOtherAllowingWork(){
+    private boolean doesOtherAllowingWork(){
         boolean otherAllow = true;
+        CoverMachineController cover;
         for (EnumFacing side : EnumFacing.values()){
             if(side != attachedSide && coverHolder.getCoverAtSide(side) instanceof  CoverMachineController ){
-                otherAllow = otherAllow && ((CoverMachineController)coverHolder.getCoverAtSide(side)).shouldAllowWorking();
+                cover = (CoverMachineController)coverHolder.getCoverAtSide(side);
+                otherAllow = otherAllow && cover.controllerMode == controllerMode && cover.shouldAllowWorking();
             }
         }
         return otherAllow;

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -196,7 +196,8 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
 
     private boolean shouldAllowWorking(){
         boolean shouldAllowWorking = getRedstoneSignalInput() < minRedstoneStrength;
-        return  isInverted != shouldAllowWorking ;// equivalent to isInverted ? !shouldAllowWorking: shouldAllowWorking
+        //noinspection SimplifiableConditionalExpression
+        return isInverted ? !shouldAllowWorking : shouldAllowWorking;
     }
 
     private boolean isOtherAllowingWork(){

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -14,6 +14,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.render.Textures;
+import gregtech.api.util.GTLog;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -33,7 +34,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
 
     public CoverMachineController(ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);
-        this.minRedstoneStrength = 1;
+        this.minRedstoneStrength = 0;
         this.isInverted = false;
         this.controllerMode = ControllerMode.MACHINE;
     }
@@ -115,7 +116,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         updateDisplayInventory();
         return ModularUI.defaultBuilder()
             .label(10, 5, "cover.machine_controller.name")
-            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 1.0f, 16.0f,
+            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 0f, 15.0f,
                 minRedstoneStrength, it -> setMinRedstoneStrength((int) it)))
             .widget(new ClickButtonWidget(10, 45, 126, 20, "", data -> cycleNextControllerMode()))
             .widget(new SimpleTextWidget(68, 55, "", 0xFFFFFF, () -> getControllerMode().getName()))
@@ -222,6 +223,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         this.minRedstoneStrength = tagCompound.getInteger("MinRedstoneStrength");
         this.isInverted = tagCompound.getBoolean("Inverted");
         this.controllerMode = ControllerMode.values()[tagCompound.getInteger("ControllerMode")];
+        if (minRedstoneStrength > 15) minRedstoneStrength = 15;
     }
 
     public enum ControllerMode implements IStringSerializable {

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -73,7 +73,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     private void cycleNextControllerMode() {
         List<ControllerMode> allowedModes = getAllowedModes();
         int nextIndex = allowedModes.indexOf(controllerMode) + 1;
-        if(!allowedModes.isEmpty()) {
+        if (!allowedModes.isEmpty()) {
             setControllerMode(allowedModes.get(nextIndex % allowedModes.size()));
         }
     }
@@ -115,7 +115,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         updateDisplayInventory();
         return ModularUI.defaultBuilder()
             .label(10, 5, "cover.machine_controller.name")
-            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 1f, 15.0f,
+            .widget(new SliderWidget("cover.machine_controller.redstone", 10, 20, 156, 20, 1.0f, 15.0f,
                 minRedstoneStrength, it -> setMinRedstoneStrength((int) it)))
             .widget(new ClickButtonWidget(10, 45, 126, 20, "", data -> cycleNextControllerMode()))
             .widget(new SimpleTextWidget(68, 55, "", 0xFFFFFF, () -> getControllerMode().getName()))
@@ -157,9 +157,9 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     private void updateDisplayInventory() {
         EnumFacing controlledSide = getControllerMode().side;
         ItemStack resultStack = ItemStack.EMPTY;
-        if(controlledSide != null) {
+        if (controlledSide != null) {
             CoverBehavior coverBehavior = coverHolder.getCoverAtSide(controlledSide);
-            if(coverBehavior != null) {
+            if (coverBehavior != null) {
                 resultStack = coverBehavior.getCoverDefinition().getDropItemStack();
             }
         }
@@ -168,11 +168,11 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
 
     private IControllable getControllable() {
         EnumFacing side = controllerMode.side;
-        if(side == null) {
+        if (side == null) {
             return coverHolder.getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, null);
         } else {
             CoverBehavior coverBehavior = coverHolder.getCoverAtSide(side);
-            if(coverBehavior == null) {
+            if (coverBehavior == null) {
                 return null;
             }
             return coverBehavior.getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, null);
@@ -181,30 +181,30 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
 
     private void resetCurrentControllable() {
         IControllable controllable = getControllable();
-        if(controllable != null) {
+        if (controllable != null) {
             controllable.setWorkingEnabled(doesOtherAllowingWork());
         }
     }
 
     private void updateRedstoneStatus() {
         IControllable controllable = getControllable();
-        if(controllable != null) {
+        if (controllable != null) {
             controllable.setWorkingEnabled(shouldAllowWorking() && doesOtherAllowingWork());
         }
     }
 
-    private boolean shouldAllowWorking(){
+    private boolean shouldAllowWorking() {
         boolean shouldAllowWorking = getRedstoneSignalInput() < minRedstoneStrength;
         //noinspection SimplifiableConditionalExpression
         return isInverted ? !shouldAllowWorking : shouldAllowWorking;
     }
 
-    private boolean doesOtherAllowingWork(){
+    private boolean doesOtherAllowingWork() {
         boolean otherAllow = true;
         CoverMachineController cover;
-        for (EnumFacing side : EnumFacing.values()){
-            if(side != attachedSide && coverHolder.getCoverAtSide(side) instanceof  CoverMachineController ){
-                cover = (CoverMachineController)coverHolder.getCoverAtSide(side);
+        for (EnumFacing side : EnumFacing.values()) {
+            if (side != attachedSide && coverHolder.getCoverAtSide(side) instanceof CoverMachineController) {
+                cover = (CoverMachineController) coverHolder.getCoverAtSide(side);
                 otherAllow = otherAllow && cover.controllerMode == controllerMode && cover.shouldAllowWorking();
             }
         }
@@ -223,9 +223,9 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
     public void readFromNBT(NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         this.minRedstoneStrength = tagCompound.getInteger("MinRedstoneStrength");
+        if (minRedstoneStrength > 15) minRedstoneStrength = 15;
         this.isInverted = tagCompound.getBoolean("Inverted");
         this.controllerMode = ControllerMode.values()[tagCompound.getInteger("ControllerMode")];
-        if (minRedstoneStrength > 15) minRedstoneStrength = 15;
     }
 
     public enum ControllerMode implements IStringSerializable {


### PR DESCRIPTION
**What:**
Fixed Machine controller slide bar not showing correct bounds
Fixed Machine controller setting being ignored if multiple controller control the same machine.

**How solved:**
Set maximum of `SliderWidge` to 15 and minimum to 0.
Set value loaded from NBT to 15 if it is above it.
Added two methods `shouldAllowWorking()` which is just moved code from `updateRedstoneStatus` and `isOtherAllowingWork()` for checking if other controllers will allow the machine to work.

**Outcome:**
Fixes : #1161 
Fixes : #1268 

**Additional info:**
![Machine controller ui](https://cdn.discordapp.com/attachments/220456119485595648/774291212617908224/Capture_decran_de_2020-11-06_16-15-26.png)

**Possible compatibility issue:**
Possible compatibility issue with older setup if the controller was set to redstone level 16, briefly tested with other level no compatibility issue found.
