### PR TITLE
Fix Forge data and Capabilities not being synced to client.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -78,9 +78,6 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     @Override
     public NBTTagCompound getUpdateTag() {
         NBTTagCompound updateTag = super.getUpdateTag();
-        updateTag.setInteger("x", getPos().getX());
-        updateTag.setInteger("y", getPos().getY());
-        updateTag.setInteger("z", getPos().getZ());
         ByteBuf backedBuffer = Unpooled.buffer();
         writeInitialSyncData(new PacketBuffer(backedBuffer));
         byte[] updateData = Arrays.copyOfRange(backedBuffer.array(), 0, backedBuffer.writerIndex());

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -11,6 +11,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraftforge.common.util.Constants.NBT;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -88,7 +89,8 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public void handleUpdateTag(NBTTagCompound tag) {
+    public void handleUpdateTag(@Nonnull NBTTagCompound tag) {
+        super.readFromNBT(tag); // deserializes Forge data and capabilities
         byte[] updateData = tag.getByteArray("d");
         ByteBuf backedBuffer = Unpooled.copiedBuffer(updateData);
         receiveInitialSyncData(new PacketBuffer(backedBuffer));


### PR DESCRIPTION
**What:**
This PR ensures that Forge's additional data and any attached Forge Capabilities are deserialized when tile entities are synced to the client.

**How solved:**
The `readFromData` method in TileEntity [patched by Forge](https://github.com/MinecraftForge/MinecraftForge/blob/a8b9abcb17e28007ed5f5e110997be8e499575e5/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch#L16-L17) does everything necessary for deserializing Forge data and capabilities, so a call to it was inserted in `handleUpdateTag`.

**Outcome:**
Any data stored on GTCE Tile Entities through either capabilities or the [custom persistent data](https://github.com/MinecraftForge/MinecraftForge/blob/a8b9abcb17e28007ed5f5e110997be8e499575e5/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch#L209) will properly be synchronized to client. This means mods that use Forge capabilities won't have desync issues between server and client on GTCE tile entities.

**Additional info:**
I also noticed that [these lines above in `getUpdateTag`](https://github.com/GregTechCE/GregTech/blob/22a594d9f945c2281a354e8de4aef84d94a895bd/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java#L80-L82) seem to be redundant, as the position is serialized in [`super.getUpdateTag()`](https://github.com/MinecraftForge/MinecraftForge/blob/a8b9abcb17e28007ed5f5e110997be8e499575e5/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch#L22-L24) anyway.

**Possible compatibility issue:**
Should be none.