### PR TITLE
Fixing duplicate recipes for seed oil

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/ChemistryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ChemistryRecipes.java
@@ -262,9 +262,6 @@ public class ChemistryRecipes {
                 .buildAndRegister();
         }
 
-        RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(32).EUt(2).inputs(new ItemStack(Items.WHEAT_SEEDS)).fluidOutputs(Materials.SeedOil.getFluid(10)).buildAndRegister();
-        RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(32).EUt(2).inputs(new ItemStack(Items.MELON_SEEDS)).fluidOutputs(Materials.SeedOil.getFluid(10)).buildAndRegister();
-        RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(32).EUt(2).inputs(new ItemStack(Items.PUMPKIN_SEEDS)).fluidOutputs(Materials.SeedOil.getFluid(10)).buildAndRegister();
         RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder().duration(32).EUt(2).inputs(new ItemStack(Items.BEETROOT_SEEDS)).fluidOutputs(Materials.SeedOil.getFluid(10)).buildAndRegister();
 
         RecipeMaps.CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(30).input(OrePrefix.dustTiny, Materials.SodiumHydroxide).fluidInputs(Materials.SeedOil.getFluid(6000), Materials.Methanol.getFluid(1000)).fluidOutputs(Materials.Glycerol.getFluid(1000), Materials.BioDiesel.getFluid(6000)).buildAndRegister();


### PR DESCRIPTION
**What:**
Remove Recipes for Wheat seeds, Melon seeds, and Pumpkin seeds, fixes issue #1412 

**How solved:**
Wheat seeds, Melon seeds, and Pumpkin seeds are all covered in GTUtility.getGrassSeedEntries(), however, Beetroot seeds are not.  So, by removing the 3 recipes for those seeds, a recipe for it will not be built twice.  


**Outcome:**
Removed Duplicate Seed Oil recipes from Fluid Extractor
Fixes: #1412 


**Additional info:**
Old recipes:
![image](https://user-images.githubusercontent.com/29822509/105132284-abef4880-5ab8-11eb-8821-d669c75b2bd1.png)
![image](https://user-images.githubusercontent.com/29822509/105132292-af82cf80-5ab8-11eb-87b2-b599d37c3fa4.png)
![image](https://user-images.githubusercontent.com/29822509/105132300-b27dc000-5ab8-11eb-9f84-9473df7bb822.png)
![image](https://user-images.githubusercontent.com/29822509/105132312-b6114700-5ab8-11eb-8e0d-104b3dad34db.png)
New recipes:
![image](https://user-images.githubusercontent.com/29822509/105132330-be698200-5ab8-11eb-9de6-dbe0438ae1fa.png)
![image](https://user-images.githubusercontent.com/29822509/105132335-c0cbdc00-5ab8-11eb-9bed-bd2bb2ea9cf5.png)


**Possible compatibility issue:**
None, as this only removes duplicate recipes.