### PR TITLE
Multi block tank fixes

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -98,7 +98,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
                 MetaTileEntityTank.this.onFluidChangedInternal();
             }
         };
-        initializeInventory();
+        this.fluidInventory = getActualFluidTank();
     }
 
     @Override
@@ -152,6 +152,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
     protected void onCoverPlacementUpdate() {
         super.onCoverPlacementUpdate();
         this.needsCoversUpdate = true;
+        setTankController(null);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -103,8 +103,8 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
 
     @Override
     public void onLoad() {
-        this.recheckBlockedSides();
         super.onLoad();
+        this.recheckBlockedSides();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -102,6 +102,12 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
     }
 
     @Override
+    public void onLoad() {
+        this.recheckBlockedSides();
+        super.onLoad();
+    }
+
+    @Override
     public void update() {
         this.fluidInventory = getActualFluidTank();
         super.update();

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -196,10 +196,10 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         tankMap.values().forEach(it -> it.setTankController(newController));
     }
 
-    private double getFluidLevelForTank(BlockPos tankPos, Boolean rendering) {
+    private double getFluidLevelForTank(BlockPos tankPos) {
         if (!isTankController()) {
             MetaTileEntityTank controller = getControllerEntity();
-            return controller == null ? 0.0 : controller.getFluidLevelForTank(tankPos, rendering);
+            return controller == null ? 0.0 : controller.getFluidLevelForTank(tankPos);
         }
         FluidStack fluidStack = multiblockFluidTank.getFluid();
         if (fluidStack == null) {
@@ -207,16 +207,13 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         }
         double fluidLevel = multiblockFluidTank.getFluidAmount() / (1.0 * multiblockFluidTank.getCapacity());
         double resultLevel;
-        if (rendering) {
-            if (fluidStack.getFluid().isGaseous(fluidStack)) {
-                resultLevel = fluidLevel;
-            } else {
-                int tankOffset = (tankPos.getY() - getPos().getY());
-                resultLevel = fluidLevel * multiblockSize.getY() - tankOffset;
-            }
-            return MathHelper.clamp(resultLevel, 0.0, 1.0);
+        if (fluidStack.getFluid().isGaseous(fluidStack)) {
+            resultLevel = fluidLevel;
+        } else {
+            int tankOffset = (tankPos.getY() - getPos().getY());
+            resultLevel = fluidLevel * multiblockSize.getY() - tankOffset;
         }
-        return fluidLevel;
+        return MathHelper.clamp(resultLevel, 0.0, 1.0);
     }
 
     private int getConnectionMaskForTank(BlockPos blockPos, int excludeMask) {
@@ -235,7 +232,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
     }
 
     private int getFluidStoredInTank(BlockPos blockPos) {
-        double fluidLevel = getFluidLevelForTank(blockPos,false);
+        double fluidLevel = getFluidLevelForTank(blockPos);
         return MathHelper.floor(fluidLevel * tankSize);
     }
 
@@ -373,7 +370,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         debugInfo.add("Tank fluid: " + multiblockFluidTank.getFluidAmount() + "/" + multiblockFluidTank.getCapacity() + " #" + multiblockFluidTank.hashCode());
         FluidTank actualTankFluid = getActualFluidTank();
         debugInfo.add("Actual Tank fluid: " + actualTankFluid.getFluidAmount() + "/" + actualTankFluid.getCapacity() + " #" + actualTankFluid.hashCode());
-        debugInfo.add("FluidLevel: " + getFluidLevelForTank(getPos(),false));
+        debugInfo.add("FluidLevel: " + getFluidLevelForTank(getPos()));
         debugInfo.add("FluidInTank: " + getFluidStoredInTank(getPos()));
     }
 
@@ -639,7 +636,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
         if (getWorld() == null) {
             fillPercent = fluidStack == null ? 0 : fluidStack.amount / (tankSize * 1.0);
         } else {
-            fillPercent = getFluidLevelForTank(getPos(),true);
+            fillPercent = getFluidLevelForTank(getPos());
         }
         if (fillPercent > 0.0) {
             getTankRenderer().renderFluid(renderState, translation, connectionMask, fillPercent, fluidStack);


### PR DESCRIPTION
**What:**
This changes
 a) MetaTileEntityTank fluidInventory initialization, preventing a NPE with pump cover on world load.
 b) Check for MetaTileEntityTank blockedsides on load, before trying to assemble the multiblock.
 c) Changed how MetaTileEntityTank removal from multiblock works to try to fix fluid voiding

**How solved:**
As previously discussed:
a) instead of initializeInventory(), a metaTileEntity method that initialize fluidinventory as
this.fluidInventory = new FluidHandlerProxy(importFluids, exportFluids);
but we have neither importFluids nor exportFluids on meta tile entities tanks, leading
to getTankProperties().length being 0, so when the tank is asked by the cover for its capability, null is returned.
Since the pump need the capability to be non null, it crashes.

b) call for a `recheckBlocked `sides on the `onLoad `method, so `blockedSides` is not always 0 (no sides blocked) in `canTanksConnect()`

c) `removeTankFromMultiblock` calls for `getFluidStoredInTank` to get the amount of fluid based on a ratio of amount of fluid in the multiblock and the actual MetaTileEntityTank that contains the fluid.
i have split the method for this so we could get the fluid in the actual tank to determine how much should go to the removed tank.

**Outcome:**
a) fixes #1289 and #1263, that comes from the tank being asked for its capability before the actual valid fluid inventory exists
b) multiblocks keep their shape even after world reloads
c) this changes how tanks look after they are broken/multiblock gets invalidated, but retain the full amount of liquid, but does not look right

**Additional info:**
c)![Screenshot 2020-11-16 015051](https://user-images.githubusercontent.com/11739607/99214321-97d45580-27ae-11eb-953f-f40d5dc63a91.jpg)
cutting horizontally with shutters will split the tank in halves, each with half of the original tank, even if the fluid looked like it was on the bottom originally:
![Screenshot 2020-11-16 015123](https://user-images.githubusercontent.com/11739607/99214334-a458ae00-27ae-11eb-94bd-4f47512a4269.jpg)
Breaking one of the tanks will make the tanks show their real inventory. Keeps the total amount of fluid.
![Screenshot 2020-11-16 015159](https://user-images.githubusercontent.com/11739607/99214406-d5d17980-27ae-11eb-8a55-9f22196dbaed.jpg)

I know c) still needs some work but the actual issue here is getting over my head.