### PR TITLE
Changed shouldCheckWeakPower to work around bug

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -315,7 +315,9 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Override
     public boolean shouldCheckWeakPower(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-        return true;
+        // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
+        // actually cause getWeakPower to be called, rather than prevent it.
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -140,7 +140,9 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
     @Override
     public boolean shouldCheckWeakPower(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-        return true;
+        // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
+        // actually cause getWeakPower to be called, rather than prevent it.
+        return false;
     }
 
     @Override


### PR DESCRIPTION
**What:**
A vanilla bug prevents getWeakPower from being called. This results in machines and covers being unable to set redstone outputs.

From line 3546 of World::getRedstonePower:
![image](https://user-images.githubusercontent.com/16456946/100784310-9b81f200-33d4-11eb-9f4e-69aaab9e3587.png)

As the above image shows, the ternary statement is reversed.

**How solved:**
I've changed the two implementations of shouldCheckWeakPower to return 'false' instead of 'true', along with an inline explanation of why that's the case.

**Outcome:**
Fixes: Machines and covers now have the ability to output redstone.

**Possible compatibility issue:**
No machines or covers currently exist that use this. The change should only affect addons.