### PR TITLE
Fix Multismelter Voiding items.

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -136,6 +136,11 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
             ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
             ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
             for (int index = 0; index < inputs.getSlots(); index++) {
+                //Check first if there is room in the output bus
+                if(findFreeOutputSlots(this.getOutputInventory()) == 0) {
+                    break;
+                }
+
                 ItemStack stackInSlot = inputs.getStackInSlot(index);
                 if (stackInSlot.isEmpty())
                     continue;
@@ -148,7 +153,7 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
                         (maxItemsLimit - currentItemsEngaged) / inputIngredient.getCount());
                     recipeInputs.add(new CountableIngredient(inputIngredient.getIngredient(),
                         inputIngredient.getCount() * overclockAmount));
-                    if (!outputStack.isEmpty()) {
+                    if (!outputStack.isEmpty() && currentItemsEngaged < findFreeOutputSlots(this.getOutputInventory()) * 64) {
                         outputStack.setCount(outputStack.getCount() * overclockAmount);
                         recipeOutputs.add(outputStack);
                     }
@@ -163,6 +168,20 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
                 .EUt(Math.max(1, 16 / heatingCoilDiscount))
                 .duration((int) Math.max(1.0, 256 * (currentItemsEngaged / (maxItemsLimit * 1.0))))
                 .build().getResult();
+        }
+
+        //Finds the number of empty slots in an output bus
+        protected int findFreeOutputSlots(IItemHandlerModifiable outputInventory) {
+            int outputSlots = 0;
+
+            for(int index = 0; index < outputInventory.getSlots(); index++) {
+                ItemStack stackInSlot = outputInventory.getStackInSlot(index);
+                if(stackInSlot.isEmpty()) {
+                    outputSlots++;
+                }
+            }
+
+            return outputSlots;
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -135,12 +135,12 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
             int maxItemsLimit = 32 * heatingCoilLevel;
             ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
             ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
-            for (int index = 0; index < inputs.getSlots(); index++) {
-                //Check first if there is room in the output bus
-                if(findFreeOutputSlots(this.getOutputInventory()) == 0) {
-                    break;
-                }
+            //Check first if there is room in the output bus
+            if(findFreeOutputSlots(this.getOutputInventory()) == 0) {
+                return null;
+            }
 
+            for (int index = 0; index < inputs.getSlots(); index++) {
                 ItemStack stackInSlot = inputs.getStackInSlot(index);
                 if (stackInSlot.isEmpty())
                     continue;


### PR DESCRIPTION
**What:**
This PR fixes the Multismelter voiding items due to the coil bonus of the multismelter.

**How solved:**
An additional method is added to check the number of empty output slots in the multismelter. If there are no free output slots, then nothing is added to the output list. If there is room in the output slots, then the number of engaged items has to be less than the number of item room available in the output bus for new outputs to be added to the output list.

**Outcome:**
Fixes multismelter voiding items due to the coil bonus. Closes #1332.


**Possible compatibility issue:**
None to be expected.

Edit: One thing I could use feedback on is the harcoded check in the for loop of number of free slots * 64. I am not sure if this would work in cases where the stack size of the output is < 64. It did work for a test recipe I added via crafttweaker for pumpkin pie -> egg, so that the output item had a max stack size of 16, but I am not sure if I covered all the possible cases.