### PR TITLE
properly initialize metaTileEntityTank fluid inventory

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -98,7 +98,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
                 MetaTileEntityTank.this.onFluidChangedInternal();
             }
         };
-        initializeInventory();
+        this.fluidInventory = getActualFluidTank();
     }
 
     @Override


### PR DESCRIPTION
**What:**
Suggested Fix for #1289 and #1263
Separated from PR #1303
those issues happen due to metaTileEntityTank fluid inventory not being properly initialised on load.

**How solved:**
calling this.fluidInventory = getActualFluidTank();
instead of initializeInventory();

instead of initializeInventory() is a metaTileEntity method that initialize fluidinventory as
`this.fluidInventory = new FluidHandlerProxy(importFluids, exportFluids);`
but we have neither `importFluids` nor `exportFluids` on meta tile entities tanks, leading
to `getTankProperties().length` being 0, so when the tank is asked by the cover for its capability, null is returned.
Since the pump need the capability to be non null, it crashes

**Outcome:**
World loading normally
