### PR TITLE
Fix wood recipes detection

### DIFF
--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -235,6 +235,7 @@ public class CommonProxy {
     }
 
     public void onPostLoad() {
+        WoodMachineRecipes.postInit();
     }
 
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -22,6 +22,9 @@ public class WoodMachineRecipes {
     public static void init() {
         initializeWoodRecipes();
         registerPyrolyseOvenRecipes();
+    }
+
+    public static void postInit() {
         processLogOreDictionary();
     }
 


### PR DESCRIPTION
**What:**
Some mods (like forestry) were registering their wood recipes after GTCE `CommonProxy.registerRecipesLowest` causing incompatibilities.

**How solved:**
Delaying `processLogOreDictionary` to `FMLPostInitializationEvent` to catch every possible recipe addition.

**Outcome:**
Closes #1233, Fixes #1341.

**Possible compatibility issue:**
Should't be.