### PR TITLE
Make oregen check local chunk coordinates instead of origin corners

### DIFF
--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -94,6 +94,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         if (masterEntry == null) {
             Chunk primerChunk = world.getChunkFromChunkCoords(primerChunkX, primerChunkZ);
             BlockPos heightSpot = findOptimalSpot(gridX, gridZ, primerChunkX, primerChunkZ);
+            heightSpot = heightSpot.add(primerChunkX * 16, 0, primerChunkZ * 16);
             int masterHeight = world.getHeight(heightSpot).getY();
             int masterBottomHeight = world.getTopSolidOrLiquidBlock(heightSpot).getY();
             this.masterEntry = primerChunk.getCapability(GTWorldGenCapability.CAPABILITY, null);


### PR DESCRIPTION
**What:**
This PR adjusts the oregen to check the height of the chunk in the local chunk coordinates, instead of always at the defined origin chunk corners. In doing so, this PR addresses the first issue mentioned in #1152.

Previously, the `findOptimalSpot` method would check which corner of the chunk was closest to the center of the defined chunk grid. When doing so, it would add the chunk's coordinates to the defined origin chunks, see `double diffX = (chunkBaseX + pos.getX()) - gridCenterX;`, and would use this to check which corner is closest to the center of the chunk grid. However, when returning the result, it would instead just return the `mostClosePos`, which was one of these defined origin chunks, and not take into account the offset used when finding the corner closest to the center of the chunk grid.

After exiting the `findOptimalSpot` method, the height of returned position would then be gathered, however since the returned pos was one of the defined origin corners, the height would always be the height of the chunk at 0,0, instead of the local chunk where the vein was trying to generate. This means that there could be some issues trying to generate ore veins if the origin chunk had a very low height, such as a deep ocean biome as mentioned in #1152.

**How solved:**
This PR simply adds the chunk offset to the returned value of the defined origin corners, so that when the height of the chunk is checked, the height is checked at the chunk, instead of at the origin chunk

**Outcome:**
Fixes an issue where oregen for some veins could fail if the 0,0 chunk had extremely low height.

**Possible compatibility issue:**
None expected