### PR TITLE
fix surface rocks ccl exceptions while using optifine shaders

### DIFF
--- a/src/main/java/gregtech/common/render/StoneRenderer.java
+++ b/src/main/java/gregtech/common/render/StoneRenderer.java
@@ -5,12 +5,9 @@ import codechicken.lib.render.CCModel;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.block.BlockRenderingRegistry;
 import codechicken.lib.render.block.ICCBlockRenderer;
-import codechicken.lib.render.pipeline.ColourMultiplier;
-import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.texture.TextureUtils;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
-import codechicken.lib.vec.TransformationList;
 import codechicken.lib.vec.Vector3;
 import codechicken.lib.vec.uv.IconTransformation;
 import gregtech.api.unification.material.type.Material;
@@ -68,22 +65,16 @@ public class StoneRenderer implements ICCBlockRenderer {
         CCRenderState renderState = CCRenderState.instance();
         renderState.reset();
         renderState.bind(buffer);
+        renderState.setBrightness(world, pos);
+
         Matrix4 translation = new Matrix4();
         translation.translate(pos.getX(), pos.getY(), pos.getZ());
         TextureAtlasSprite stoneSprite = TextureUtils.getBlockTexture("stone");
         Material material = ((BlockSurfaceRock) state.getBlock()).getStoneMaterial(world, pos, state);
         int renderingColor = GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB);
-        IVertexOperation[] operations = new IVertexOperation[] {
-            new IconTransformation(stoneSprite),
-            new ColourMultiplier(renderingColor),
-            new TransformationList(translation)};
-        if (world != null) {
-            renderState.setBrightness(world, pos);
-        }
-        renderState.setPipeline(operations);
-        CCModel actualModel = getActualModel(world, pos);
-        renderState.setModel(actualModel);
-        renderState.render();
+
+        CCModel actualModel = getActualModel(world, pos).setColour(renderingColor).computeNormals().smoothNormals();
+        actualModel.render(renderState, new IconTransformation(stoneSprite), translation);
         return true;
     }
 

--- a/src/main/java/gregtech/common/render/StoneRenderer.java
+++ b/src/main/java/gregtech/common/render/StoneRenderer.java
@@ -5,6 +5,7 @@ import codechicken.lib.render.CCModel;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.block.BlockRenderingRegistry;
 import codechicken.lib.render.block.ICCBlockRenderer;
+import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.texture.TextureUtils;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
@@ -73,8 +74,8 @@ public class StoneRenderer implements ICCBlockRenderer {
         Material material = ((BlockSurfaceRock) state.getBlock()).getStoneMaterial(world, pos, state);
         int renderingColor = GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB);
 
-        CCModel actualModel = getActualModel(world, pos).setColour(renderingColor).computeNormals().smoothNormals();
-        actualModel.render(renderState, new IconTransformation(stoneSprite), translation);
+        CCModel actualModel = getActualModel(world, pos).computeNormals().smoothNormals();
+        actualModel.render(renderState, new ColourMultiplier(renderingColor), new IconTransformation(stoneSprite), translation);
         return true;
     }
 


### PR DESCRIPTION
**What:**
Optifine was complaining that surface rocks didn't have normals setted for the shaders.

**How solved:**
Added the computeNormals() to the model builder.

**Outcome:**
Closes #1363. And a few more before.

**Additional info:**
![2020-12-22_20 27 24](https://user-images.githubusercontent.com/66888526/102952932-0643bc00-44af-11eb-8fad-ecc9efdfd6c4.png)

**Possible compatibility issue:**
none
