### PR TITLE
Fixes GregTechCE/GregTech#1085. Fluids missing texture when poured into the world

### DIFF
--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -81,13 +81,13 @@ public class CommonProxy {
         SURFACE_ROCKS.values().stream().distinct().forEach(registry::register);
         FRAMES.values().stream().distinct().forEach(registry::register);
         ORES.forEach(registry::register);
-        FLUID_BLOCKS.forEach(registry::register);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void registerBlocksLast(RegistryEvent.Register<Block> event) {
         //last chance for mods to register their potion types is here
         PotionFluids.initPotionFluids();
+        FLUID_BLOCKS.forEach(event.getRegistry()::register);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**What:**
This PR solves potion fluid blocks rendering with a mixing texture when poured into the world, and then being gone from the world upon relog

**How solved:**
Moved the registration of the fluid blocks later on in the registration cycle, so that all fluid blocks have had a chance to be registered

**Outcome:**
Fixes Fluids rendering with a mixing texture when poured into the world and being missing on world reload. Closes #1085.

**Additional info:**
Potion of Luck and Strength on the ground:
![2020-12-27_20 00 05](https://user-images.githubusercontent.com/31759736/103186567-44a9f400-487e-11eb-83ce-4d42f3de759c.png)


**Possible compatibility issue:**
None expected.
