### PR TITLE
Ensure saw-broken ice blocks don't create water.

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -3,13 +3,20 @@ package gregtech.common.tools;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorldEventListener;
 import net.minecraft.world.World;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 public class ToolSaw extends ToolBase {
@@ -57,10 +64,94 @@ public class ToolSaw extends ToolBase {
     @Override
     public void convertBlockDrops(World world, BlockPos blockPos, IBlockState blockState, EntityPlayer player, List<ItemStack> dropList, ItemStack toolStack) {
         if (blockState.getMaterial() == Material.PACKED_ICE || blockState.getMaterial() == Material.ICE) {
+            if (blockState.getMaterial() == Material.ICE) {
+                world.addEventListener(new IceEventListener(blockPos, world.getTotalWorldTime()));
+            }
             Item item = Item.getItemFromBlock(blockState.getBlock());
             ItemStack dropStack = new ItemStack(item, 1);
-            world.setBlockToAir(blockPos);
             dropList.add(dropStack);
+        }
+    }
+
+    /**
+     * Added to the world event listeners to hopefully catch and revert the ice-to-water conversion.
+     *
+     * The conversion may never happen, for example when there is air under the ice block,
+     * so this invalidates itself on the first block update after the tick it was added.
+     */
+    @ParametersAreNonnullByDefault
+    private static class IceEventListener implements IWorldEventListener {
+
+        private final BlockPos blockPos;
+        private final long time;
+
+        public IceEventListener(BlockPos blockPos, long totalWorldTime) {
+            this.blockPos = blockPos;
+            this.time = totalWorldTime;
+        }
+
+        @Override
+        public void notifyBlockUpdate(World worldIn, BlockPos pos, IBlockState oldState, IBlockState newState, int flags) {
+            /*
+            It should be reasonably safe to remove the event listener at this time:
+            - The loop this is called from is index-based, rather than iterator-based,
+              so it shouldn't throw a ConcurrentModificationException.
+            - Hopefully this is the last entry in the list, so removal here
+              doesn't skip any of the other listeners.
+             */
+            if (time != worldIn.getTotalWorldTime()) {
+                worldIn.removeEventListener(this);
+                return;
+            }
+            if (pos == blockPos && newState.getBlock() == Blocks.FLOWING_WATER) {
+                // it's probably alright to assume this will only be attempted once
+                worldIn.removeEventListener(this);
+                worldIn.setBlockState(pos, Blocks.AIR.getDefaultState(), flags);
+            }
+        }
+
+        @Override
+        public void notifyLightSet(BlockPos pos) {
+        }
+
+        @Override
+        public void markBlockRangeForRenderUpdate(int x1, int y1, int z1, int x2, int y2, int z2) {
+        }
+
+        @Override
+        public void playSoundToAllNearExcept(@Nullable EntityPlayer player, SoundEvent soundIn, SoundCategory category, double x, double y, double z, float volume, float pitch) {
+        }
+
+        @Override
+        public void playRecord(SoundEvent soundIn, BlockPos pos) {
+        }
+
+        @Override
+        public void spawnParticle(int particleID, boolean ignoreRange, double xCoord, double yCoord, double zCoord, double xSpeed, double ySpeed, double zSpeed, int... parameters) {
+        }
+
+        @Override
+        public void spawnParticle(int id, boolean ignoreRange, boolean p_190570_3_, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, int... parameters) {
+        }
+
+        @Override
+        public void onEntityAdded(Entity entityIn) {
+        }
+
+        @Override
+        public void onEntityRemoved(Entity entityIn) {
+        }
+
+        @Override
+        public void broadcastSound(int soundID, BlockPos pos, int data) {
+        }
+
+        @Override
+        public void playEvent(EntityPlayer player, int type, BlockPos blockPosIn, int data) {
+        }
+
+        @Override
+        public void sendBlockBreakProgress(int breakerId, BlockPos pos, int progress) {
         }
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -103,7 +103,7 @@ public class ToolSaw extends ToolBase {
                 worldIn.removeEventListener(this);
                 return;
             }
-            if (pos == blockPos && newState.getBlock() == Blocks.FLOWING_WATER) {
+            if (pos.equals(blockPos) && newState.getBlock() == Blocks.FLOWING_WATER) {
                 // it's probably alright to assume this will only be attempted once
                 worldIn.removeEventListener(this);
                 worldIn.setBlockState(pos, Blocks.AIR.getDefaultState(), flags);


### PR DESCRIPTION
**What:**
This PR ensures that ice blocks don't melt into water when broken by a saw, but harvest like a silk-touch tool would, leaving no water behind.

**How solved:**
The presented solution is to use vanilla means to listen to block updates in the world, reverting the change if it appears to be from an ice block trying to turn into water. 
Essentially, when the block is to be harvested, this event listener is added to the world, and reverts the first attempt to set the block at that position to flowing water on that tick.

**Outcome:**
Ice blocks broken by saws no longer create water like they might if broken by other tools.
Fixes #1314

**Possible compatibility issue:**
Other mods that use similar means to their ends may experience unexpected behaviours when an ice block is broken by a saw but wouldn't convert into water: other world listeners added after the ice listener may be skipped when the ice listener is removed from the list on a later tick.