### PR TITLE
Add Cable Recipes and 4x Cable/Wire Recipes

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
@@ -40,10 +40,18 @@ public class WireRecipeHandler {
             wirePrefix.addProcessingHandler(IngotMaterial.class, WireRecipeHandler::generateWireRecipe);
             wirePrefix.addProcessingHandler(Material.class, WireRecipeHandler::generateWireCombiningRecipe);
         }
+
+        for (OrePrefix cablePrefix : CABLE_DOUBLING_ORDER) {
+            cablePrefix.addProcessingHandler(Material.class, WireRecipeHandler::generateCableCombiningRecipe);
+        }
     }
 
     private static final OrePrefix[] WIRE_DOUBLING_ORDER = new OrePrefix[]{
         OrePrefix.wireGtSingle, OrePrefix.wireGtDouble, OrePrefix.wireGtQuadruple, OrePrefix.wireGtOctal, OrePrefix.wireGtHex
+    };
+
+    private static final OrePrefix[] CABLE_DOUBLING_ORDER = new OrePrefix[]{
+        OrePrefix.cableGtSingle, OrePrefix.cableGtDouble, OrePrefix.cableGtQuadruple, OrePrefix.cableGtOctal, OrePrefix.cableGtHex
     };
 
     public static void processWireSingle(OrePrefix wirePrefix, IngotMaterial material) {
@@ -134,6 +142,41 @@ public class WireRecipeHandler {
             ModHandler.addShapelessRecipe(String.format("%s_wire_%s_splitting", material, wirePrefix),
                 OreDictUnifier.get(WIRE_DOUBLING_ORDER[wireIndex - 1], material, 2),
                 new UnificationEntry(wirePrefix, material));
+        }
+
+        if (wireIndex < 3) {
+            ModHandler.addShapelessRecipe(String.format("%s_wire_%s_quadrupling", material, wirePrefix),
+                OreDictUnifier.get(WIRE_DOUBLING_ORDER[wireIndex + 2], material),
+                new UnificationEntry(wirePrefix, material),
+                new UnificationEntry(wirePrefix, material),
+                new UnificationEntry(wirePrefix, material),
+                new UnificationEntry(wirePrefix, material));
+        }
+    }
+
+    public static void generateCableCombiningRecipe(OrePrefix cablePrefix, Material material) {
+        int cableIndex = ArrayUtils.indexOf(CABLE_DOUBLING_ORDER, cablePrefix);
+
+        if (cableIndex < CABLE_DOUBLING_ORDER.length - 1) {
+            ModHandler.addShapelessRecipe(String.format("%s_cable_%s_doubling", material, cablePrefix),
+                OreDictUnifier.get(CABLE_DOUBLING_ORDER[cableIndex + 1], material),
+                new UnificationEntry(cablePrefix, material),
+                new UnificationEntry(cablePrefix, material));
+        }
+
+        if (cableIndex > 0) {
+            ModHandler.addShapelessRecipe(String.format("%s_cable_%s_splitting", material, cablePrefix),
+                OreDictUnifier.get(CABLE_DOUBLING_ORDER[cableIndex - 1], material, 2),
+                new UnificationEntry(cablePrefix, material));
+        }
+
+        if (cableIndex < 3) {
+            ModHandler.addShapelessRecipe(String.format("%s_cable_%s_quadrupling", material, cablePrefix),
+                OreDictUnifier.get(CABLE_DOUBLING_ORDER[cableIndex + 2], material),
+                new UnificationEntry(cablePrefix, material),
+                new UnificationEntry(cablePrefix, material),
+                new UnificationEntry(cablePrefix, material),
+                new UnificationEntry(cablePrefix, material));
         }
     }
 


### PR DESCRIPTION
**What:**
Currently, there are no recipes being created to combine or deconstruct cables. For example, crafting two 1x cables into a 2x cable, or crafting one 2x cable into two 1x cables. Additionally, you can currently only do cable and wire recipes like this in pairs. I added recipes to be able to combine four 1x cables/wires into a 4x cable/wire, and same with four 2x and four 4x.

**How solved:**
Added some simple code to the WireRecipeHandler class to allow you to do this.

**Outcome:**
Cables are now much more easily used, and can be simply crafted or uncrafted into whichever size you need at the moment.

**Additional info:**
Quick example of one of the added recipes:
![cable](https://user-images.githubusercontent.com/10861407/105001411-5867f680-59f5-11eb-919f-f7f0e7b82188.PNG)


**Possible compatibility issue:**
None expected.