### PR TITLE
Fix Tooltip Bounding Box

### DIFF
--- a/src/main/java/gregtech/api/gui/Widget.java
+++ b/src/main/java/gregtech/api/gui/Widget.java
@@ -120,7 +120,7 @@ public abstract class Widget {
     }
 
     public static boolean isMouseOver(int x, int y, int width, int height, int mouseX, int mouseY) {
-        return mouseX >= x && mouseY >= y && x + width >= mouseX && y + height >= mouseY;
+        return mouseX >= x && mouseY >= y && x + width > mouseX && y + height > mouseY;
     }
 
     /**


### PR DESCRIPTION
**What:**
This PR fixes the bounding box issue for `isMouseOver()`, causing tooltips to overlap when a fluid slot and an item slot are directly next to each other.

**How solved:**
The fix was a simple off-by-one error, and all I had to change was a check that was previously `>=`, but should have simply been `>`.

**Outcome:**
Closes #1347 

**Additional info:**
Tooltip of item shown when hovering over item slot:
![itemhover](https://user-images.githubusercontent.com/10861407/105457454-7a0eeb00-5c4c-11eb-85ff-282aeb2b2b39.png)

Tooltip of fluid slot, and only fluid slot, shown when mouse is moved 1 pixel to the left:
![fluidhover](https://user-images.githubusercontent.com/10861407/105457488-88f59d80-5c4c-11eb-911f-306cf0cc2e64.png)

(Don't mind the missing textures in my inventory, they are left over from my Rotor extruder shape/mold work from a different PR)

**Possible compatibility issue:**
None expected.