### PR TITLE
Bug fix for ItemHandlerList::extractItem

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -72,7 +72,7 @@ public class ItemHandlerList implements IItemHandlerModifiable {
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         IItemHandler itemHandler = handlerBySlotIndex.get(slot);
-        return itemHandler.extractItem(slot - baseIndexOffset.get(itemHandler), slot, simulate);
+        return itemHandler.extractItem(slot - baseIndexOffset.get(itemHandler), amount, simulate);
     }
 
 }


### PR DESCRIPTION
**What:**
Mistake in ItemHandlerList::extractItem cases 'slot' number of items to be extracted instead of 'amount'. This PR fixes that mistake.

**How solved:**
Swapped 'slot' for 'amount' in the 'itemHandler.extractItem' method call.

**Outcome:**
Fixed extraction amount bug in ItemHandlerList::extractItem.

**Possible compatibility issue:**
I am about 90% sure that this method is not called anywhere in the base mod but it may be by addons. My limited testing didn't show any issues but others could potentially arise if this method is used elsewhere.