### PR TITLE
Fix Drained Fluid Cells not stacking due to empty NBT.

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
@@ -26,4 +26,25 @@ public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSim
         int liquidTemperature = fluid.getFluid().getTemperature();
         return liquidTemperature >= minFluidTemperature && liquidTemperature <= maxFluidTemperature;
     }
+
+
+    @Override
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        FluidStack drained = super.drain(resource, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        FluidStack drained = super.drain(maxDrain, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    private void removeTagWhenEmpty(Boolean doDrain) {
+        if(doDrain && this.getFluid() == null) {
+            this.container.setTagCompound(null);
+        }
+    }
 }

--- a/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
@@ -26,4 +26,24 @@ public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack {
         int liquidTemperature = fluid.getFluid().getTemperature();
         return liquidTemperature >= minFluidTemperature && liquidTemperature <= maxFluidTemperature;
     }
+
+    @Override
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        FluidStack drained = super.drain(resource, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        FluidStack drained = super.drain(maxDrain, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    private void removeTagWhenEmpty(Boolean doDrain) {
+        if(doDrain && this.getFluid() == null) {
+            this.container.setTagCompound(null);
+        }
+    }
 }


### PR DESCRIPTION
**What:**
Similar to #1127, this PR makes it so that fluid cells that are drained entirely have their empty NBT removed, so that they can stack with fluid cells with no NBT tag that have been created.

**How solved:**
Adds checks in two places to see if the fluid cells are drained all the way when they are drained, and if they are removes their tags. It was required to add this check in two places, as there are two implementations of the fluid cells, one that allows partial filling and one that does not allow partial filling.

**Outcome:**
Allows fully drained fluid cells to stack newly created fluid cells. Works for all types of fluid cells.


**Possible compatibility issue:**
None expected.

