### PR TITLE
Add "Regular" to dust oredict entries

### DIFF
--- a/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
@@ -54,8 +54,9 @@ public class MaterialMetaItem extends StandardMetaItem {
             OrePrefix prefix = this.orePrefixes[metaItem / 1000];
             Material material = Material.MATERIAL_REGISTRY.getObjectById(metaItem % 1000);
             OreDictUnifier.registerOre(new ItemStack(this, 1, metaItem), prefix, material);
+
             if(prefix.name().equals("dust"))
-                OreDictUnifier.registerOre(new ItemStack(this, 1, metaItem), prefix.name() + "Regular", material);
+                OreDictUnifier.registerOre(new ItemStack(this, 1, metaItem), "dustRegular", material);
         }
     }
 

--- a/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MaterialMetaItem.java
@@ -54,6 +54,8 @@ public class MaterialMetaItem extends StandardMetaItem {
             OrePrefix prefix = this.orePrefixes[metaItem / 1000];
             Material material = Material.MATERIAL_REGISTRY.getObjectById(metaItem % 1000);
             OreDictUnifier.registerOre(new ItemStack(this, 1, metaItem), prefix, material);
+            if(prefix.name().equals("dust"))
+                OreDictUnifier.registerOre(new ItemStack(this, 1, metaItem), prefix.name() + "Regular", material);
         }
     }
 

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -74,8 +74,12 @@ public class OreDictUnifier {
     }
 
     public static void registerOre(ItemStack itemStack, OrePrefix orePrefix, @Nullable Material material) {
+        registerOre(itemStack, orePrefix.name(), material);
+    }
+
+    public static void registerOre(ItemStack itemStack, String customOrePrefix, @Nullable Material material) {
         if (itemStack.isEmpty()) return;
-        OreDictionary.registerOre(orePrefix.name() + (material == null ? "" : material.toCamelCaseString()), itemStack);
+        OreDictionary.registerOre(customOrePrefix + (material == null ? "" : material.toCamelCaseString()), itemStack);
     }
 
     public static void registerOre(ItemStack itemStack, String oreDict) {


### PR DESCRIPTION
**What:**
This PR addresses issue #1315 and adds an oredict entry to full piles of dust, "dustRegular<material>". I did not remove the other oredict, as that would introduce compatibility issues, so normal dusts have 2 oredict entries.

**How solved:**
I created a generic oredict `registerOre()` method that creates an oredict from a String rather than OrePrefix. I also adjusted the OrePrefix `registerOre()` method to call the String one, as to not have duplicate code, and to maintain compatibility in the code. While there is already a `registerOre()` method that uses a String as the oredict prefix, it does not support using materials, so I decided this route was the best implementation.

**Outcome:**
Closes #1315

**Additional info:**
Chest of input items:
![sampleinventory](https://user-images.githubusercontent.com/10861407/105532690-c9870280-5cb0-11eb-80ba-4dfcb2b466d2.PNG)

Conveyor settings with Oredict filter:
![conveyorsettings](https://user-images.githubusercontent.com/10861407/105532721-d3106a80-5cb0-11eb-8eb3-b4a62e83bdf0.PNG)

Chest with output items, showing only the regular dust:
![exportinv](https://user-images.githubusercontent.com/10861407/105532746-de639600-5cb0-11eb-82ed-e39fbd50297b.PNG)

**Possible compatibility issue:**
None expected.