### PR TITLE
Integrate the Chemical Bath into the ore byproduct page. Remove extra…

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -712,8 +712,6 @@ public class Materials {
         Sodalite.addOreByProducts(Lazurite, Lapis);
         Spodumene.addOreByProducts(Aluminium, Lithium);
         Ruby.addOreByProducts(Chrome, GarnetRed);
-        Redstone.addOreByProducts(Cinnabar, Pyrite);
-        Cinnabar.addOreByProducts(Ruby);
         Phosphor.addOreByProducts(Apatite, Phosphate);
         Iridium.addOreByProducts(Platinum, Osmium);
         Pyrope.addOreByProducts(GarnetRed, Magnesium);

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -164,6 +164,8 @@ public class GTJeiPlugin implements IModPlugin {
             registry.addRecipeCatalyst(machine.getStackForm(), oreByProductId);
         for (MetaTileEntity machine : MetaTileEntities.THERMAL_CENTRIFUGE)
             registry.addRecipeCatalyst(machine.getStackForm(), oreByProductId);
+        for (MetaTileEntity machine : MetaTileEntities.CHEMICAL_BATH)
+            registry.addRecipeCatalyst(machine.getStackForm(), oreByProductId);
 
         ingredientRegistry = registry.getIngredientRegistry();
         for (int i = 0; i <= IntCircuitIngredient.CIRCUIT_MAX; i++) {

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -102,15 +102,21 @@ public class OreByProduct implements IRecipeWrapper {
 			addOreTooltip(tooltip, 0, RecipeMaps.MACERATOR_RECIPES.getLocalizedName(), true);
 			addOreTooltip(tooltip, 1, RecipeMaps.ORE_WASHER_RECIPES.getLocalizedName(), true);
 			addOreTooltip(tooltip, 1, RecipeMaps.THERMAL_CENTRIFUGE_RECIPES.getLocalizedName(), true);
-			break;
+            if (material.washedIn != null && material.oreByProducts.size() == 1)
+                addOreTooltip(tooltip, 1, RecipeMaps.CHEMICAL_BATH_RECIPES.getLocalizedName(), true);
+            break;
 		case 8: // 2nd Byproduct
 			addOreTooltip(tooltip, 2, RecipeMaps.MACERATOR_RECIPES.getLocalizedName(), true);
 			addOreTooltip(tooltip, 2, RecipeMaps.THERMAL_CENTRIFUGE_RECIPES.getLocalizedName(), true);
 			addOreTooltip(tooltip, 5, RecipeMaps.CENTRIFUGE_RECIPES.getLocalizedName(), true);
+			if (material.washedIn != null && material.oreByProducts.size() == 2)
+			    addOreTooltip(tooltip, 1, RecipeMaps.CHEMICAL_BATH_RECIPES.getLocalizedName(), true);
 			break;
 		case 9: // 3rd Byproduct
 			addOreTooltip(tooltip, 3, RecipeMaps.MACERATOR_RECIPES.getLocalizedName(), true);
 			addOreTooltip(tooltip, 4, RecipeMaps.CENTRIFUGE_RECIPES.getLocalizedName(), true);
+            if (material.washedIn != null && material.oreByProducts.size() == 3)
+                addOreTooltip(tooltip, 1, RecipeMaps.CHEMICAL_BATH_RECIPES.getLocalizedName(), true);
 			break;
 		case 10: // 4th Byproduct
 			if (material.washedIn != null)

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
@@ -38,8 +38,8 @@ public class OreByProductCategory extends PrimitiveRecipeCategory<OreByProduct, 
 		IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
 		itemStackGroup.init(0, true,  22,  29); //Ore
 		itemStackGroup.init(1, true,  70,  19); //Crushed
-		itemStackGroup.init(2, true,  88,  19); //Crushed Prurified
-		itemStackGroup.init(3, true, 106,  19); //Crushed Centfiguged
+		itemStackGroup.init(2, true,  88,  19); //Crushed Purified
+		itemStackGroup.init(3, true, 106,  19); //Crushed Centrifuged
 		itemStackGroup.init(4, true,  70,  37); //Dust Impure
 		itemStackGroup.init(5, true,  88,  37); //Dust Purified
 		itemStackGroup.init(6, true, 106,  37); //Dust


### PR DESCRIPTION
… byproduct additions from some materials.

**What:**
This PR aims for better integration of the Chemical Bath for the Ore Byproduct page, solving several issues brought up in #1032.
For further clarification of the ore byproduct page, some materials with extraneous ore byproduct additions were removed.

**How solved:**
Adds the Chemical Bath as a catalyst to the ore byproduct page.
Adds the Chemical Bath tooltip to byproducts in all positions (if applicable) instead of just to the 4th position. This is done simply because the byproducts for the Chemical Bath are always the last byproduct in the list.
Remove duplicate byproduct additions for redstone and cinnabar, as they were causing in correct information to appear on the ore byproduct page, as they extra byproducts were not actually available from any machine.

**Outcome:**
Better integrates the Chemical Bath into the Ore Byproduct page, and removes some extraneous, non-applicable byproducts. Closes #1032.

**Additional info:**
An example of the updated tooltips for the chemical bath. This specific one comes from silver ore, which has sulfur as its second, and last byproduct

![cbath](https://user-images.githubusercontent.com/31759736/98964718-6285ea00-24c6-11eb-81cf-98cbbe26249f.PNG)


