### PR TITLE
Remove Extra Fuel recipe additions

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
@@ -24,9 +24,6 @@ public class FuelRecipes {
         registerSteamGeneratorFuel(Materials.Steam.getFluid(60), 1, GTValues.LV);
 
         //low-tier gas turbine fuels
-        registerGasGeneratorFuel(Materials.Hydrogen.getFluid(1), 1, GTValues.LV);
-        registerGasGeneratorFuel(Materials.Methane.getFluid(1), 2, GTValues.LV);
-
         registerGasGeneratorFuel(Materials.NaturalGas.getFluid(8), 5, GTValues.LV);
         registerGasGeneratorFuel(Materials.Hydrogen.getFluid(8), 5, GTValues.LV);
         registerGasGeneratorFuel(Materials.CarbonMonoxde.getFluid(8), 6, GTValues.LV);


### PR DESCRIPTION
**What:**
This PR removes some extra additions of Hydrogen and Methane to the Gas Generator Fuel RecipeMap. These additions did not show up in game, as the additions that came after them were always the ones that showed up. Therefore, these additions were removed to not change any recipes in game.

**How solved:**
Removed the extraneous additions

**Outcome:**
Removed extraneous Hydrogen and Methane additions to the Gas Generator. Closes #1377.

**Additional info:**
Recipes in game before change:

![2021-01-08_15 38 27](https://user-images.githubusercontent.com/31759736/104072106-bc094d00-51c7-11eb-8eaa-70a6b715f884.png)
![2021-01-08_15 38 36](https://user-images.githubusercontent.com/31759736/104072112-bdd31080-51c7-11eb-84be-58d7e599423b.png)

Recipes in game after change:

![2021-01-08_15 43 47](https://user-images.githubusercontent.com/31759736/104072373-58cbea80-51c8-11eb-81ea-264fbdd42aa8.png)
![2021-01-08_15 43 55](https://user-images.githubusercontent.com/31759736/104072379-5bc6db00-51c8-11eb-921d-ae31463dddcb.png)


**Possible compatibility issue:**
None expected. If an addon mod was removing this recipe, then at most the recipe removal will fail, which would not crash.