### PR TITLE
Fix incorrect Lapotron Crystal crafting recipe

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -835,16 +835,6 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             return itemStack;
         }
 
-        public long getChargeAmount() {
-            ItemStack itemstack = getStackForm(1);
-            IElectricItem electricItem = itemstack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
-            if(electricItem == null) {
-                throw new IllegalStateException("Not an electric item");
-            }
-
-            return electricItem.getMaxCharge();
-        }
-
         public ItemStack getInfiniteChargedStack() {
             ItemStack itemStack = getStackForm(1);
             IElectricItem electricItem = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -835,6 +835,16 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             return itemStack;
         }
 
+        public long getChargeAmount() {
+            ItemStack itemstack = getStackForm(1);
+            IElectricItem electricItem = itemstack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
+            if(electricItem == null) {
+                throw new IllegalStateException("Not an electric item");
+            }
+
+            return electricItem.getMaxCharge();
+        }
+
         public ItemStack getInfiniteChargedStack() {
             ItemStack itemStack = getStackForm(1);
             IElectricItem electricItem = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -260,25 +260,10 @@ public class ModHandler {
     }
 
     public static void addShapedEnergyTransferRecipe(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, boolean transferMaxCharge, Object... recipe) {
-        boolean skip = false;
-        if (result.isEmpty()) {
-            GTLog.logger.error("Result cannot be an empty ItemStack. Recipe: {}", regName);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
-            skip = true;
-        }
-        skip |= validateRecipe(regName, recipe);
-        if (skip) {
-            RecipeMap.setFoundInvalidRecipe(true);
-            return;
-        }
-
-        IRecipe shapedOreRecipe = new ShapedOreEnergyTransferRecipe(null, result.copy(), chargePredicate, transferMaxCharge, finalizeShapedRecipeInput(recipe))
-            .setMirrored(false) //make all recipes not mirrored by default
-            .setRegistryName(regName);
-        ForgeRegistries.RECIPES.register(shapedOreRecipe);
+        addShapedEnergyTransferRecipeWithOverride(regName, result, chargePredicate, true, transferMaxCharge, recipe);
     }
 
-    public static void addShapedEnergyTransferRecipe(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, Object... recipe) {
+    public static void addShapedEnergyTransferRecipeWithOverride(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {
         boolean skip = false;
         if (result.isEmpty()) {
             GTLog.logger.error("Result cannot be an empty ItemStack. Recipe: {}", regName);
@@ -291,7 +276,7 @@ public class ModHandler {
             return;
         }
 
-        IRecipe shapedOreRecipe = new ShapedOreEnergyTransferRecipe(null, result.copy(), chargePredicate, chargeAmount, transferMaxCharge, finalizeShapedRecipeInput(recipe))
+        IRecipe shapedOreRecipe = new ShapedOreEnergyTransferRecipe(null, result.copy(), chargePredicate, overrideCharge, transferMaxCharge, finalizeShapedRecipeInput(recipe))
             .setMirrored(false) //make all recipes not mirrored by default
             .setRegistryName(regName);
         ForgeRegistries.RECIPES.register(shapedOreRecipe);

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -278,6 +278,25 @@ public class ModHandler {
         ForgeRegistries.RECIPES.register(shapedOreRecipe);
     }
 
+    public static void addShapedEnergyTransferRecipe(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, Object... recipe) {
+        boolean skip = false;
+        if (result.isEmpty()) {
+            GTLog.logger.error("Result cannot be an empty ItemStack. Recipe: {}", regName);
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            skip = true;
+        }
+        skip |= validateRecipe(regName, recipe);
+        if (skip) {
+            RecipeMap.setFoundInvalidRecipe(true);
+            return;
+        }
+
+        IRecipe shapedOreRecipe = new ShapedOreEnergyTransferRecipe(null, result.copy(), chargePredicate, chargeAmount, transferMaxCharge, finalizeShapedRecipeInput(recipe))
+            .setMirrored(false) //make all recipes not mirrored by default
+            .setRegistryName(regName);
+        ForgeRegistries.RECIPES.register(shapedOreRecipe);
+    }
+
     private static boolean validateRecipe(String regName, Object... recipe) {
         boolean skip = false;
         if (recipe == null) {

--- a/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
@@ -25,28 +25,20 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
         this(group, result, chargePredicate, transferMaxCharge, CraftingHelper.parseShaped(recipe));
     }
 
-    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, Object... recipe) {
-        this(group, result, chargePredicate, chargeAmount, transferMaxCharge, CraftingHelper.parseShaped(recipe));
+    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {
+        this(group, result, chargePredicate, overrideCharge, transferMaxCharge, CraftingHelper.parseShaped(recipe));
     }
 
     public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, boolean transferMaxCharge, ShapedPrimer primer) {
+        this(group, result, chargePredicate, true, transferMaxCharge, primer);
+    }
+
+    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, ShapedPrimer primer) {
         super(group, result, primer);
         this.chargePredicate = chargePredicate;
         this.transferMaxCharge = transferMaxCharge;
-        fixOutputItemMaxCharge();
-    }
-
-    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, ShapedPrimer primer) {
-        super(group, result, primer);
-        this.chargePredicate = chargePredicate;
-        this.transferMaxCharge = transferMaxCharge;
-        setMaxChargeInRecipe(chargeAmount);
-    }
-
-    private void setMaxChargeInRecipe(long chargeAmount) {
-        IElectricItem electricItem = output.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
-        if(!(electricItem == null)) {
-            ((ElectricItem) electricItem).setMaxChargeOverride(chargeAmount);
+        if(overrideCharge) {
+            fixOutputItemMaxCharge();
         }
     }
 

--- a/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
@@ -25,11 +25,29 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
         this(group, result, chargePredicate, transferMaxCharge, CraftingHelper.parseShaped(recipe));
     }
 
+    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, Object... recipe) {
+        this(group, result, chargePredicate, chargeAmount, transferMaxCharge, CraftingHelper.parseShaped(recipe));
+    }
+
     public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, boolean transferMaxCharge, ShapedPrimer primer) {
         super(group, result, primer);
         this.chargePredicate = chargePredicate;
         this.transferMaxCharge = transferMaxCharge;
         fixOutputItemMaxCharge();
+    }
+
+    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, long chargeAmount, boolean transferMaxCharge, ShapedPrimer primer) {
+        super(group, result, primer);
+        this.chargePredicate = chargePredicate;
+        this.transferMaxCharge = transferMaxCharge;
+        setMaxChargeInRecipe(chargeAmount);
+    }
+
+    private void setMaxChargeInRecipe(long chargeAmount) {
+        IElectricItem electricItem = output.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
+        if(!(electricItem == null)) {
+            ((ElectricItem) electricItem).setMaxChargeOverride(chargeAmount);
+        }
     }
 
     //transfer initial max charge for correct display in JEI

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -90,7 +90,7 @@ public class CraftingRecipeLoader {
         for(Material material : new Material[] {Materials.Lapis, Materials.Lazurite, Materials.Sodalite}) {
             String recipeName = "lapotron_crystal_" + material.toString();
             ModHandler.addShapedEnergyTransferRecipe(recipeName, MetaItems.LAPOTRON_CRYSTAL.getStackForm(),
-                Ingredient.fromStacks(MetaItems.ENERGY_CRYSTAL.getStackForm()), false,
+                Ingredient.fromStacks(MetaItems.LAPOTRON_CRYSTAL.getStackForm()), MetaItems.LAPOTRON_CRYSTAL.getChargeAmount(), false,
                 "XCX", "XEX", "XCX",
                 'X', new UnificationEntry(OrePrefix.plate, material),
                 'C', new UnificationEntry(OrePrefix.circuit, Tier.Advanced),

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -89,8 +89,8 @@ public class CraftingRecipeLoader {
 
         for(Material material : new Material[] {Materials.Lapis, Materials.Lazurite, Materials.Sodalite}) {
             String recipeName = "lapotron_crystal_" + material.toString();
-            ModHandler.addShapedEnergyTransferRecipe(recipeName, MetaItems.LAPOTRON_CRYSTAL.getStackForm(),
-                Ingredient.fromStacks(MetaItems.LAPOTRON_CRYSTAL.getStackForm()), MetaItems.LAPOTRON_CRYSTAL.getChargeAmount(), false,
+            ModHandler.addShapedEnergyTransferRecipeWithOverride(recipeName, MetaItems.LAPOTRON_CRYSTAL.getStackForm(),
+                Ingredient.fromStacks(MetaItems.ENERGY_CRYSTAL.getStackForm()), false, false,
                 "XCX", "XEX", "XCX",
                 'X', new UnificationEntry(OrePrefix.plate, material),
                 'C', new UnificationEntry(OrePrefix.circuit, Tier.Advanced),


### PR DESCRIPTION
**What:**
This PR fixes the incorrect Lapotron Crystal crafting recipe, where the Lapotron Crystal had a capacity of 10M EU, but the crafting recipe only crafted to one with 4M EU.

**How solved:**
A new method was added, which takes an additional parameter of the maximum charge, which then sets the output of the crafting recipe to have a maximum charge of that amount. This is used in conjunction with a new helper method in `MetaItem` that will return the maximum charge of an electric item.

**Outcome:**
Fixes Lapotron Crystal crafting to one with incorrect EU capacity. Closes #1336.

**Additional info:**
![2020-12-13_11 13 47](https://user-images.githubusercontent.com/31759736/102020131-69f21a80-3d34-11eb-91ab-5cc6772e0439.png)

This is the case for all variants of the Lapotron, they craft to the correct amount

**Possible compatibility issue:**
None expected


