### PR TITLE
Check all inputs to the Furnace recipe map

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -28,20 +28,15 @@ public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {
         for(ItemStack input : inputs) {
             ItemStack output = ModHandler.getSmeltingOutput(input);
 
-            if(output == null) {
-                continue;
-            }
-            else {
+            if(!output.isEmpty()) {
                 return this.recipeBuilder()
                     .inputs(GTUtility.copyAmount(1, input))
                     .outputs(output)
                     .duration(128).EUt(4)
                     .build().getResult();
             }
-
         }
 
         return null;
-
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -24,11 +24,24 @@ public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {
         Recipe normalRecipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity, mode);
         if (normalRecipe != null || inputs.size() == 0 || inputs.get(0).isEmpty())
             return normalRecipe;
-        ItemStack output = ModHandler.getSmeltingOutput(inputs.get(0));
-        return output.isEmpty() ? null : this.recipeBuilder()
-            .inputs(GTUtility.copyAmount(1, inputs.get(0)))
-            .outputs(output)
-            .duration(128).EUt(4)
-            .build().getResult();
+
+        for(ItemStack input : inputs) {
+            ItemStack output = ModHandler.getSmeltingOutput(input);
+
+            if(output == null) {
+                continue;
+            }
+            else {
+                return this.recipeBuilder()
+                    .inputs(GTUtility.copyAmount(1, input))
+                    .outputs(output)
+                    .duration(128).EUt(4)
+                    .build().getResult();
+            }
+
+        }
+
+        return null;
+
     }
 }


### PR DESCRIPTION
**What:**
This PR changes the Furnace recipe map to check all input ItemStacks for a possible recipe, instead of just checking the first item in the input list. This is especially useful for addons that may pass a list to the furnace recipe map with more than one ItemStack, such as is the case with the Processing Array in Shadows of Greg.

**How solved:**
Changed the code to check each input ItemStack for a recipe, returning a constructed recipe for the first non-null recipe found, or else returning null

**Outcome:**
Check all inputs for recipes for the Electric Furnace. Closes #1360.

**Possible compatibility issue:**
None Expected