### PR TITLE
Allow Smart Filter matching to ignore required fluid inputs

### DIFF
--- a/src/main/java/gregtech/api/recipes/MatchingMode.java
+++ b/src/main/java/gregtech/api/recipes/MatchingMode.java
@@ -1,0 +1,13 @@
+package gregtech.api.recipes;
+
+/**
+ * This enum is used to describe the way {@link Recipe#matches} should determine if the recipe matches the provided input.
+ * DEFAULT - Both Items and Liquids are checked.
+ * IGNORE_ITEMS - Items input are ignored, only Liquids input are checked.
+ * IGNORE_FLUIDS - Liquids input are ignored, only Items input are checked.
+ */
+public enum MatchingMode {
+    DEFAULT,
+    IGNORE_ITEMS,
+    IGNORE_FLUIDS
+}

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -118,7 +118,6 @@ public class Recipe {
             if (getFluidInputs().isEmpty()) {
                 return false;
             }
-
         } else {
             items = matchesItems(inputs);
             if (!items.getKey()) {

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -204,7 +204,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         }
         return ValidationResult.newResult(recipeStatus, recipe);
     }
-    
+
     @Nullable
     public Recipe findRecipe(long voltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, int outputFluidTankCapacity) {
         return this.findRecipe(voltage, GTUtility.itemHandlerToList(inputs), GTUtility.fluidHandlerToList(fluidInputs), outputFluidTankCapacity);
@@ -213,9 +213,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     /**
      * Finds a Recipe matching the Fluid and ItemStack Inputs.
      *
-     * @param voltage     Voltage of the Machine or Long.MAX_VALUE if it has no Voltage
-     * @param inputs      the Item Inputs
-     * @param fluidInputs the Fluid Inputs
+     * @param voltage                 Voltage of the Machine or Long.MAX_VALUE if it has no Voltage
+     * @param inputs                  the Item Inputs
+     * @param fluidInputs             the Fluid Inputs
      * @param outputFluidTankCapacity minimal capacity of output fluid tank, used for fluid canner recipes for example
      * @return the Recipe it has found or null for no matching Recipe
      */
@@ -236,6 +236,31 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         }
     }
 
+    /**
+     * Finds a Recipe matching ItemStack Inputs ignoring any required fluid input .
+     *
+     * @param voltage                 Voltage of the Machine or Long.MAX_VALUE if it has no Voltage
+     * @param inputs                  the Item Inputs
+     * @param outputFluidTankCapacity minimal capacity of output fluid tank, used for fluid canner recipes for example
+     * @return the Recipe it has found or null for no matching Recipe
+     */
+    @Nullable
+    public Recipe findRecipe(long voltage, List<ItemStack> inputs, int outputFluidTankCapacity) {
+        if (recipeList.isEmpty())
+            return null;
+        if (minInputs > 0 && GTUtility.amountOfNonEmptyStacks(inputs) < minInputs) {
+            return null;
+        }
+        if (inputs.isEmpty())
+            return null;
+        if (maxInputs > 0) {
+            return findByInputs(voltage, inputs);
+        } else {
+            return null;
+        }
+    }
+
+
     @Nullable
     private Recipe findByFluidInputs(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs) {
         for (FluidStack fluid : fluidInputs) {
@@ -255,6 +280,16 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private Recipe findByInputs(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs) {
         for (Recipe recipe : recipeList) {
             if (recipe.matches(false, inputs, fluidInputs)) {
+                return voltage >= recipe.getEUt() ? recipe : null;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private Recipe findByInputs(long voltage, List<ItemStack> inputs) {
+        for (Recipe recipe : recipeList) {
+            if (recipe.matches(inputs) && !recipe.getInputs().isEmpty()) {
                 return voltage >= recipe.getEUt() ? recipe : null;
             }
         }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -33,8 +33,8 @@ import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
-import stanhebben.zenscript.annotations.*;
 import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.*;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -286,10 +286,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     private Recipe findByInputs(long voltage, List<ItemStack> inputs) {
         for (Recipe recipe : recipeList) {
-            if (recipe.matches(inputs) && !recipe.getInputs().isEmpty()) {
+            if (recipe.matches(false, inputs, Collections.EMPTY_LIST, Recipe.MatchingMode.ITEM_ONLY) && !recipe.getInputs().isEmpty()) {
                 return voltage >= recipe.getEUt() ? recipe : null;
             }
         }

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -2,10 +2,7 @@ package gregtech.common.covers.filter;
 
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.CycleButtonWidget;
-import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.Recipe;
-import gregtech.api.recipes.RecipeMap;
-import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.*;
 import gregtech.api.unification.stack.ItemAndMetadata;
 import gregtech.api.util.ItemStackKey;
 import net.minecraft.item.ItemStack;
@@ -56,12 +53,9 @@ public class SmartItemFilter extends ItemFilter {
         if (cachedTransferRateValue == null) {
             ItemStack infinitelyBigStack = itemStack.copy();
             infinitelyBigStack.setCount(Integer.MAX_VALUE);
-            Recipe recipe;
-            if (matchingMode == SmartMatchingMode.DEFAULT) {
-                recipe = filteringMode.recipeMap.findRecipe(Long.MAX_VALUE, Collections.singletonList(infinitelyBigStack), Collections.emptyList(), Integer.MAX_VALUE);
-            } else {
-                recipe = filteringMode.recipeMap.findRecipe(Long.MAX_VALUE, Collections.singletonList(infinitelyBigStack), Integer.MAX_VALUE);
-            }
+
+            Recipe recipe = filteringMode.recipeMap.findRecipe(Long.MAX_VALUE, Collections.singletonList(infinitelyBigStack), Collections.emptyList(), Integer.MAX_VALUE, matchingMode.matchingMode);
+
             if (recipe == null) {
                 filteringMode.transferStackSizesCache.put(itemAndMetadata, 0);
                 cachedTransferRateValue = 0;
@@ -81,9 +75,11 @@ public class SmartItemFilter extends ItemFilter {
     @Override
     public void initUI(Consumer<Widget> widgetGroup) {
         widgetGroup.accept(new CycleButtonWidget(10, 0, 75, 20,
-            SmartFilteringMode.class, this::getFilteringMode, this::setFilteringMode).setTooltipHoverString("cover.smart_item_filter.filtering_mode.description"));
+            SmartFilteringMode.class, this::getFilteringMode, this::setFilteringMode)
+            .setTooltipHoverString("cover.smart_item_filter.filtering_mode.description"));
         widgetGroup.accept(new CycleButtonWidget(10, 20, 75, 20,
-            SmartMatchingMode.class, this::getMatchingMode, this::setMatchingMode).setTooltipHoverString("cover.smart_item_filter.matching_mode.description"));
+            SmartMatchingMode.class, this::getMatchingMode, this::setMatchingMode)
+            .setTooltipHoverString("cover.smart_item_filter.matching_mode.description"));
     }
 
     @Override
@@ -154,13 +150,15 @@ public class SmartItemFilter extends ItemFilter {
 
     public enum SmartMatchingMode implements IStringSerializable {
 
-        DEFAULT("cover.smart_item_filter.matching_mode.default"),
-        IGNORE_FLUID("cover.smart_item_filter.matching_mode.ignore_fluid");
+        DEFAULT("cover.smart_item_filter.matching_mode.default", MatchingMode.DEFAULT),
+        IGNORE_FLUID("cover.smart_item_filter.matching_mode.ignore_fluid", MatchingMode.IGNORE_FLUIDS);
 
         public final String localeName;
+        public final MatchingMode matchingMode;
 
-        SmartMatchingMode(String localeName) {
+        SmartMatchingMode(String localeName, MatchingMode matchingMode) {
             this.localeName = localeName;
+            this.matchingMode = matchingMode;
         }
 
         @Override

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -55,7 +55,6 @@ public class SmartItemFilter extends ItemFilter {
             infinitelyBigStack.setCount(Integer.MAX_VALUE);
 
             Recipe recipe = filteringMode.recipeMap.findRecipe(Long.MAX_VALUE, Collections.singletonList(infinitelyBigStack), Collections.emptyList(), Integer.MAX_VALUE, matchingMode.matchingMode);
-
             if (recipe == null) {
                 filteringMode.transferStackSizesCache.put(itemAndMetadata, 0);
                 cachedTransferRateValue = 0;

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -81,9 +81,9 @@ public class SmartItemFilter extends ItemFilter {
     @Override
     public void initUI(Consumer<Widget> widgetGroup) {
         widgetGroup.accept(new CycleButtonWidget(10, 0, 75, 20,
-            SmartFilteringMode.class, this::getFilteringMode, this::setFilteringMode));
+            SmartFilteringMode.class, this::getFilteringMode, this::setFilteringMode).setTooltipHoverString("cover.smart_item_filter.filtering_mode.description"));
         widgetGroup.accept(new CycleButtonWidget(10, 20, 75, 20,
-            SmartMatchingMode.class, this::getMatchingMode, this::setMatchingMode));
+            SmartMatchingMode.class, this::getMatchingMode, this::setMatchingMode).setTooltipHoverString("cover.smart_item_filter.matching_mode.description"));
     }
 
     @Override
@@ -107,8 +107,6 @@ public class SmartItemFilter extends ItemFilter {
         this.filteringMode = SmartFilteringMode.values()[tagCompound.getInteger("FilterMode")];
         if (tagCompound.hasKey("MatchingMode")) {
             this.matchingMode = SmartMatchingMode.values()[tagCompound.getInteger("MatchingMode")];
-        } else {
-            this.matchingMode = SmartMatchingMode.DEFAULT;
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -700,10 +700,10 @@ cover.item_filter.ignore_nbt.disabled=Respect NBT
 cover.smart_item_filter.title=Smart Item Filter
 cover.smart_item_filter.filtering_mode.electrolyzer=Electrolyzer
 cover.smart_item_filter.filtering_mode.centrifuge=Centrifuge
-cover.smart_item_filter.filtering_mode.tooltip=Select Machine this Smart Filter will use for filtering./nIt will automatically pick right portions of items for robotic arm.
+cover.smart_item_filter.filtering_mode.description=Select Machine this Smart Filter will use for filtering./nIt will automatically pick right portions of items for robotic arm.
 cover.smart_item_filter.matching_mode.default=Default
 cover.smart_item_filter.matching_mode.ignore_fluid=Ignore Fluids
-cover.smart_item_filter.matching_mode.tooltip=Select mode this Smart Filter will use for filtering./nDefault will assume your not providing any fluid for the recipe.
+cover.smart_item_filter.matching_mode.description=§eDefault§r - Will match recipes on both items/fluids criteria assuming you aren't providing any fluid. /n§eIgnore Fluids§r - Will match recipes only on items criteria.
 
 cover.conveyor.title=Conveyor Cover Settings (%s)
 cover.conveyor.transfer_rate=%s items/sec

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -702,7 +702,7 @@ cover.smart_item_filter.filtering_mode.electrolyzer=Electrolyzer
 cover.smart_item_filter.filtering_mode.centrifuge=Centrifuge
 cover.smart_item_filter.filtering_mode.tooltip=Select Machine this Smart Filter will use for filtering./nIt will automatically pick right portions of items for robotic arm.
 cover.smart_item_filter.matching_mode.default=Default
-cover.smart_item_filter.matching_mode.ignore_fluid=Ignore fluids
+cover.smart_item_filter.matching_mode.ignore_fluid=Ignore Fluids
 cover.smart_item_filter.matching_mode.tooltip=Select mode this Smart Filter will use for filtering./nDefault will assume your not providing any fluid for the recipe.
 
 cover.conveyor.title=Conveyor Cover Settings (%s)

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -698,9 +698,12 @@ cover.item_filter.ignore_nbt.enabled=Ignore NBT
 cover.item_filter.ignore_nbt.disabled=Respect NBT
 
 cover.smart_item_filter.title=Smart Item Filter
-cover.smart_item_filter.mode.electrolyzer=Electrolyzer
-cover.smart_item_filter.mode.centrifuge=Centrifuge
-cover.smart_item_filter.mode.tooltip=Select Machine this Smart Filter will use for filtering./nIt will automatically pick right portions of items for robotic arm.
+cover.smart_item_filter.filtering_mode.electrolyzer=Electrolyzer
+cover.smart_item_filter.filtering_mode.centrifuge=Centrifuge
+cover.smart_item_filter.filtering_mode.tooltip=Select Machine this Smart Filter will use for filtering./nIt will automatically pick right portions of items for robotic arm.
+cover.smart_item_filter.matching_mode.default=Default
+cover.smart_item_filter.matching_mode.ignore_fluid=Ignore fluids
+cover.smart_item_filter.matching_mode.tooltip=Select mode this Smart Filter will use for filtering./nDefault will assume your not providing any fluid for the recipe.
 
 cover.conveyor.title=Conveyor Cover Settings (%s)
 cover.conveyor.transfer_rate=%s items/sec


### PR DESCRIPTION
**What:**
Implement #1300  Allow Smart Filter matching to ignore required fluid inputs.

**How solved:**
Adding a new widget in SmartItemFilter for configuring matching mode, overloaded `findRecipe` and  `findByInputs` from `RecipeMap` class and `matches` from `Recipes` class adding a new parameter allowing to only check if items or fluid coresspond.

**Outcome:**
Closes #1300 

**Additional info:**
GUIs : 

![Default](https://cdn.discordapp.com/attachments/763408591126265867/775851965061267556/Capture_decran_de_2020-11-10_23-17-08.png)
![ignoreFluid](https://cdn.discordapp.com/attachments/763408591126265867/775851974918012928/Capture_decran_de_2020-11-10_23-17-51.png)

**Possible compatibility issue:**
none the default behavior of the cover is unchanged.