### PR TITLE
Fix Logic Bugs and Improve Utility of Multiblock Voiding Fix Code

### DIFF
--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -90,8 +90,8 @@ public final class InventoryUtils {
      * @return a list containing the resulting ItemStacks.
      */
     static List<ItemStack> compactItemStacks(Collection<ItemStack> inputItems) {
-        Hash.Strategy<ItemStack>      strategy = ItemStackHashStrategy.comparingAllButCount();
-        final Map<ItemStack, Integer> map      = new Object2IntOpenCustomHashMap<>(strategy);
+        Hash.Strategy<ItemStack> strategy = ItemStackHashStrategy.comparingAllButCount();
+        final Map<ItemStack, Integer> map = new Object2IntOpenCustomHashMap<>(strategy);
 
         return inputItems.stream()
 
@@ -190,7 +190,7 @@ public final class InventoryUtils {
 
         final ArrayList<ItemStack> splitStacks = new ArrayList<>();
 
-        int count     = stack.getCount();
+        int count = stack.getCount();
         int numStacks = count / maxCount;
         int remainder = count % maxCount;
 

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -48,6 +48,10 @@ public class InventoryUtils
      * simulating merging like items into existing stacks, then checking if there
      * are enough empty stacks left to accommodate the remaining items.
      * <br /><br />
+     * <b>Precondition:</b> the target inventory must not virtualize ItemStacks such that
+     *               they can exceed the maximum stackable size of the item as
+     *               defined by {@link net.minecraft.item.ItemStack#getMaxStackSize()}.
+     * <br /><br />
      * <b>Precondition:</b> the target inventory must actually accept the types of items
      *               you are trying to insert.
      * <br /><br />

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -9,9 +9,10 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.*;
 
+import static gregtech.api.util.Predicates.*;
 import static gregtech.api.util.StreamUtils.*;
 
-public class InventoryUtils {
+public final class InventoryUtils {
     /**
      * @param inventory the target inventory
      * @return the number of empty slots in {@code inventory}

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -1,25 +1,29 @@
 package gregtech.api.util;
 
+import it.unimi.dsi.fastutil.*;
+import it.unimi.dsi.fastutil.objects.*;
 import net.minecraft.item.*;
 import net.minecraftforge.items.*;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.*;
 
-public class InventoryUtils {
+import static gregtech.api.util.StreamUtils.*;
 
+public class InventoryUtils
+{
     /**
      * @param inventory the target inventory
      * @return the number of empty slots in {@code inventory}
      */
-    public static int getNumberOfEmptySlotsInInventory(IItemHandler inventory) {
-        int emptySlots = 0;
-        for(int index = 0; index < inventory.getSlots(); index++) {
-            if(inventory.getStackInSlot(index).isEmpty()) {
-                emptySlots++;
-            }
-        }
-
-        return emptySlots;
+    public static int getNumberOfEmptySlotsInInventory(IItemHandler inventory)
+    {
+        // IItemHandler#getSlots() is an int, so this cast is safe.
+        return (int)
+            streamFrom(inventory)
+                .filter(ItemStack::isEmpty)
+                .count();
     }
 
     /**
@@ -29,15 +33,14 @@ public class InventoryUtils {
      * @param keepEmpty whether to keep empty ItemStacks (if {@code true}, stacks will be kept).
      * @return a deep copy of the inventory.
      */
-    public static List<ItemStack> deepCopy(IItemHandler inventory, boolean keepEmpty) {
-        int numSlots = inventory.getSlots();
-        List<ItemStack> inventoryStacks = new ArrayList<>(numSlots);
-        for(int slotIndex = 0; slotIndex < numSlots; slotIndex++) {
-            ItemStack stack = inventory.getStackInSlot(slotIndex);
-            if(keepEmpty || !stack.isEmpty())
-                inventoryStacks.add(stack.copy());
-        }
-        return inventoryStacks;
+    public static List<ItemStack> deepCopy(final IItemHandler inventory,
+                                           final boolean keepEmpty)
+    {
+        return streamFrom(inventory)
+            .filter(or(x -> keepEmpty,
+                       not(ItemStack::isEmpty)))
+            .map(ItemStack::copy)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -45,29 +48,25 @@ public class InventoryUtils {
      * simulating merging like items into existing stacks, then checking if there
      * are enough empty stacks left to accommodate the remaining items.
      * <br /><br />
-     * <b>Precondition:</b> the target inventory must not virtualize ItemStacks such that
-     *               they can exceed the maximum stackable size of the item as
-     *               defined by {@link net.minecraft.item.ItemStack#getMaxStackSize()}.
-     * <br /><br />
      * <b>Precondition:</b> the target inventory must actually accept the types of items
      *               you are trying to insert.
      * <br /><br />
-     * @param items the items you want to insert
-     * @param inventory the target inventory receiving items
+     *
+     * @param inputItems the items you want to insert
+     * @param inventory  the target inventory receiving items
      * @return {@code true} if inventory contains sufficient slots to merge and
      *         insert all requested items, {@code false} otherwise.
      */
-    public static boolean simulateItemStackMerge(List<ItemStack> items,
+    public static boolean simulateItemStackMerge(List<ItemStack> inputItems,
                                                  IItemHandler inventory)
     {
+        // Generate a stack-minimized copy of the input items
+        final List<ItemStack> itemStacks = compactItemStacks(inputItems);
+
         // If there's enough empty output slots then we don't need to compute merges.
         final int emptySlots = getNumberOfEmptySlotsInInventory(inventory);
-        if(items.size() <= emptySlots)
+        if(itemStacks.size() <= emptySlots)
             return true;
-
-        // Deep copy the recipe output ItemStacks
-        final List<ItemStack> itemStacks = new ArrayList<>(items.size());
-        items.forEach(itemStack -> itemStacks.add(itemStack.copy()));
 
         // Sort by the number of items in each stack so we merge smallest stacks first.
         itemStacks.sort(Comparator.comparingInt(ItemStack::getCount));
@@ -83,6 +82,44 @@ public class InventoryUtils {
     }
 
     /**
+     * Compacts multiple ItemStacks into as few stacks as possible. The input items are not modified;
+     * the returned stacks are copies.
+     *
+     * @param inputItems the itemStacks to compact.
+     * @return a list containing the resulting ItemStacks.
+     */
+    static List<ItemStack> compactItemStacks(Collection<ItemStack> inputItems)
+    {
+        Hash.Strategy<ItemStack>      strategy = ItemStackHashStrategy.comparingAllButCount();
+        final Map<ItemStack, Integer> map      = new Object2IntOpenCustomHashMap<>(strategy);
+
+        return inputItems.stream()
+
+                         // keep only non-empty item stacks
+                         .filter(not(ItemStack::isEmpty))
+
+                         // Track the number of identical items
+                         .collect(Collectors.toMap(Function.identity(),
+                                                   ItemStack::getCount,
+                                                   Math::addExact,
+                                                   () -> map))
+
+                         // Create a single stack of the combined count for each item
+                         .entrySet().stream()
+                         .map(entry ->
+                              {
+                                  ItemStack combined = entry.getKey().copy();
+                                  combined.setCount(entry.getValue());
+                                  return combined;
+                              })
+
+                         // Normalize these stacks into separate valid ItemStacks, flattening them into a List
+                         .map(InventoryUtils::normalizeItemStack)
+                         .flatMap(Collection::stream)
+                         .collect(Collectors.toList());
+    }
+
+    /**
      * Merges stacks of identical items from a source into a destination.<br />
      * Successfully merged items will be removed from {@code source} and will appear in {@code destination}.<br />
      * Empty stacks in {@code destination} are not considered for this process.
@@ -90,29 +127,93 @@ public class InventoryUtils {
      * @param source      the ItemStacks to merge into {@code destination}.
      * @param destination a target inventory of existing ItemStacks.
      */
-    private static void mergeItemStacks(Collection<ItemStack> source, Collection<ItemStack> destination) {
+    static void mergeItemStacks(Collection<ItemStack> source, Collection<ItemStack> destination)
+    {
         // Since we're mutating the collection during iteration, use an iterator.
         final Iterator<ItemStack> sourceItemStacks = source.iterator();
-        while(sourceItemStacks.hasNext()) {
+        while(sourceItemStacks.hasNext())
+        {
             final ItemStack sourceItemStack = sourceItemStacks.next();
 
             // Find a matching item in the output bus, if any
             for(ItemStack destItemStack : destination)
-                if(ItemStack.areItemsEqual(destItemStack, sourceItemStack)) {
+                if(ItemStack.areItemsEqual(destItemStack, sourceItemStack) &&
+                   ItemStack.areItemStackTagsEqual(destItemStack, sourceItemStack))
+                {
                     // if it's possible to merge stacks
                     final int availableSlots = destItemStack.getMaxStackSize() - destItemStack.getCount();
-                    if(availableSlots > 0) {
+                    if(availableSlots > 0)
+                    {
                         final int itemCount = Math.min(availableSlots, sourceItemStack.getCount());
                         sourceItemStack.shrink(itemCount);
                         destItemStack.grow(itemCount);
 
                         // if the output stack was merged completely, remove it and stop looking
-                        if(sourceItemStack.isEmpty()) {
+                        if(sourceItemStack.isEmpty())
+                        {
                             sourceItemStacks.remove();
                             break;
                         }
                     }
                 }
         }
+    }
+
+    /**
+     * Normalizes a potentially problematic ItemStack by splitting it into copied stacks of at most
+     * {@link ItemStack#getMaxStackSize()} items. Empty ItemStacks produce an empty
+     * result list, and stacks already in normalized form are copied as a singleton list.
+     *
+     * @param stack an ItemStack to process.
+     * @return an immutable List of the resulting ItemStacks, in descending size order.
+     */
+    public static List<ItemStack> normalizeItemStack(ItemStack stack)
+    {
+        if(stack.isEmpty())
+            return Collections.emptyList();
+
+        int maxCount = stack.getMaxStackSize();
+
+        if(stack.getCount() <= maxCount)
+            return Collections.singletonList(stack.copy());
+
+        return Collections.unmodifiableList(apportionStack(stack, maxCount));
+    }
+
+    /**
+     * Divides a stack of items into as many stacks of {@code maxCount} size as possible, followed by
+     * a partial stack of any remaining quantity. The original stack is not modified.
+     *
+     * @param stack    a non-empty ItemStack to split into stacks of at most {@code maxCount} items.
+     * @param maxCount the maximum number of items in each stack. Must be a positive, non-zero integer.
+     * @return the resulting zero to many whole stacks and zero to one partial stack.
+     */
+    public static List<ItemStack> apportionStack(ItemStack stack,
+                                                 final int maxCount)
+    {
+        assert !stack.isEmpty();
+        assert maxCount > 0;
+
+        final ArrayList<ItemStack> splitStacks = new ArrayList<>();
+
+        int count     = stack.getCount();
+        int numStacks = count / maxCount;
+        int remainder = count % maxCount;
+
+        for(int fullStackCount = numStacks; fullStackCount > 0; fullStackCount--)
+        {
+            ItemStack fullStack = stack.copy();
+            fullStack.setCount(maxCount);
+            splitStacks.add(fullStack);
+        }
+
+        if(remainder > 0)
+        {
+            ItemStack partialStack = stack.copy();
+            partialStack.setCount(remainder);
+            splitStacks.add(partialStack);
+        }
+
+        return splitStacks;
     }
 }

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -7,6 +7,7 @@ import net.minecraftforge.items.*;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.*;
 
 import static gregtech.api.util.Predicates.*;
@@ -91,7 +92,8 @@ public final class InventoryUtils {
      */
     static List<ItemStack> compactItemStacks(Collection<ItemStack> inputItems) {
         Hash.Strategy<ItemStack> strategy = ItemStackHashStrategy.comparingAllButCount();
-        final Map<ItemStack, Integer> map = new Object2IntOpenCustomHashMap<>(strategy);
+        final Supplier<Map<ItemStack, Integer>> mapSupplier =
+                () -> new Object2IntOpenCustomHashMap<>(strategy);
 
         return inputItems.stream()
 
@@ -102,7 +104,7 @@ public final class InventoryUtils {
                          .collect(Collectors.toMap(Function.identity(),
                                                    ItemStack::getCount,
                                                    Math::addExact,
-                                                   () -> map))
+                                                   mapSupplier))
 
                          // Create a single stack of the combined count for each item
                          .entrySet().stream()

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -183,8 +183,10 @@ public final class InventoryUtils {
      */
     public static List<ItemStack> apportionStack(ItemStack stack,
                                                  final int maxCount) {
-        assert !stack.isEmpty();
-        assert maxCount > 0;
+        if(stack.isEmpty())
+            throw new IllegalArgumentException("Cannot apportion an empty stack.");
+        if(maxCount <= 0)
+            throw new IllegalArgumentException("Count must be non-zero and positive.");
 
         final ArrayList<ItemStack> splitStacks = new ArrayList<>();
 

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -11,14 +11,12 @@ import java.util.stream.*;
 
 import static gregtech.api.util.StreamUtils.*;
 
-public class InventoryUtils
-{
+public class InventoryUtils {
     /**
      * @param inventory the target inventory
      * @return the number of empty slots in {@code inventory}
      */
-    public static int getNumberOfEmptySlotsInInventory(IItemHandler inventory)
-    {
+    public static int getNumberOfEmptySlotsInInventory(IItemHandler inventory) {
         // IItemHandler#getSlots() is an int, so this cast is safe.
         return (int)
             streamFrom(inventory)
@@ -34,8 +32,7 @@ public class InventoryUtils
      * @return a deep copy of the inventory.
      */
     public static List<ItemStack> deepCopy(final IItemHandler inventory,
-                                           final boolean keepEmpty)
-    {
+                                           final boolean keepEmpty) {
         return streamFrom(inventory)
             .filter(or(x -> keepEmpty,
                        not(ItemStack::isEmpty)))
@@ -62,8 +59,7 @@ public class InventoryUtils
      *         insert all requested items, {@code false} otherwise.
      */
     public static boolean simulateItemStackMerge(List<ItemStack> inputItems,
-                                                 IItemHandler inventory)
-    {
+                                                 IItemHandler inventory) {
         // Generate a stack-minimized copy of the input items
         final List<ItemStack> itemStacks = compactItemStacks(inputItems);
 
@@ -92,8 +88,7 @@ public class InventoryUtils
      * @param inputItems the itemStacks to compact.
      * @return a list containing the resulting ItemStacks.
      */
-    static List<ItemStack> compactItemStacks(Collection<ItemStack> inputItems)
-    {
+    static List<ItemStack> compactItemStacks(Collection<ItemStack> inputItems) {
         Hash.Strategy<ItemStack>      strategy = ItemStackHashStrategy.comparingAllButCount();
         final Map<ItemStack, Integer> map      = new Object2IntOpenCustomHashMap<>(strategy);
 
@@ -110,12 +105,11 @@ public class InventoryUtils
 
                          // Create a single stack of the combined count for each item
                          .entrySet().stream()
-                         .map(entry ->
-                              {
-                                  ItemStack combined = entry.getKey().copy();
-                                  combined.setCount(entry.getValue());
-                                  return combined;
-                              })
+                         .map(entry -> {
+                             ItemStack combined = entry.getKey().copy();
+                             combined.setCount(entry.getValue());
+                             return combined;
+                         })
 
                          // Normalize these stacks into separate valid ItemStacks, flattening them into a List
                          .map(InventoryUtils::normalizeItemStack)
@@ -131,30 +125,25 @@ public class InventoryUtils
      * @param source      the ItemStacks to merge into {@code destination}.
      * @param destination a target inventory of existing ItemStacks.
      */
-    static void mergeItemStacks(Collection<ItemStack> source, Collection<ItemStack> destination)
-    {
+    static void mergeItemStacks(Collection<ItemStack> source, Collection<ItemStack> destination) {
         // Since we're mutating the collection during iteration, use an iterator.
         final Iterator<ItemStack> sourceItemStacks = source.iterator();
-        while(sourceItemStacks.hasNext())
-        {
+        while(sourceItemStacks.hasNext()) {
             final ItemStack sourceItemStack = sourceItemStacks.next();
 
             // Find a matching item in the output bus, if any
             for(ItemStack destItemStack : destination)
                 if(ItemStack.areItemsEqual(destItemStack, sourceItemStack) &&
-                   ItemStack.areItemStackTagsEqual(destItemStack, sourceItemStack))
-                {
+                   ItemStack.areItemStackTagsEqual(destItemStack, sourceItemStack)) {
                     // if it's possible to merge stacks
                     final int availableSlots = destItemStack.getMaxStackSize() - destItemStack.getCount();
-                    if(availableSlots > 0)
-                    {
+                    if(availableSlots > 0) {
                         final int itemCount = Math.min(availableSlots, sourceItemStack.getCount());
                         sourceItemStack.shrink(itemCount);
                         destItemStack.grow(itemCount);
 
                         // if the output stack was merged completely, remove it and stop looking
-                        if(sourceItemStack.isEmpty())
-                        {
+                        if(sourceItemStack.isEmpty()) {
                             sourceItemStacks.remove();
                             break;
                         }
@@ -171,8 +160,7 @@ public class InventoryUtils
      * @param stack an ItemStack to process.
      * @return an immutable List of the resulting ItemStacks, in descending size order.
      */
-    public static List<ItemStack> normalizeItemStack(ItemStack stack)
-    {
+    public static List<ItemStack> normalizeItemStack(ItemStack stack) {
         if(stack.isEmpty())
             return Collections.emptyList();
 
@@ -193,8 +181,7 @@ public class InventoryUtils
      * @return the resulting zero to many whole stacks and zero to one partial stack.
      */
     public static List<ItemStack> apportionStack(ItemStack stack,
-                                                 final int maxCount)
-    {
+                                                 final int maxCount) {
         assert !stack.isEmpty();
         assert maxCount > 0;
 
@@ -204,15 +191,13 @@ public class InventoryUtils
         int numStacks = count / maxCount;
         int remainder = count % maxCount;
 
-        for(int fullStackCount = numStacks; fullStackCount > 0; fullStackCount--)
-        {
+        for(int fullStackCount = numStacks; fullStackCount > 0; fullStackCount--) {
             ItemStack fullStack = stack.copy();
             fullStack.setCount(maxCount);
             splitStacks.add(fullStack);
         }
 
-        if(remainder > 0)
-        {
+        if(remainder > 0) {
             ItemStack partialStack = stack.copy();
             partialStack.setCount(remainder);
             splitStacks.add(partialStack);

--- a/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
+++ b/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
@@ -1,0 +1,124 @@
+package gregtech.api.util;
+
+import it.unimi.dsi.fastutil.*;
+import net.minecraft.item.*;
+
+import javax.annotation.*;
+import java.util.*;
+
+/**
+ * A configurable generator of hashing strategies, allowing for consideration of select properties of ItemStacks when
+ * considering equality.
+ */
+public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
+{
+    /**
+     * @return a builder object for producing a custom ItemStackHashStrategy.
+     */
+    static ItemStackHashStrategyBuilder builder()
+    {
+        return new ItemStackHashStrategyBuilder();
+    }
+
+    /**
+     * Generates an ItemStackHash configured to compare every aspect of ItemStacks except the number
+     * of items in the stack.
+     *
+     * @return the ItemStackHashStrategy as described above.
+     */
+    static ItemStackHashStrategy comparingAllButCount()
+    {
+        return builder().compareItem(true)
+                        .compareDamage(true)
+                        .compareTag(true)
+                        .build();
+    }
+
+    /**
+     * Builder pattern class for generating customized ItemStackHashStrategy
+     */
+    class ItemStackHashStrategyBuilder
+    {
+        private boolean item, count, damage, tag;
+
+        /**
+         * Defines whether the Item type should be considered for equality.
+         *
+         * @param choice {@code true} to consider this property, {@code false} to ignore it.
+         * @return {@code this}
+         */
+        public ItemStackHashStrategyBuilder compareItem(boolean choice)
+        {
+            item = choice;
+            return this;
+        }
+
+        /**
+         * Defines whether stack size should be considered for equality.
+         *
+         * @param choice {@code true} to consider this property, {@code false} to ignore it.
+         * @return {@code this}
+         */
+        public ItemStackHashStrategyBuilder compareCount(boolean choice)
+        {
+            count = choice;
+            return this;
+        }
+
+        /**
+         * Defines whether damage values should be considered for equality.
+         *
+         * @param choice {@code true} to consider this property, {@code false} to ignore it.
+         * @return {@code this}
+         */
+        public ItemStackHashStrategyBuilder compareDamage(boolean choice)
+        {
+            damage = choice;
+            return this;
+        }
+
+        /**
+         * Defines whether NBT Tags should be considered for equality.
+         *
+         * @param choice {@code true} to consider this property, {@code false} to ignore it.
+         * @return {@code this}
+         */
+        public ItemStackHashStrategyBuilder compareTag(boolean choice)
+        {
+            tag = choice;
+            return this;
+        }
+
+        /**
+         * @return the ItemStackHashStrategy as configured by "compare" methods.
+         */
+        public ItemStackHashStrategy build()
+        {
+            return new ItemStackHashStrategy()
+            {
+                @Override
+                public int hashCode(@Nullable ItemStack o)
+                {
+                    return o == null || o.isEmpty() ? 0 : Objects.hash(
+                        item ? o.getItem() : null,
+                        count ? o.getCount() : null,
+                        damage ? o.getItemDamage() : null,
+                        tag ? o.getTagCompound() : null
+                    );
+                }
+
+                @Override
+                public boolean equals(@Nullable ItemStack a, @Nullable ItemStack b)
+                {
+                    if(a == null || a.isEmpty()) return b == null || b.isEmpty();
+                    if(b == null || b.isEmpty()) return false;
+
+                    return (!item || a.getItem() == b.getItem()) &&
+                           (!count || a.getCount() == b.getCount()) &&
+                           (!damage || a.getItemDamage() == b.getItemDamage()) &&
+                           (!tag || Objects.equals(a.getTagCompound(), b.getTagCompound()));
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
+++ b/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
@@ -10,13 +10,11 @@ import java.util.*;
  * A configurable generator of hashing strategies, allowing for consideration of select properties of ItemStacks when
  * considering equality.
  */
-public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
-{
+public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack> {
     /**
      * @return a builder object for producing a custom ItemStackHashStrategy.
      */
-    static ItemStackHashStrategyBuilder builder()
-    {
+    static ItemStackHashStrategyBuilder builder() {
         return new ItemStackHashStrategyBuilder();
     }
 
@@ -26,8 +24,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
      *
      * @return the ItemStackHashStrategy as described above.
      */
-    static ItemStackHashStrategy comparingAllButCount()
-    {
+    static ItemStackHashStrategy comparingAllButCount() {
         return builder().compareItem(true)
                         .compareDamage(true)
                         .compareTag(true)
@@ -37,8 +34,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
     /**
      * Builder pattern class for generating customized ItemStackHashStrategy
      */
-    class ItemStackHashStrategyBuilder
-    {
+    class ItemStackHashStrategyBuilder {
         private boolean item, count, damage, tag;
 
         /**
@@ -47,8 +43,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
          * @param choice {@code true} to consider this property, {@code false} to ignore it.
          * @return {@code this}
          */
-        public ItemStackHashStrategyBuilder compareItem(boolean choice)
-        {
+        public ItemStackHashStrategyBuilder compareItem(boolean choice) {
             item = choice;
             return this;
         }
@@ -59,8 +54,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
          * @param choice {@code true} to consider this property, {@code false} to ignore it.
          * @return {@code this}
          */
-        public ItemStackHashStrategyBuilder compareCount(boolean choice)
-        {
+        public ItemStackHashStrategyBuilder compareCount(boolean choice) {
             count = choice;
             return this;
         }
@@ -71,8 +65,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
          * @param choice {@code true} to consider this property, {@code false} to ignore it.
          * @return {@code this}
          */
-        public ItemStackHashStrategyBuilder compareDamage(boolean choice)
-        {
+        public ItemStackHashStrategyBuilder compareDamage(boolean choice) {
             damage = choice;
             return this;
         }
@@ -83,8 +76,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
          * @param choice {@code true} to consider this property, {@code false} to ignore it.
          * @return {@code this}
          */
-        public ItemStackHashStrategyBuilder compareTag(boolean choice)
-        {
+        public ItemStackHashStrategyBuilder compareTag(boolean choice) {
             tag = choice;
             return this;
         }
@@ -92,13 +84,10 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
         /**
          * @return the ItemStackHashStrategy as configured by "compare" methods.
          */
-        public ItemStackHashStrategy build()
-        {
-            return new ItemStackHashStrategy()
-            {
+        public ItemStackHashStrategy build() {
+            return new ItemStackHashStrategy() {
                 @Override
-                public int hashCode(@Nullable ItemStack o)
-                {
+                public int hashCode(@Nullable ItemStack o) {
                     return o == null || o.isEmpty() ? 0 : Objects.hash(
                         item ? o.getItem() : null,
                         count ? o.getCount() : null,
@@ -108,8 +97,7 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack>
                 }
 
                 @Override
-                public boolean equals(@Nullable ItemStack a, @Nullable ItemStack b)
-                {
+                public boolean equals(@Nullable ItemStack a, @Nullable ItemStack b) {
                     if(a == null || a.isEmpty()) return b == null || b.isEmpty();
                     if(b == null || b.isEmpty()) return false;
 

--- a/src/main/java/gregtech/api/util/Predicates.java
+++ b/src/main/java/gregtech/api/util/Predicates.java
@@ -1,0 +1,34 @@
+package gregtech.api.util;
+
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Various Quality-of-Life methods for working with Java 8 Predicates.
+ */
+public final class Predicates {
+    /**
+     * Create an inverse predicate from another predicate. Makes it less ugly to use method references.
+     */
+    public static <T> Predicate<T> not(Predicate<T> predicate) {
+        return predicate.negate();
+    }
+
+    /**
+     * Reduce multiple OR predicates into a single predicate.
+     */
+    @SafeVarargs
+    public static <T> Predicate<T> or(Predicate<T>... predicates) {
+        return Arrays.stream(predicates)
+                     .reduce(x -> false, Predicate::or);
+    }
+
+    /**
+     * Reduce multiple AND predicates into a single predicate.
+     */
+    @SafeVarargs
+    public static <T> Predicate<T> and(Predicate<T>... predicates) {
+        return Arrays.stream(predicates)
+                     .reduce(x -> true, Predicate::and);
+    }
+}

--- a/src/main/java/gregtech/api/util/StreamUtils.java
+++ b/src/main/java/gregtech/api/util/StreamUtils.java
@@ -10,13 +10,11 @@ import java.util.stream.*;
 /**
  * Various Quality-of-Life methods for working with Java 8 Streams.
  */
-public class StreamUtils
-{
+public class StreamUtils {
     /**
      * Create an inverse predicate from another predicate. Makes it less ugly to use method references.
      */
-    public static <T> Predicate<T> not(Predicate<T> predicate)
-    {
+    public static <T> Predicate<T> not(Predicate<T> predicate) {
         return predicate.negate();
     }
 
@@ -24,8 +22,7 @@ public class StreamUtils
      * Reduce multiple OR predicates into a single predicate.
      */
     @SafeVarargs
-    public static <T> Predicate<T> or(Predicate<T>... predicates)
-    {
+    public static <T> Predicate<T> or(Predicate<T>... predicates) {
         return Arrays.stream(predicates)
                      .reduce(x -> false, Predicate::or);
     }
@@ -34,8 +31,7 @@ public class StreamUtils
      * Reduce multiple AND predicates into a single predicate.
      */
     @SafeVarargs
-    public static <T> Predicate<T> and(Predicate<T>... predicates)
-    {
+    public static <T> Predicate<T> and(Predicate<T>... predicates) {
         return Arrays.stream(predicates)
                      .reduce(x -> true, Predicate::and);
     }
@@ -47,8 +43,7 @@ public class StreamUtils
      * @param inventory the target inventory
      * @return a stream over the contents of the target inventory
      */
-    public static Stream<ItemStack> streamFrom(IItemHandler inventory)
-    {
+    public static Stream<ItemStack> streamFrom(IItemHandler inventory) {
         return StreamSupport.stream(iterableFrom(inventory).spliterator(),
                                     false);
     }
@@ -63,26 +58,20 @@ public class StreamUtils
      * @see Iterator
      * @see Iterable
      */
-    public static Iterable<ItemStack> iterableFrom(IItemHandler inventory)
-    {
-        return new Iterable<ItemStack>()
-        {
+    public static Iterable<ItemStack> iterableFrom(IItemHandler inventory) {
+        return new Iterable<ItemStack>() {
             @Override
-            public Iterator<ItemStack> iterator()
-            {
-                return new Iterator<ItemStack>()
-                {
+            public Iterator<ItemStack> iterator() {
+                return new Iterator<ItemStack>() {
                     private int cursor = 0;
 
                     @Override
-                    public boolean hasNext()
-                    {
+                    public boolean hasNext() {
                         return cursor < inventory.getSlots();
                     }
 
                     @Override
-                    public ItemStack next()
-                    {
+                    public ItemStack next() {
                         if(!hasNext())
                             throw new NoSuchElementException();
 
@@ -94,8 +83,7 @@ public class StreamUtils
             }
 
             @Override
-            public Spliterator<ItemStack> spliterator()
-            {
+            public Spliterator<ItemStack> spliterator() {
                 return Spliterators.spliterator(iterator(), inventory.getSlots(), 0);
             }
         };

--- a/src/main/java/gregtech/api/util/StreamUtils.java
+++ b/src/main/java/gregtech/api/util/StreamUtils.java
@@ -1,0 +1,103 @@
+package gregtech.api.util;
+
+import net.minecraft.item.*;
+import net.minecraftforge.items.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * Various Quality-of-Life methods for working with Java 8 Streams.
+ */
+public class StreamUtils
+{
+    /**
+     * Create an inverse predicate from another predicate. Makes it less ugly to use method references.
+     */
+    public static <T> Predicate<T> not(Predicate<T> predicate)
+    {
+        return predicate.negate();
+    }
+
+    /**
+     * Reduce multiple OR predicates into a single predicate.
+     */
+    @SafeVarargs
+    public static <T> Predicate<T> or(Predicate<T>... predicates)
+    {
+        return Arrays.stream(predicates)
+                     .reduce(x -> false, Predicate::or);
+    }
+
+    /**
+     * Reduce multiple AND predicates into a single predicate.
+     */
+    @SafeVarargs
+    public static <T> Predicate<T> and(Predicate<T>... predicates)
+    {
+        return Arrays.stream(predicates)
+                     .reduce(x -> true, Predicate::and);
+    }
+
+    /**
+     * Creates a stream view of the actual contents of the inventory.
+     * Caller must not modify the contents of the inventory returned by this stream.
+     *
+     * @param inventory the target inventory
+     * @return a stream over the contents of the target inventory
+     */
+    public static Stream<ItemStack> streamFrom(IItemHandler inventory)
+    {
+        return StreamSupport.stream(iterableFrom(inventory).spliterator(),
+                                    false);
+    }
+
+    /**
+     * Simple Iterable supplier to permit iterating over an inventory using for-each semantics.
+     *
+     * @param inventory the target inventory
+     * @return an Iterable over the slots of the specified inventory.
+     * @throws UnsupportedOperationException if {@link Iterator#remove()} is called on the iterator returned by
+     *                                       {@link Iterable#iterator()}
+     * @see Iterator
+     * @see Iterable
+     */
+    public static Iterable<ItemStack> iterableFrom(IItemHandler inventory)
+    {
+        return new Iterable<ItemStack>()
+        {
+            @Override
+            public Iterator<ItemStack> iterator()
+            {
+                return new Iterator<ItemStack>()
+                {
+                    private int cursor = 0;
+
+                    @Override
+                    public boolean hasNext()
+                    {
+                        return cursor < inventory.getSlots();
+                    }
+
+                    @Override
+                    public ItemStack next()
+                    {
+                        if(!hasNext())
+                            throw new NoSuchElementException();
+
+                        ItemStack next = inventory.getStackInSlot(cursor);
+                        cursor++;
+                        return next;
+                    }
+                };
+            }
+
+            @Override
+            public Spliterator<ItemStack> spliterator()
+            {
+                return Spliterators.spliterator(iterator(), inventory.getSlots(), 0);
+            }
+        };
+    }
+}

--- a/src/main/java/gregtech/api/util/StreamUtils.java
+++ b/src/main/java/gregtech/api/util/StreamUtils.java
@@ -4,37 +4,12 @@ import net.minecraft.item.*;
 import net.minecraftforge.items.*;
 
 import java.util.*;
-import java.util.function.*;
 import java.util.stream.*;
 
 /**
  * Various Quality-of-Life methods for working with Java 8 Streams.
  */
-public class StreamUtils {
-    /**
-     * Create an inverse predicate from another predicate. Makes it less ugly to use method references.
-     */
-    public static <T> Predicate<T> not(Predicate<T> predicate) {
-        return predicate.negate();
-    }
-
-    /**
-     * Reduce multiple OR predicates into a single predicate.
-     */
-    @SafeVarargs
-    public static <T> Predicate<T> or(Predicate<T>... predicates) {
-        return Arrays.stream(predicates)
-                     .reduce(x -> false, Predicate::or);
-    }
-
-    /**
-     * Reduce multiple AND predicates into a single predicate.
-     */
-    @SafeVarargs
-    public static <T> Predicate<T> and(Predicate<T>... predicates) {
-        return Arrays.stream(predicates)
-                     .reduce(x -> true, Predicate::and);
-    }
+public final class StreamUtils {
 
     /**
      * Creates a stream view of the actual contents of the inventory.

--- a/src/test/java/gregtech/api/util/InventoryUtilsTest.java
+++ b/src/test/java/gregtech/api/util/InventoryUtilsTest.java
@@ -5,6 +5,7 @@ import net.minecraft.item.*;
 import net.minecraft.nbt.*;
 import net.minecraftforge.items.*;
 import org.junit.*;
+import org.junit.rules.*;
 
 import java.util.*;
 
@@ -20,6 +21,12 @@ public class InventoryUtilsTest
     {
         Bootstrap.register();
     }
+
+    /**
+     * Used by tests where exception properties need to be verified.
+     */
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_single_stack_into_empty_one_slot_inventory()
@@ -285,21 +292,27 @@ public class InventoryUtilsTest
                    ItemStack.areItemStacksEqual(expectedPartial, result.get(2)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void apportionStack_throws_AssertionError_when_supplied_stack_is_empty()
     {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Cannot apportion an empty stack.");
         InventoryUtils.apportionStack(ItemStack.EMPTY, 64);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void apportionStack_throws_AssertionError_when_maxCount_is_zero()
     {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Count must be non-zero and positive.");
         InventoryUtils.apportionStack(new ItemStack(Items.ARROW, 1), 0);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void apportionStack_throws_AssertionError_when_maxCount_is_negative()
     {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Count must be non-zero and positive.");
         InventoryUtils.apportionStack(new ItemStack(Items.ARROW, 1), -1);
     }
 

--- a/src/test/java/gregtech/api/util/InventoryUtilsTest.java
+++ b/src/test/java/gregtech/api/util/InventoryUtilsTest.java
@@ -2,8 +2,8 @@ package gregtech.api.util;
 
 import net.minecraft.init.*;
 import net.minecraft.item.*;
+import net.minecraft.nbt.*;
 import net.minecraftforge.items.*;
-
 import org.junit.*;
 
 import java.util.*;
@@ -24,8 +24,8 @@ public class InventoryUtilsTest
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_single_stack_into_empty_one_slot_inventory()
     {
-        IItemHandler handler = new ItemStackHandler(1);
-        ItemStack feathers = new ItemStack(Items.FEATHER, 64);
+        IItemHandler handler  = new ItemStackHandler(1);
+        ItemStack    feathers = new ItemStack(Items.FEATHER, 64);
 
         boolean result =
             InventoryUtils.simulateItemStackMerge(
@@ -43,12 +43,11 @@ public class InventoryUtilsTest
      * This test currently fails (because there's a bug discovered) and the resulting error halts the build, so it is
      * skipped for the moment.
      */
-    @Ignore
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_two_half_stacks_into_empty_one_slot_inventory()
     {
-        IItemHandler handler = new ItemStackHandler(1);
-        ItemStack feathers = new ItemStack(Items.FEATHER, 32);
+        IItemHandler handler  = new ItemStackHandler(1);
+        ItemStack    feathers = new ItemStack(Items.FEATHER, 32);
 
         boolean result =
             InventoryUtils.simulateItemStackMerge(
@@ -65,8 +64,8 @@ public class InventoryUtilsTest
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_one_half_stack_into_inventory_with_one_half_stack()
     {
-        IItemHandler handler = new ItemStackHandler(1);
-        ItemStack feathers = new ItemStack(Items.FEATHER, 32);
+        IItemHandler handler  = new ItemStackHandler(1);
+        ItemStack    feathers = new ItemStack(Items.FEATHER, 32);
 
         handler.insertItem(0, feathers, false);
 
@@ -85,9 +84,9 @@ public class InventoryUtilsTest
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_one_half_stack_into_inventory_with_two_three_quarter_stacks()
     {
-        IItemHandler handler = new ItemStackHandler(2);
-        ItemStack feathers_32 = new ItemStack(Items.FEATHER, 32);
-        ItemStack feathers_48 = new ItemStack(Items.FEATHER, 48);
+        IItemHandler handler     = new ItemStackHandler(2);
+        ItemStack    feathers_32 = new ItemStack(Items.FEATHER, 32);
+        ItemStack    feathers_48 = new ItemStack(Items.FEATHER, 48);
 
         handler.insertItem(0, feathers_48, false);
         handler.insertItem(1, feathers_48, false);
@@ -107,9 +106,9 @@ public class InventoryUtilsTest
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_one_half_stack_into_inventory_with_one_three_quarter_stack_and_one_empty_slot()
     {
-        IItemHandler handler = new ItemStackHandler(2);
-        ItemStack feathers_32 = new ItemStack(Items.FEATHER, 32);
-        ItemStack feathers_48 = new ItemStack(Items.FEATHER, 48);
+        IItemHandler handler     = new ItemStackHandler(2);
+        ItemStack    feathers_32 = new ItemStack(Items.FEATHER, 32);
+        ItemStack    feathers_48 = new ItemStack(Items.FEATHER, 48);
 
         handler.insertItem(0, feathers_48, false);
         handler.insertItem(1, feathers_48, false);
@@ -129,9 +128,9 @@ public class InventoryUtilsTest
     @Test
     public void simulateItemStackMerge_fails_to_insert_items_into_a_full_inventory_with_no_common_items()
     {
-        IItemHandler handler = new ItemStackHandler(1);
-        ItemStack feathers = new ItemStack(Items.FEATHER, 32);
-        ItemStack arrows = new ItemStack(Items.ARROW, 1);
+        IItemHandler handler  = new ItemStackHandler(1);
+        ItemStack    feathers = new ItemStack(Items.FEATHER, 32);
+        ItemStack    arrows   = new ItemStack(Items.ARROW, 1);
 
         handler.insertItem(0, feathers, false);
 
@@ -145,5 +144,236 @@ public class InventoryUtilsTest
             "Unexpectedly succeeded at merging an arrow into an inventory full of feathers.",
             result
         );
+    }
+
+    @Test
+    public void simulateItemStackMerge_fails_to_insert_items_into_a_full_inventory_with_common_items()
+    {
+        IItemHandler handler       = new ItemStackHandler(1);
+        ItemStack    inv_feathers  = new ItemStack(Items.FEATHER, 64);
+        ItemStack    more_feathers = new ItemStack(Items.FEATHER, 1);
+
+        handler.insertItem(0, inv_feathers, false);
+
+        boolean result =
+            InventoryUtils.simulateItemStackMerge(
+                Collections.singletonList(more_feathers),
+                handler
+            );
+
+        assertFalse(
+            "Unexpectedly succeeded at merging feathers into an inventory full of feathers.",
+            result
+        );
+    }
+
+    /**
+     * This test also fails because there's a bug it detects. Ignored to prevent breaking build.
+     */
+    @Test
+    public void simulateItemStackMerge_respects_different_NBT_tags_as_different_items()
+    {
+        IItemHandler handler          = new ItemStackHandler(1);
+        ItemStack    feathers         = new ItemStack(Items.FEATHER, 1);
+        ItemStack    special_feathers = new ItemStack(Items.FEATHER, 1);
+        special_feathers.setTagInfo("Foo", new NBTTagString("Test"));
+
+        handler.insertItem(0, feathers, false);
+
+        boolean result =
+            InventoryUtils.simulateItemStackMerge(
+                Collections.singletonList(special_feathers),
+                handler
+            );
+
+        assertFalse(
+            "Unexpectedly succeeded at merging feathers with NBT tags into a stack of plain feathers.",
+            result
+        );
+    }
+
+    @Test
+    public void simulateItemStackMerge_respects_different_damage_values_as_different_items()
+    {
+        IItemHandler handler          = new ItemStackHandler(1);
+        ItemStack    feathers         = new ItemStack(Items.FEATHER, 1);
+        ItemStack    special_feathers = new ItemStack(Items.FEATHER, 1);
+        special_feathers.setItemDamage(1);
+
+        handler.insertItem(0, feathers, false);
+
+        boolean result =
+            InventoryUtils.simulateItemStackMerge(
+                Collections.singletonList(special_feathers),
+                handler
+            );
+
+        assertFalse(
+            "Unexpectedly succeeded at merging damaged feathers into a stack of plain feathers.",
+            result
+        );
+    }
+
+    @Test
+    public void simulateItemStackMerge_respects_unstackable_but_otherwise_identical_items()
+    {
+        IItemHandler handler        = new ItemStackHandler(1);
+        ItemStack    pickaxe        = new ItemStack(Items.IRON_PICKAXE, 1);
+        ItemStack    anotherPickaxe = new ItemStack(Items.IRON_PICKAXE, 1);
+
+        assertFalse(pickaxe.isStackable());
+
+        handler.insertItem(0, pickaxe, false);
+
+        boolean result =
+            InventoryUtils.simulateItemStackMerge(
+                Collections.singletonList(anotherPickaxe),
+                handler
+            );
+
+        assertFalse(
+            "Unexpectedly succeeded at merging a pickaxe into another one.",
+            result
+        );
+    }
+
+    @Test
+    public void normalizeItemStack_returns_empty_list_for_single_empty_stack()
+    {
+        List<ItemStack> result = InventoryUtils.normalizeItemStack(ItemStack.EMPTY);
+        assertTrue(
+            "Unexpectedly got results when normalizing an empty ItemStack",
+            result.isEmpty()
+        );
+    }
+
+    @Test
+    public void normalizeItemStack_returns_single_element_list_for_a_single_already_normal_stack()
+    {
+        ItemStack       stack  = new ItemStack(Items.ENDER_PEARL, 16);
+        List<ItemStack> result = InventoryUtils.normalizeItemStack(stack);
+
+        assertFalse(
+            "Unexpectedly got no results when normalizing an already normal ItemStack",
+            result.isEmpty()
+        );
+        assertEquals(
+            "Unexpectedly got wrong number of resulting stacks when normalizing an already normal ItemStack",
+            1, result.size()
+        );
+        assertTrue(
+            "ItemStack was modified when it didn't need to be",
+            ItemStack.areItemStacksEqual(stack, result.get(0))
+        );
+    }
+
+    @Test
+    public void normalizeItemStack_returns_normalized_stacks_for_an_abnormal_stack()
+    {
+        ItemStack       stack  = new ItemStack(Items.ENDER_PEARL, 45);
+        List<ItemStack> result = InventoryUtils.normalizeItemStack(stack);
+
+        assertFalse(
+            "Unexpectedly got no results when normalizing an abnormal stack",
+            result.isEmpty()
+        );
+        assertEquals(
+            "Unexpectedly got wrong number of resulting stacks when normalizing an abnormal ItemStack",
+            3, result.size()
+        );
+
+        ItemStack expectedFull    = new ItemStack(Items.ENDER_PEARL, 16);
+        ItemStack expectedPartial = new ItemStack(Items.ENDER_PEARL, 13);
+        assertTrue("First item stack does not match expected full stack",
+                   ItemStack.areItemStacksEqual(expectedFull, result.get(0)));
+        assertTrue("Second item stack does not match expected full stack",
+                   ItemStack.areItemStacksEqual(expectedFull, result.get(1)));
+        assertTrue("Third item stack does not match expected partial stack",
+                   ItemStack.areItemStacksEqual(expectedPartial, result.get(2)));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void apportionStack_throws_AssertionError_when_supplied_stack_is_empty()
+    {
+        InventoryUtils.apportionStack(ItemStack.EMPTY, 64);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void apportionStack_throws_AssertionError_when_maxCount_is_zero()
+    {
+        InventoryUtils.apportionStack(new ItemStack(Items.ARROW, 1), 0);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void apportionStack_throws_AssertionError_when_maxCount_is_negative()
+    {
+        InventoryUtils.apportionStack(new ItemStack(Items.ARROW, 1), -1);
+    }
+
+    @Test
+    public void apportionStack_splits_evenly_divisible_stack()
+    {
+        ItemStack oversized = new ItemStack(Items.ENDER_PEARL, 64);
+        ItemStack normal    = new ItemStack(Items.ENDER_PEARL, 16);
+
+        List<ItemStack> result = InventoryUtils.apportionStack(oversized, 16);
+
+        assertFalse(result.isEmpty());
+        assertEquals(4, result.size());
+        for(ItemStack stack : result)
+        {
+            assertTrue(ItemStack.areItemStacksEqual(stack, normal));
+        }
+    }
+
+    @Test
+    public void apportionStack_splits_unevenly_divisible_stack_with_remainder_at_end()
+    {
+        ItemStack oversized = new ItemStack(Items.ENDER_PEARL, 45);
+        ItemStack normal    = new ItemStack(Items.ENDER_PEARL, 16);
+        ItemStack remainder = new ItemStack(Items.ENDER_PEARL, 13);
+
+        List<ItemStack> result = InventoryUtils.apportionStack(oversized, 16);
+
+        assertFalse(result.isEmpty());
+        assertEquals(3, result.size());
+
+        assertTrue(ItemStack.areItemStacksEqual(result.get(0), normal));
+        assertTrue(ItemStack.areItemStacksEqual(result.get(1), normal));
+        assertTrue(ItemStack.areItemStacksEqual(result.get(2), remainder));
+    }
+
+    @Test
+    public void deepCopy_retains_empty_stacks_when_requested()
+    {
+        IItemHandler inventory = new ItemStackHandler(2);
+
+        inventory.insertItem(1, new ItemStack(Items.FEATHER, 1), false);
+
+        assertTrue(inventory.getStackInSlot(0).isEmpty());
+        assertFalse(inventory.getStackInSlot(1).isEmpty());
+
+        List<ItemStack> result = InventoryUtils.deepCopy(inventory, true);
+
+        assertFalse(result.isEmpty());
+        assertEquals(2, result.size());
+        assertTrue(result.get(0).isEmpty());
+    }
+
+    @Test
+    public void deepCopy_discards_empty_stacks_when_requested()
+    {
+        IItemHandler inventory = new ItemStackHandler(2);
+        ItemStack    feather   = new ItemStack(Items.FEATHER, 1);
+        inventory.insertItem(1, feather, false);
+
+        assertTrue(inventory.getStackInSlot(0).isEmpty());
+        assertFalse(inventory.getStackInSlot(1).isEmpty());
+
+        List<ItemStack> result = InventoryUtils.deepCopy(inventory, false);
+
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        assertTrue(ItemStack.areItemStacksEqual(feather, result.get(0)));
     }
 }

--- a/src/test/java/gregtech/api/util/InventoryUtilsTest.java
+++ b/src/test/java/gregtech/api/util/InventoryUtilsTest.java
@@ -39,10 +39,6 @@ public class InventoryUtilsTest
         );
     }
 
-    /**
-     * This test currently fails (because there's a bug discovered) and the resulting error halts the build, so it is
-     * skipped for the moment.
-     */
     @Test
     public void simulateItemStackMerge_succeeds_for_inserting_two_half_stacks_into_empty_one_slot_inventory()
     {
@@ -167,9 +163,6 @@ public class InventoryUtilsTest
         );
     }
 
-    /**
-     * This test also fails because there's a bug it detects. Ignored to prevent breaking build.
-     */
     @Test
     public void simulateItemStackMerge_respects_different_NBT_tags_as_different_items()
     {


### PR DESCRIPTION
**What:**
This PR addresses several shortcomings with the multiblock voiding fix code provided via #1333 and revisions thereto in #1337, which were released as part of GTCE 1.10.8.599.

The specific issues are as follows:
1. `ItemStack`s provided to `InventoryUtils#simulateItemStackMerge()` as items to merge, where `ItemStack#getCount()` exceeds `ItemStack#getMaxStackSize()`, fail to be accounted for and result in an exception when the stack passes simulation but cannot actually be merged in subsequent code.
2. NBT data is incorrectly omitted from consideration when comparing `ItemStack`s for equality.
3. `simulateItemStackMerge()` fails if a recipe is defined to produce multiple partial stacks of the same item that could actually fit in the target inventory (example: inserting two stacks of 32 ingots into an empty small wooden chest).

This PR supersedes the proposed fixes from #1378 by @ALongStringOfNumbers, which targeted (1) above. The other two bugs were discovered while I was implementing comprehensive branch coverage tests for `InventoryUtils`.

**How solved:**
Issue (1) is solved by normalizing oversized stacks to a minimal number of valid stacks not exceeding `ItemStack#getMaxStackSize()`.
Issue (2) is solved by additionally ensuring that `ItemStack`s have the same NBT tags to be considered the same item.
Issue (3) is solved by generating compacted copies of the input `ItemStacks` in `simulateItemStackMerge()`.

**Outcome:**
The discovered bugs are corrected and the test suite is updated to contain 100% branch coverage of `InventoryUtils` methods.

**Additional info:**
To facilitate these changes, I have incorporated two additional classes:
1. `ItemStackHashStrategy` designed by @eutropius225, which provides a flexible `ItemStack` hashing strategy for use with FastUtils maps
2. `StreamUtils`, which provides convenience functions for using Minecraft constructs more cleanly with for-each and Stream semantics.

**Possible compatibility issue:**
None anticipated, unless addon mods were relying on specific incorrect behavior introduced by these PRs.