### PR TITLE
Add Oredicts to granite variants, marble, basalt.

### DIFF
--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -10,6 +10,7 @@ import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTLog;
 import gregtech.common.blocks.BlockConcrete;
+import gregtech.common.blocks.BlockMineral;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.StoneBlock;
 import net.minecraft.init.Blocks;
@@ -94,6 +95,10 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 6), OrePrefix.stone, Materials.Andesite);
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 3), OrePrefix.stone, Materials.Diorite);
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONE, 1, 4), OrePrefix.stone, Materials.Diorite);
+        OreDictUnifier.registerOre(new ItemStack(MetaBlocks.GRANITE, 1, 0), OrePrefix.stone, Materials.GraniteBlack);
+        OreDictUnifier.registerOre(new ItemStack(MetaBlocks.GRANITE, 1, 1), OrePrefix.stone, Materials.GraniteRed);
+        OreDictUnifier.registerOre(MetaBlocks.MINERAL.getItemVariant(BlockMineral.MineralVariant.MARBLE, StoneBlock.ChiselingVariant.NORMAL), OrePrefix.stone, Materials.Marble);
+        OreDictUnifier.registerOre(MetaBlocks.MINERAL.getItemVariant(BlockMineral.MineralVariant.BASALT, StoneBlock.ChiselingVariant.NORMAL), OrePrefix.stone, Materials.Basalt);
 
         OreDictUnifier.registerOre(new ItemStack(Blocks.ANVIL), "craftingAnvil");
         OreDictUnifier.registerOre(new ItemStack(Blocks.OBSIDIAN, 1, W), OrePrefix.stone, Materials.Obsidian);


### PR DESCRIPTION
**What:**
Adds missing granite variants, marble, and basalt to their correct oredicts to generate their maceration recipes, which were reported as missing in #1285 

**How solved:**
The blocks were registered to the correct oredict in the OreDictionaryLoader. For those blocks that had multiple variants, aka bricks, cracked, etc, the normal variant was chosen. 

**Outcome:**
Adds granite variants, marble, and basalt to their respective oredicts. Closes #1285.

**Additional info:**
Screenshot of the output of `/ct hand` for all blocks, demonstrating their oredicts

![oredicts](https://user-images.githubusercontent.com/31759736/98636502-37dc3b80-22e4-11eb-8535-c2fe150e1086.PNG)

**Possible compatibility issue:**
None Expected.


_Please fill in as much useful information as possible. Also please remove all unused sections._