### PR TITLE
fixCCLErrors

### DIFF
--- a/src/main/java/gregtech/common/render/ShapeModelGenerator.java
+++ b/src/main/java/gregtech/common/render/ShapeModelGenerator.java
@@ -61,8 +61,7 @@ public class ShapeModelGenerator {
                 secondTop.y = second.y + nextSegmentHeight;
             }
         }
-        initialModel.computeNormals();
-        return initialModel;
+        return initialModel.computeNormals();
     }
 
     private static Vector3 generatePoint(double anglePerNumber, int number, double radius) {

--- a/src/main/java/gregtech/common/render/StonePileModelGenerator.java
+++ b/src/main/java/gregtech/common/render/StonePileModelGenerator.java
@@ -27,7 +27,7 @@ public class StonePileModelGenerator {
             int color = (b & 0xFF) << 24 | (b & 0xFF) << 16 | (b & 0xFF) << 8 | (0xFF);
             Arrays.fill(colours, i * 24, i* 24 + 24, color);
         }
-        return ccModel;
+        return ccModel.computeNormals();
     }
 
     private static List<IndexedCuboid6> generateCuboidList(Random random) {


### PR DESCRIPTION
What:
Fixed Renderer complaining about missing attribute, causing blocks to go transparent.

How solved:
added compute normals to model generation

Outcome:
Closes #1091 , Closes #1236, Closes #1363, Closes #1320, Closes #1216

Additional info:
After creating pull request, i realized that there is a pull request #1366, but that one would loose performance as the computation is done in renderer