### PR TITLE
Fall through instead of returning null in traceCoverSide

### DIFF
--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -164,7 +164,7 @@ public interface ICoverable {
             } else if(rayTraceResult.cuboid6.data instanceof PrimaryBoxData) {
                 PrimaryBoxData primaryBoxData = (PrimaryBoxData) rayTraceResult.cuboid6.data;
                 return primaryBoxData.usePlacementGrid ? determineGridSideHit(result) : result.sideHit;
-            } else return null; //unknown hit type, return null
+            } //unknown hit type, fall through
         }
         //normal collision ray trace, return side hit
         return determineGridSideHit(result);


### PR DESCRIPTION
**What:**
This PR removes an illogical and unnecessary null return.

**Outcome:**
`gregtech.api.cover.ICoverable#traceCoverSide` will no longer return null under specific conditions.

It doesn't make sense for it to return null ever: there was still a block raytraced, and thus a side hit, after all.

**Possible compatibility issue:**
None