### PR TITLE
Fix Multiblocks voiding partial multi item outputs when output is mostly Full

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -5,7 +5,12 @@ import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
+
+import java.util.List;
+
+import static gregtech.api.util.InventoryUtils.simulateItemStackMerge;
 
 public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
@@ -69,24 +74,13 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         IItemHandlerModifiable exportInventory = getOutputInventory();
         IMultipleTankHandler importFluids = getInputTank();
         IMultipleTankHandler exportFluids = getOutputTank();
+        List<ItemStack> itemOutputs = recipe.getAllItemOutputs(exportInventory.getSlots());
         return (totalEUt >= 0 ? getEnergyStored() >= (totalEUt > getEnergyCapacity() / 2 ? resultOverclock[0] : totalEUt) :
             (getEnergyStored() - resultOverclock[0] <= getEnergyCapacity())) &&
-            MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots())) &&
-            recipe.getAllItemOutputs(exportInventory.getSlots()).size() <= getFreeSlots(exportInventory) &&
+            MetaTileEntity.addItemsToItemHandler(exportInventory, true, itemOutputs) &&
+            simulateItemStackMerge(itemOutputs, exportInventory) &&
             MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs()) &&
             recipe.matches(true, importInventory, importFluids);
-    }
-
-    //Determines the number of free slots in the paseed inventory
-    protected int getFreeSlots(IItemHandlerModifiable inventory) {
-        int emptySlots = 0;
-        for(int index = 0; index < inventory.getSlots(); index++) {
-            if(inventory.getStackInSlot(index).isEmpty()) {
-                emptySlots++;
-            }
-        }
-
-        return emptySlots;
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -2,15 +2,9 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
-
-import java.util.List;
-
-import static gregtech.api.util.InventoryUtils.simulateItemStackMerge;
 
 public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
@@ -60,27 +54,10 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         if (controller.checkRecipe(recipe, false) &&
-            multiBlockSetupAndConsumeRecipeInputs(recipe)) {
+            super.setupAndConsumeRecipeInputs(recipe)) {
             controller.checkRecipe(recipe, true);
             return true;
         } else return false;
-    }
-
-    //Logic Mostly copied from AbstractRecipeLogic, but with some additional checking for Multiblock output spacing to prevent voiding
-    protected boolean multiBlockSetupAndConsumeRecipeInputs(Recipe recipe) {
-        int[] resultOverclock = calculateOverclock(recipe.getEUt(), getMaxVoltage(), recipe.getDuration());
-        int totalEUt = resultOverclock[0] * resultOverclock[1];
-        IItemHandlerModifiable importInventory = getInputInventory();
-        IItemHandlerModifiable exportInventory = getOutputInventory();
-        IMultipleTankHandler importFluids = getInputTank();
-        IMultipleTankHandler exportFluids = getOutputTank();
-        List<ItemStack> itemOutputs = recipe.getAllItemOutputs(exportInventory.getSlots());
-        return (totalEUt >= 0 ? getEnergyStored() >= (totalEUt > getEnergyCapacity() / 2 ? resultOverclock[0] : totalEUt) :
-            (getEnergyStored() - resultOverclock[0] <= getEnergyCapacity())) &&
-            MetaTileEntity.addItemsToItemHandler(exportInventory, true, itemOutputs) &&
-            simulateItemStackMerge(itemOutputs, exportInventory) &&
-            MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs()) &&
-            recipe.matches(true, importInventory, importFluids);
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -1,16 +1,17 @@
 package gregtech.api.util;
 
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraft.item.*;
+import net.minecraftforge.items.*;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class InventoryUtils {
 
-    //Returns the number of empty slots in an item inventory. Mostly for use with multiblock item inventories.
-    public static int getNumberOfEmptySlotsInInventory(IItemHandlerModifiable inventory) {
+    /**
+     * @param inventory the target inventory
+     * @return the number of empty slots in {@code inventory}
+     */
+    public static int getNumberOfEmptySlotsInInventory(IItemHandler inventory) {
         int emptySlots = 0;
         for(int index = 0; index < inventory.getSlots(); index++) {
             if(inventory.getStackInSlot(index).isEmpty()) {
@@ -22,6 +23,24 @@ public class InventoryUtils {
     }
 
     /**
+     * Creates a deep copy of the target inventory, optionally keeping empty ItemStacks
+     *
+     * @param inventory the target inventory
+     * @param keepEmpty whether to keep empty ItemStacks (if {@code true}, stacks will be kept).
+     * @return a deep copy of the inventory.
+     */
+    public static List<ItemStack> deepCopy(IItemHandler inventory, boolean keepEmpty) {
+        int numSlots = inventory.getSlots();
+        List<ItemStack> inventoryStacks = new ArrayList<>(numSlots);
+        for(int slotIndex = 0; slotIndex < numSlots; slotIndex++) {
+            ItemStack stack = inventory.getStackInSlot(slotIndex);
+            if(keepEmpty || !stack.isEmpty())
+                inventoryStacks.add(stack.copy());
+        }
+        return inventoryStacks;
+    }
+
+    /**
      * Determines whether all specified items will fit into a target inventory by
      * simulating merging like items into existing stacks, then checking if there
      * are enough empty stacks left to accommodate the remaining items.
@@ -30,64 +49,70 @@ public class InventoryUtils {
      *               they can exceed the maximum stackable size of the item as
      *               defined by {@link net.minecraft.item.ItemStack#getMaxStackSize()}.
      * <br /><br />
+     * <b>Precondition:</b> the target inventory must actually accept the types of items
+     *               you are trying to insert.
+     * <br /><br />
      * @param items the items you want to insert
      * @param inventory the target inventory receiving items
      * @return {@code true} if inventory contains sufficient slots to merge and
      *         insert all requested items, {@code false} otherwise.
      */
-    public static boolean simulateItemStackMerge(List<ItemStack> items, IItemHandlerModifiable inventory) {
-        // if there's enough empty output slots then we don't need to compute merges.
-        int emptySlots = getNumberOfEmptySlotsInInventory(inventory);
-        if(items.size() <= emptySlots) {
+    public static boolean simulateItemStackMerge(List<ItemStack> items,
+                                                 IItemHandler inventory)
+    {
+        // If there's enough empty output slots then we don't need to compute merges.
+        final int emptySlots = getNumberOfEmptySlotsInInventory(inventory);
+        if(items.size() <= emptySlots)
             return true;
-        }
 
-        // Deep copy the recipe output itemstacks
-        List<ItemStack> itemStackList = new ArrayList<>(items.size());
-        for(ItemStack i : items) {
-            itemStackList.add(i.copy());
-        }
+        // Deep copy the recipe output ItemStacks
+        final List<ItemStack> itemStacks = new ArrayList<>(items.size());
+        items.forEach(itemStack -> itemStacks.add(itemStack.copy()));
 
         // Sort by the number of items in each stack so we merge smallest stacks first.
-        itemStackList.sort((i,j) -> Integer.compare(i.getCount(), j.getCount()));
+        itemStacks.sort(Comparator.comparingInt(ItemStack::getCount));
 
-        // Deep copy the contents of the output bus
-        int numSlots = inventory.getSlots();
-        List<ItemStack> inventoryStacks = new ArrayList<>(numSlots);
-        for(int slotIndex = 0; slotIndex < numSlots; slotIndex++) {
-            ItemStack stack = inventory.getStackInSlot(slotIndex);
-            if(!stack.isEmpty())
-                inventoryStacks.add(stack.copy());
-        }
+        // Deep copy the contents of the target inventory, skipping empty stacks
+        final List<ItemStack> inventoryStacks = deepCopy(inventory, false);
 
+        // Perform a merge of the ItemStacks
+        mergeItemStacks(itemStacks, inventoryStacks);
+
+        // Return whether there are now sufficient empty slots to fit the unmerged items.
+        return itemStacks.size() <= emptySlots;
+    }
+
+    /**
+     * Merges stacks of identical items from a source into a destination.<br />
+     * Successfully merged items will be removed from {@code source} and will appear in {@code destination}.<br />
+     * Empty stacks in {@code destination} are not considered for this process.
+     *
+     * @param source      the ItemStacks to merge into {@code destination}.
+     * @param destination a target inventory of existing ItemStacks.
+     */
+    private static void mergeItemStacks(Collection<ItemStack> source, Collection<ItemStack> destination) {
         // Since we're mutating the collection during iteration, use an iterator.
-        Iterator<ItemStack> outIter = itemStackList.iterator();
-        while(outIter.hasNext()) {
-            ItemStack currentOut = outIter.next();
+        final Iterator<ItemStack> sourceItemStacks = source.iterator();
+        while(sourceItemStacks.hasNext()) {
+            final ItemStack sourceItemStack = sourceItemStacks.next();
 
             // Find a matching item in the output bus, if any
-            for(ItemStack currentInv : inventoryStacks) {
-                if(ItemStack.areItemsEqual(currentInv, currentOut)) {
+            for(ItemStack destItemStack : destination)
+                if(ItemStack.areItemsEqual(destItemStack, sourceItemStack)) {
                     // if it's possible to merge stacks
-                    int availableSlots = currentInv.getMaxStackSize() - currentInv.getCount();
+                    final int availableSlots = destItemStack.getMaxStackSize() - destItemStack.getCount();
                     if(availableSlots > 0) {
-                        int mergeable = Math.min(availableSlots, currentOut.getCount());
-                        currentOut.shrink(mergeable);
-                        currentInv.grow(mergeable);
+                        final int itemCount = Math.min(availableSlots, sourceItemStack.getCount());
+                        sourceItemStack.shrink(itemCount);
+                        destItemStack.grow(itemCount);
 
                         // if the output stack was merged completely, remove it and stop looking
-                        if(currentOut.isEmpty()) {
-                            outIter.remove();
+                        if(sourceItemStack.isEmpty()) {
+                            sourceItemStacks.remove();
                             break;
                         }
                     }
                 }
-            }
         }
-
-        // We now have merged everything possible.
-        // Return whether there are now sufficient empty slots to fit the unmerged items.
-        return itemStackList.size() <= emptySlots;
     }
-
 }

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -1,0 +1,93 @@
+package gregtech.api.util;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class InventoryUtils {
+
+    //Returns the number of empty slots in an item inventory. Mostly for use with multiblock item inventories.
+    public static int getNumberOfEmptySlotsInInventory(IItemHandlerModifiable inventory) {
+        int emptySlots = 0;
+        for(int index = 0; index < inventory.getSlots(); index++) {
+            if(inventory.getStackInSlot(index).isEmpty()) {
+                emptySlots++;
+            }
+        }
+
+        return emptySlots;
+    }
+
+    /**
+     * Determines whether all specified items will fit into a target inventory by
+     * simulating merging like items into existing stacks, then checking if there
+     * are enough empty stacks left to accommodate the remaining items.
+     * <br /><br />
+     * <b>Precondition:</b> the target inventory must not virtualize ItemStacks such that
+     *               they can exceed the maximum stackable size of the item as
+     *               defined by {@link net.minecraft.item.ItemStack#getMaxStackSize()}.
+     * <br /><br />
+     * @param items the items you want to insert
+     * @param inventory the target inventory receiving items
+     * @return {@code true} if inventory contains sufficient slots to merge and
+     *         insert all requested items, {@code false} otherwise.
+     */
+    public static boolean simulateItemStackMerge(List<ItemStack> items, IItemHandlerModifiable inventory) {
+        // if there's enough empty output slots then we don't need to compute merges.
+        int emptySlots = getNumberOfEmptySlotsInInventory(inventory);
+        if(items.size() <= emptySlots) {
+            return true;
+        }
+
+        // Deep copy the recipe output itemstacks
+        List<ItemStack> itemStackList = new ArrayList<>(items.size());
+        for(ItemStack i : items) {
+            itemStackList.add(i.copy());
+        }
+
+        // Sort by the number of items in each stack so we merge smallest stacks first.
+        itemStackList.sort((i,j) -> Integer.compare(i.getCount(), j.getCount()));
+
+        // Deep copy the contents of the output bus
+        int numSlots = inventory.getSlots();
+        List<ItemStack> inventoryStacks = new ArrayList<>(numSlots);
+        for(int slotIndex = 0; slotIndex < numSlots; slotIndex++) {
+            ItemStack stack = inventory.getStackInSlot(slotIndex);
+            if(!stack.isEmpty())
+                inventoryStacks.add(stack.copy());
+        }
+
+        // Since we're mutating the collection during iteration, use an iterator.
+        Iterator<ItemStack> outIter = itemStackList.iterator();
+        while(outIter.hasNext()) {
+            ItemStack currentOut = outIter.next();
+
+            // Find a matching item in the output bus, if any
+            for(ItemStack currentInv : inventoryStacks) {
+                if(ItemStack.areItemsEqual(currentInv, currentOut)) {
+                    // if it's possible to merge stacks
+                    int availableSlots = currentInv.getMaxStackSize() - currentInv.getCount();
+                    if(availableSlots > 0) {
+                        int mergeable = Math.min(availableSlots, currentOut.getCount());
+                        currentOut.shrink(mergeable);
+                        currentInv.grow(mergeable);
+
+                        // if the output stack was merged completely, remove it and stop looking
+                        if(currentOut.isEmpty()) {
+                            outIter.remove();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // We now have merged everything possible.
+        // Return whether there are now sufficient empty slots to fit the unmerged items.
+        return itemStackList.size() <= emptySlots;
+    }
+
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -201,48 +201,49 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
                 .duration((int) Math.max(1.0, 256 * (currentItemsEngaged / (maxItemsLimit * 1.0))))
                 .build().getResult();
         }
-    }
 
-    /**
-     * Computes the minimal number of ItemStacks necessary to store a multiplied recipe output, then
-     * generates the stacks. The result is then stored in {@code recipeOutputs}.
-     *
-     * @param recipeOutputs   a collection of outputs to store the resulting output ItemStacks
-     * @param outputStack     an ItemStack representing the output item of a recipe
-     * @param overclockAmount the number of times that {@code outputStack}'s quantity should
-     *                        be multiplied by for the desired total
-     */
-    private void computeOutputItemStacks(Collection<ItemStack> recipeOutputs,
-                                         ItemStack outputStack,
-                                         int overclockAmount)
-    {
-        if(!outputStack.isEmpty()) {
-            // number of output items we're generating
-            int finalAmount = outputStack.getCount() * overclockAmount;
+        /**
+         * Computes the minimal number of ItemStacks necessary to store a multiplied recipe output, then
+         * generates the stacks. The result is then stored in {@code recipeOutputs}.
+         *
+         * @param recipeOutputs   a collection of outputs to store the resulting output ItemStacks
+         * @param outputStack     an ItemStack representing the output item of a recipe
+         * @param overclockAmount the number of times that {@code outputStack}'s quantity should
+         *                        be multiplied by for the desired total
+         */
+        private void computeOutputItemStacks(Collection<ItemStack> recipeOutputs,
+                                             ItemStack outputStack,
+                                             int overclockAmount)
+        {
+            if(!outputStack.isEmpty()) {
+                // number of output items we're generating
+                int finalAmount = outputStack.getCount() * overclockAmount;
 
-            // max items allowed in a stack
-            int maxCount = outputStack.getMaxStackSize();
+                // max items allowed in a stack
+                int maxCount = outputStack.getMaxStackSize();
 
-            // number of whole stacks of output this will make
-            int numStacks = finalAmount / maxCount;
+                // number of whole stacks of output this will make
+                int numStacks = finalAmount / maxCount;
 
-            // number of items left (partial stack)
-            int remainder = finalAmount % maxCount;
+                // number of items left (partial stack)
+                int remainder = finalAmount % maxCount;
 
-            // Add full stacks of the output item
-            for(int fullStacks = numStacks; fullStacks > 0; fullStacks--) {
-                ItemStack full = outputStack.copy();
-                full.setCount(maxCount);
-                recipeOutputs.add(full);
-            }
+                // Add full stacks of the output item
+                for(int fullStacks = numStacks; fullStacks > 0; fullStacks--) {
+                    ItemStack full = outputStack.copy();
+                    full.setCount(maxCount);
+                    recipeOutputs.add(full);
+                }
 
-            // if there is a partial stack, add it too
-            if(remainder > 0) {
-                ItemStack partial = outputStack.copy();
-                partial.setCount(remainder);
-                recipeOutputs.add(partial);
+                // if there is a partial stack, add it too
+                if(remainder > 0) {
+                    ItemStack partial = outputStack.copy();
+                    partial.setCount(remainder);
+                    recipeOutputs.add(partial);
+                }
             }
         }
+
     }
 
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -191,8 +191,11 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
             }
 
             // If there were no accepted ingredients, then there is no recipe to process.
-            if(recipeInputs.isEmpty())
+            if(recipeInputs.isEmpty()) {
+                //Set here to prevent recipe deadlock on world load with full output bus
+                forceRecipeRecheck = true;
                 return null;
+            }
 
             return recipeMap.recipeBuilder()
                 .inputsIngredients(recipeInputs)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiFurnace.java
@@ -1,33 +1,23 @@
 package gregtech.common.metatileentities.multi.electric;
 
-import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.impl.MultiblockRecipeLogic;
-import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
-import gregtech.api.metatileentity.multiblock.IMultiblockPart;
-import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
-import gregtech.api.multiblock.BlockPattern;
-import gregtech.api.multiblock.FactoryBlockPattern;
-import gregtech.api.multiblock.PatternMatchContext;
-import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.Recipe;
-import gregtech.api.recipes.RecipeMaps;
-import gregtech.api.render.ICubeRenderer;
-import gregtech.api.render.Textures;
-import gregtech.common.blocks.BlockMetalCasing.MetalCasingType;
-import gregtech.common.blocks.BlockWireCoil.CoilType;
-import gregtech.common.blocks.MetaBlocks;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraftforge.items.IItemHandlerModifiable;
+import gregtech.api.capability.*;
+import gregtech.api.capability.impl.*;
+import gregtech.api.metatileentity.*;
+import gregtech.api.metatileentity.multiblock.*;
+import gregtech.api.multiblock.*;
+import gregtech.api.recipes.*;
+import gregtech.api.render.*;
+import gregtech.api.util.*;
+import gregtech.common.blocks.BlockMetalCasing.*;
+import gregtech.common.blocks.BlockWireCoil.*;
+import gregtech.common.blocks.*;
+import net.minecraft.block.state.*;
+import net.minecraft.item.*;
+import net.minecraft.util.*;
+import net.minecraft.util.text.*;
+import net.minecraftforge.items.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
 
@@ -130,39 +120,128 @@ public class MetaTileEntityMultiFurnace extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected Recipe findRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs) {
+        protected Recipe findRecipe(long maxVoltage,
+                                    IItemHandlerModifiable inputs,
+                                    IMultipleTankHandler fluidInputs)
+        {
             int currentItemsEngaged = 0;
-            int maxItemsLimit = 32 * heatingCoilLevel;
-            ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
-            ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
-            for (int index = 0; index < inputs.getSlots(); index++) {
-                ItemStack stackInSlot = inputs.getStackInSlot(index);
-                if (stackInSlot.isEmpty())
-                    continue;
-                Recipe matchingRecipe = recipeMap.findRecipe(maxVoltage,
-                    Collections.singletonList(stackInSlot), Collections.emptyList(), 0);
-                CountableIngredient inputIngredient = matchingRecipe == null ? null : matchingRecipe.getInputs().get(0);
-                if (inputIngredient != null && (maxItemsLimit - currentItemsEngaged) >= inputIngredient.getCount()) {
-                    ItemStack outputStack = matchingRecipe.getOutputs().get(0).copy();
-                    int overclockAmount = Math.min(stackInSlot.getCount() / inputIngredient.getCount(),
-                        (maxItemsLimit - currentItemsEngaged) / inputIngredient.getCount());
-                    recipeInputs.add(new CountableIngredient(inputIngredient.getIngredient(),
-                        inputIngredient.getCount() * overclockAmount));
-                    if (!outputStack.isEmpty()) {
-                        outputStack.setCount(outputStack.getCount() * overclockAmount);
-                        recipeOutputs.add(outputStack);
-                    }
-                    currentItemsEngaged += inputIngredient.getCount() * overclockAmount;
-                }
+            final int maxItemsLimit = 32 * heatingCoilLevel;
+            final ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
+            final ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
 
-                if (currentItemsEngaged >= maxItemsLimit) break;
+            /* Iterate over the input items looking for more things to add until we run either out of input items
+             * or we have exceeded the number of items permissible from the smelting bonus
+             */
+            for(int index = 0; index < inputs.getSlots() && currentItemsEngaged < maxItemsLimit; index++) {
+
+                // Skip this slot if it is empty.
+                final ItemStack currentInputItem = inputs.getStackInSlot(index);
+                if(currentInputItem.isEmpty())
+                    continue;
+
+                // Determine if there is a valid recipe for this item. If not, skip it.
+                Recipe matchingRecipe = recipeMap.findRecipe(maxVoltage,
+                                                             Collections.singletonList(currentInputItem),
+                                                             Collections.emptyList(), 0);
+                CountableIngredient inputIngredient;
+                if(matchingRecipe != null)
+                    inputIngredient = matchingRecipe.getInputs().get(0);
+                else
+                    continue;
+
+                // There's something not right with this recipe if the ingredient is null.
+                if(inputIngredient == null)
+                    throw new IllegalStateException(
+                        String.format("Got recipe with null ingredient %s", matchingRecipe));
+
+                // If there are enough slots left to smelt this item stack
+                int itemsLeftUntilMax = (maxItemsLimit - currentItemsEngaged);
+                if(itemsLeftUntilMax >= inputIngredient.getCount()) {
+
+                    /* Choose the lesser of the number of possible crafts in this ingredient's stack, or the number of
+                     * items remaining to reach the coil bonus's max smelted items.
+                     */
+                    int craftsPossible = currentInputItem.getCount() / inputIngredient.getCount();
+                    int craftsUntilMax = itemsLeftUntilMax / inputIngredient.getCount();
+                    int recipeMultiplier = Math.min(craftsPossible, craftsUntilMax);
+
+                    // copy the outputs list so we don't mutate it yet
+                    ArrayList<ItemStack> temp = new ArrayList<>(recipeOutputs);
+
+                    // Process the stacks to see how many items this makes
+                    computeOutputItemStacks(temp, matchingRecipe.getOutputs().get(0), recipeMultiplier);
+
+                    // determine if there is enough room in the output to fit all of this
+                    boolean canFitOutputs = InventoryUtils.simulateItemStackMerge(temp, this.getOutputInventory());
+
+                    // if there isn't, we can't process this recipe.
+                    if(!canFitOutputs)
+                        break;
+
+                    // otherwise, let's add the new output items and keep going
+                    temp.removeAll(recipeOutputs);
+                    recipeOutputs.addAll(temp);
+
+                    // Add the ingredients to the list of things to smelt.
+                    recipeInputs.add(new CountableIngredient(inputIngredient.getIngredient(),
+                                                             inputIngredient.getCount() * recipeMultiplier));
+
+                    currentItemsEngaged += inputIngredient.getCount() * recipeMultiplier;
+                }
             }
-            return recipeInputs.isEmpty() ? null : recipeMap.recipeBuilder()
+
+            // If there were no accepted ingredients, then there is no recipe to process.
+            if(recipeInputs.isEmpty())
+                return null;
+
+            return recipeMap.recipeBuilder()
                 .inputsIngredients(recipeInputs)
                 .outputs(recipeOutputs)
                 .EUt(Math.max(1, 16 / heatingCoilDiscount))
                 .duration((int) Math.max(1.0, 256 * (currentItemsEngaged / (maxItemsLimit * 1.0))))
                 .build().getResult();
+        }
+    }
+
+    /**
+     * Computes the minimal number of ItemStacks necessary to store a multiplied recipe output, then
+     * generates the stacks. The result is then stored in {@code recipeOutputs}.
+     *
+     * @param recipeOutputs   a collection of outputs to store the resulting output ItemStacks
+     * @param outputStack     an ItemStack representing the output item of a recipe
+     * @param overclockAmount the number of times that {@code outputStack}'s quantity should
+     *                        be multiplied by for the desired total
+     */
+    private void computeOutputItemStacks(Collection<ItemStack> recipeOutputs,
+                                         ItemStack outputStack,
+                                         int overclockAmount)
+    {
+        if(!outputStack.isEmpty()) {
+            // number of output items we're generating
+            int finalAmount = outputStack.getCount() * overclockAmount;
+
+            // max items allowed in a stack
+            int maxCount = outputStack.getMaxStackSize();
+
+            // number of whole stacks of output this will make
+            int numStacks = finalAmount / maxCount;
+
+            // number of items left (partial stack)
+            int remainder = finalAmount % maxCount;
+
+            // Add full stacks of the output item
+            for(int fullStacks = numStacks; fullStacks > 0; fullStacks--) {
+                ItemStack full = outputStack.copy();
+                full.setCount(maxCount);
+                recipeOutputs.add(full);
+            }
+
+            // if there is a partial stack, add it too
+            if(remainder > 0) {
+                ItemStack partial = outputStack.copy();
+                partial.setCount(remainder);
+                recipeOutputs.add(partial);
+            }
         }
     }
 


### PR DESCRIPTION
**What:**
This PR fixes multiblocks voiding parts of multi item outputs when the output bus only has room for the first output of the recipe.

**How solved:**
This PR adds logic and methods checking if the output of recipes can merge into available slots in the output bus to prevent the issue of output voiding due to checking each item individually, which missed out on possible output inventory changes, causing some portions of the output to be voided.

**Outcome:**
Fixes Multiblocks voiding partial recipe outputs when output bus is mostly full. Closes #1334. Closes #1332. Supersedes #1333.


**Possible compatibility issue:**
The old method was redirected to the new method, so there should be minimal chance for compatibility issues.