### PR TITLE
Streamlining FuelRecipeMap to be like RecipeMap

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/FuelRecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/machines/FuelRecipeMap.java
@@ -39,9 +39,9 @@ public class FuelRecipeMap {
     }
 
     @ZenMethod
-    public static FuelRecipeMap getByName(String name) {
+    public static FuelRecipeMap getByName(String unlocalizedName) {
         return RECIPE_MAPS.stream()
-            .filter(map -> map.unlocalizedName.equals(name))
+            .filter(map -> map.unlocalizedName.equals(unlocalizedName))
             .findFirst().orElse(null);
     }
 

--- a/src/main/java/gregtech/api/recipes/machines/FuelRecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/machines/FuelRecipeMap.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.machines;
 
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import gregtech.api.GTValues;
@@ -10,11 +11,14 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.*;
 
+@ZenClass("mods.gregtech.recipe.FuelRecipeMap")
+@ZenRegister
 public class FuelRecipeMap {
 
     private static final List<FuelRecipeMap> RECIPE_MAPS = new ArrayList<>();
@@ -32,6 +36,13 @@ public class FuelRecipeMap {
     @ZenGetter("recipeMaps")
     public static List<FuelRecipeMap> getRecipeMaps() {
         return RECIPE_MAPS;
+    }
+
+    @ZenMethod
+    public static FuelRecipeMap getByName(String name) {
+        return RECIPE_MAPS.stream()
+            .filter(map -> map.unlocalizedName.equals(name))
+            .findFirst().orElse(null);
     }
 
     @ZenMethod


### PR DESCRIPTION
**What:**
Made it so that you can get FuelRecipeMap's by doing `FuelRecipeMap.getByName("gas_turbine");`. Also exposed it properly to CraftTweaker.