### PR TITLE
Bugfix/recipes progress being one tick shorter

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -119,7 +119,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
     protected void updateRecipeProgress() {
         boolean drawEnergy = drawEnergy(recipeEUt);
         if (drawEnergy || (recipeEUt < 0)) {
-            if (++progressTime >= maxProgressTime) {
+            //as recipe starts with progress on 1 this has to be > only not => to compensate for it
+            if (++progressTime > maxProgressTime) {
                 completeRecipe();
             }
         } else if (recipeEUt > 0) {


### PR DESCRIPTION
**What:**
As mentioned in #1272 recipe progress takes one less tick then it should. Which will consume one less tick of energy.
Problem basically is in recipe starting on tick one, as defined here: https://github.com/GregTechCE/GregTech/blob/master/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java#L272

**How solved:**
I choose to go with compensating that one tick by changing logic for recipe finish. It is not best solution but most easy to implement and straight forward. As changing start to 0 would require additional NBT logic shuffling and that can wait to recipe system rewrite.

**Outcome:**
Fixed recipes progress being one tick shorter
Fixes: #1272 
