### PR TITLE
Fixes for WorldSaveData dimension handling (#1398) and fluid in pipes…

### DIFF
--- a/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
@@ -9,27 +9,33 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants.NBT;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 
 public abstract class WorldPipeNet<NodeDataType, T extends PipeNet<NodeDataType>> extends WorldSavedData {
 
-    private World world;
-    protected boolean isFirstTick = true;
+    private WeakReference<World> worldRef = new WeakReference<>(null);
     protected List<T> pipeNets = new ArrayList<>();
     protected Map<ChunkPos, List<T>> pipeNetsByChunk = new HashMap<>();
+
+    public static String getDataID(final String baseID, final World world) {
+        if (world == null || world.isRemote)
+            throw new RuntimeException("WorldPipeNet should only be created on the server!");
+        final int dimension = world.provider.getDimension();
+        return dimension == 0 ? baseID : baseID + '.' + dimension;
+    }
 
     public WorldPipeNet(String name) {
         super(name);
     }
 
     public World getWorld() {
-        return world;
+        return this.worldRef.get();
     }
 
     protected void setWorldAndInit(World world) {
-        if (isFirstTick) {
-            this.world = world;
-            this.isFirstTick = false;
+        if (world != this.worldRef.get()) {
+            this.worldRef = new WeakReference<World>(world);
             onWorldSet();
         }
     }

--- a/src/main/java/gregtech/api/pipenet/tickable/TickableWorldPipeNetEventHandler.java
+++ b/src/main/java/gregtech/api/pipenet/tickable/TickableWorldPipeNetEventHandler.java
@@ -27,16 +27,25 @@ public class TickableWorldPipeNetEventHandler {
 
     @SubscribeEvent
     public static void onWorldTick(WorldTickEvent event) {
-        getPipeNetsForWorld(event.world).forEach(TickableWorldPipeNet::update);
+        final World world = event.world;
+        if (world == null || world.isRemote)
+            return;
+        getPipeNetsForWorld(world).forEach(TickableWorldPipeNet::update);
     }
 
     @SubscribeEvent
     public static void onChunkLoad(ChunkEvent.Load event) {
-        getPipeNetsForWorld(event.getWorld()).forEach(it -> it.onChunkLoaded(event.getChunk()));
+        final World world = event.getWorld();
+        if (world == null || world.isRemote)
+            return;
+        getPipeNetsForWorld(world).forEach(it -> it.onChunkLoaded(event.getChunk()));
     }
 
     @SubscribeEvent
     public static void onChunkUnload(ChunkEvent.Unload event) {
-        getPipeNetsForWorld(event.getWorld()).forEach(it -> it.onChunkUnloaded(event.getChunk()));
+        final World world = event.getWorld();
+        if (world == null || world.isRemote)
+            return;
+        getPipeNetsForWorld(world).forEach(it -> it.onChunkUnloaded(event.getChunk()));
     }
 }

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -105,6 +105,8 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
 
     @Override
     public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+        if (worldIn.isRemote)
+            return;
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
         boolean damageOnLossless = ConfigHolder.doLosslessWiresDamage;
         if (!worldIn.isRemote && insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {

--- a/src/main/java/gregtech/common/pipelike/cable/net/WorldENet.java
+++ b/src/main/java/gregtech/common/pipelike/cable/net/WorldENet.java
@@ -6,9 +6,10 @@ import net.minecraft.world.World;
 
 public class WorldENet extends WorldPipeNet<WireProperties, EnergyNet> {
 
-    private static final String DATA_ID = "gregtech.e_net";
+    private static final String DATA_ID_BASE = "gregtech.e_net";
 
     public static WorldENet getWorldENet(World world) {
+        final String DATA_ID = getDataID(DATA_ID_BASE, world);
         WorldENet eNetWorldData = (WorldENet) world.loadData(WorldENet.class, DATA_ID);
         if (eNetWorldData == null) {
             eNetWorldData = new WorldENet(DATA_ID);

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -139,6 +139,8 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
 
     @Override
     public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+        if (worldIn.isRemote)
+            return;
         if (entityIn instanceof EntityLivingBase && entityIn.world.getWorldTime() % 20 == 0L) {
             EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
             FluidPipeNet pipeNet = getWorldPipeNet(worldIn).getNetFromPos(pos);

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -154,4 +154,19 @@ public class FluidPipeNet extends MonolithicPipeNet<FluidPipeProperties> {
         return new FluidPipeProperties(maxTemperature, throughput, gasProof);
     }
 
+    @Override
+    public NBTTagCompound serializeNBT() {
+        final NBTTagCompound nbt = super.serializeNBT();
+        nbt.setTag("FluidNetTank", this.fluidNetTank.writeToNBT(new NBTTagCompound()));
+        return nbt;
+    }
+
+    @Override
+    public void deserializeNBT(final NBTTagCompound nbt) {
+        super.deserializeNBT(nbt);
+        final NBTTagCompound tankData = nbt.getCompoundTag("FluidNetTank");
+        // Guard against old data that didn't have this tag
+        if (tankData != null)
+            this.fluidNetTank.readFromNBT(tankData);
+    }
 }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/WorldFluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/WorldFluidPipeNet.java
@@ -6,9 +6,10 @@ import net.minecraft.world.World;
 
 public class WorldFluidPipeNet extends WorldPipeNet<FluidPipeProperties, FluidPipeNet> {
 
-    private static final String DATA_ID = "gregtech.fluid_pipe_net";
+    private static final String DATA_ID_BASE = "gregtech.fluid_pipe_net";
 
     public static WorldFluidPipeNet getWorldPipeNet(World world) {
+        final String DATA_ID = getDataID(DATA_ID_BASE, world);
         WorldFluidPipeNet netWorldData = (WorldFluidPipeNet) world.loadData(WorldFluidPipeNet.class, DATA_ID);
         if (netWorldData == null) {
             netWorldData = new WorldFluidPipeNet(DATA_ID);

--- a/src/main/java/gregtech/common/pipelike/inventory/net/WorldInventoryPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/inventory/net/WorldInventoryPipeNet.java
@@ -6,9 +6,10 @@ import net.minecraft.world.World;
 
 public class WorldInventoryPipeNet extends TickableWorldPipeNet<EmptyNodeData, InventoryPipeNet> {
 
-    private static final String DATA_ID = "gregtech.inventory_pipe_net";
+    private static final String DATA_ID_BASE = "gregtech.inventory_pipe_net";
 
     public static WorldInventoryPipeNet getWorldPipeNet(World world) {
+        final String DATA_ID = getDataID(DATA_ID_BASE, world);
         WorldInventoryPipeNet netWorldData = (WorldInventoryPipeNet) world.loadData(WorldInventoryPipeNet.class, DATA_ID);
         if (netWorldData == null) {
             netWorldData = new WorldInventoryPipeNet(DATA_ID);


### PR DESCRIPTION
… not being persisted (#1357)

**What:**
I have included the fix for #1357 (fluid in pipes is not persisted across restarts/reloads) because I found the main issue while testing that fix.

The main fix is for #1398 which is about properly separating pipenets by dimension and not running pipenet processing on the client.

**How solved:**
Data for dimensions other than the overworld now have their dimension number appended to the WorldSaveData data id.
e.g. gregtech.fluid_pipe_net is used for the overworld and gregtech.fluid_pipe_net.-1 is used for the nether.

The reference to the world in the WorldPipeNet has been changed to a WeakReference so it doesn't stop garbage collection
of an unloaded dimension, and setWorldInit() can now handle reloading of dimensions by checking for a change instead
of the firstTick flag. 

Additionally there are corrections to stop pipenet processing running on the client. 
With an additional check to try to spot this happening in future changes.   

**Outcome:**
Fixes: #1398, correctly separate pipenets by dimension. 
Fixes: #1357 persist fluid in pipes across reloads.

**Possible compatibility issue:**
This is the elephant in the room. 

People that have built bases in other dimensions, e.g. in space in OmniFactory or FTB interations will have their pipenets currently saved against the overworld.
Despite that it would have kind of worked  provided no cables/pipes have the same blockpos in the 2 dimensions.
e.g. PipeNet.getNetFromPos() would choose a "random" dimension's pipenet if block positions are shared

This fix looks for non-overworld data somewhere else, so old pipenet data for non-overworld dimensions will not be used.
There is no way to migrate this old data. The necessary dimension info is not available in the old data to fix it.

To fix these old non-overworld cable/fluid networks, the blocks will need to be broken and replaced to recreate them.

_Please fill in as much useful information as possible. Also please remove all unused sections._