### PR TITLE
Fix Fluid Canner and Electric Furnace recipe finder not working.

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes.machines;
 
 import gregtech.api.recipes.CountableIngredient;
+import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.builders.SimpleRecipeBuilder;
@@ -27,8 +28,8 @@ public class RecipeMapFluidCanner extends RecipeMap<SimpleRecipeBuilder> {
 
     @Override
     @Nullable
-    public Recipe findRecipe(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, int outputFluidTankCapacity) {
-        Recipe recipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity);
+    public Recipe findRecipe(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, int outputFluidTankCapacity, MatchingMode mode) {
+        Recipe recipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity, mode);
         if (inputs.size() == 0 || inputs.get(0).isEmpty() || recipe != null)
             return recipe;
 

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.machines;
 
+import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
@@ -19,8 +20,8 @@ public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {
 
     @Override
     @Nullable
-    public Recipe findRecipe(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, int outputFluidTankCapacity) {
-        Recipe normalRecipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity);
+    public Recipe findRecipe(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, int outputFluidTankCapacity, MatchingMode mode) {
+        Recipe normalRecipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity, mode);
         if (normalRecipe != null || inputs.size() == 0 || inputs.get(0).isEmpty())
             return normalRecipe;
         ItemStack output = ModHandler.getSmeltingOutput(inputs.get(0));


### PR DESCRIPTION
**What:**
Fixes the Fluid Canner and Electric Furnace recipe maps not working, as they did not override the correct findRecipe method after the addition of MatchingMode

**How solved:**
Added the MatchingMode parameter so that the correct findRecipe method was being overwritten.

**Outcome:**
Fixed Fluid Canner and Electric Furnace not functioning. Closes #1325.

**Additional info:**
These were the two machines that I could find that did not work after the update, after some brief machine testing. 

**Possible compatibility issue:**
Possibly, if some addon was using the findRecipe method of one of the changed recipe maps. I can change this if it determined that it needs to be changed.


