### PR TITLE
Fix the Primitive Blast Furnace Voiding outputs

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -47,6 +47,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 
+import static gregtech.api.util.InventoryUtils.simulateItemStackMerge;
+
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
@@ -133,8 +135,11 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
     }
 
     private boolean setupRecipe(ItemStack inputStack, int fuelAmount, PrimitiveBlastFurnaceRecipe recipe) {
+        List<ItemStack> outputs = new ArrayList<>();
+        outputs.add(recipe.getOutput());
+        outputs.add(getAshForRecipeFuelConsumption(recipe.getFuelAmount()));
         return inputStack.getCount() >= recipe.getInput().getCount() && fuelAmount >= recipe.getFuelAmount() &&
-            ItemHandlerHelper.insertItemStacked(exportItems, recipe.getOutput(), true).isEmpty();
+                simulateItemStackMerge(outputs, exportItems);
     }
 
     private boolean tryPickNewRecipe() {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -139,7 +139,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
         outputs.add(recipe.getOutput());
         outputs.add(getAshForRecipeFuelConsumption(recipe.getFuelAmount()));
         return inputStack.getCount() >= recipe.getInput().getCount() && fuelAmount >= recipe.getFuelAmount() &&
-                simulateItemStackMerge(outputs, exportItems);
+            ItemHandlerHelper.insertItemStacked(exportItems, recipe.getOutput(), true).isEmpty();
     }
 
     private boolean tryPickNewRecipe() {
@@ -166,8 +166,15 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
             this.currentProgress = 0;
             NonNullList<ItemStack> outputs = NonNullList.create();
             outputs.add(currentRecipe.getOutput().copy());
-            outputs.add(getAshForRecipeFuelConsumption(currentRecipe.getFuelAmount()));
-            this.outputsList = outputs;
+            NonNullList<ItemStack> outputsWithAsh = NonNullList.create();
+            outputsWithAsh.add(currentRecipe.getOutput().copy());
+            outputsWithAsh.add(getAshForRecipeFuelConsumption(currentRecipe.getFuelAmount()));
+            if(simulateItemStackMerge(outputs, exportItems) && !simulateItemStackMerge(outputsWithAsh, exportItems)) {
+                this.outputsList = outputs;
+            }
+            else {
+                this.outputsList = outputsWithAsh;
+            }
             markDirty();
             return true;
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -135,9 +135,6 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
     }
 
     private boolean setupRecipe(ItemStack inputStack, int fuelAmount, PrimitiveBlastFurnaceRecipe recipe) {
-        List<ItemStack> outputs = new ArrayList<>();
-        outputs.add(recipe.getOutput());
-        outputs.add(getAshForRecipeFuelConsumption(recipe.getFuelAmount()));
         return inputStack.getCount() >= recipe.getInput().getCount() && fuelAmount >= recipe.getFuelAmount() &&
             ItemHandlerHelper.insertItemStacked(exportItems, recipe.getOutput(), true).isEmpty();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -135,8 +135,11 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
     }
 
     private boolean setupRecipe(ItemStack inputStack, int fuelAmount, PrimitiveBlastFurnaceRecipe recipe) {
+        List<ItemStack> outputs = new ArrayList<>();
+        outputs.add(recipe.getOutput());
+        outputs.add(getAshForRecipeFuelConsumption(recipe.getFuelAmount()));
         return inputStack.getCount() >= recipe.getInput().getCount() && fuelAmount >= recipe.getFuelAmount() &&
-            ItemHandlerHelper.insertItemStacked(exportItems, recipe.getOutput(), true).isEmpty();
+                simulateItemStackMerge(outputs, exportItems);
     }
 
     private boolean tryPickNewRecipe() {
@@ -163,15 +166,8 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
             this.currentProgress = 0;
             NonNullList<ItemStack> outputs = NonNullList.create();
             outputs.add(currentRecipe.getOutput().copy());
-            NonNullList<ItemStack> outputsWithAsh = NonNullList.create();
-            outputsWithAsh.add(currentRecipe.getOutput().copy());
-            outputsWithAsh.add(getAshForRecipeFuelConsumption(currentRecipe.getFuelAmount()));
-            if(simulateItemStackMerge(outputs, exportItems) && !simulateItemStackMerge(outputsWithAsh, exportItems)) {
-                this.outputsList = outputs;
-            }
-            else {
-                this.outputsList = outputsWithAsh;
-            }
+            outputs.add(getAshForRecipeFuelConsumption(currentRecipe.getFuelAmount()));
+            this.outputsList = outputs;
             markDirty();
             return true;
         }


### PR DESCRIPTION
**What:**
After the latest version of GTCE (1.10.8.599) was released, it was noticed that the Primitive Blast Furnace was voiding both the steel and the ashes outputs when the ash output in the output slot was too high and thus the recipe outputs could not be merged into the output slots

**How solved:**
Since the PBF is somewhat special and checks for room based on only the recipe outputs (not including the ash), and then adds the ash outputs after, there were issues with the outputs voiding. To keep with the previous behavior of the PBF, it has been adjusted to void the ash outputs when those are full/almost full, while continuing to produce steel. The steel will not be voided however, when its output slot fills up. The PBF will instead stop. However, this is easy to change so that the PBF will not function is there is not room for both the Ash and the recipe output. Please let me know what you prefer in this case.

**Outcome:**
Fixes recipe outputs being voided in the Primitive Blast Furnace if one output slot was full
