### PR TITLE
Fixes #1085

### DIFF
--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -81,13 +81,13 @@ public class CommonProxy {
         SURFACE_ROCKS.values().stream().distinct().forEach(registry::register);
         FRAMES.values().stream().distinct().forEach(registry::register);
         ORES.forEach(registry::register);
-        FLUID_BLOCKS.forEach(registry::register);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void registerBlocksLast(RegistryEvent.Register<Block> event) {
         //last chance for mods to register their potion types is here
         PotionFluids.initPotionFluids();
+        FLUID_BLOCKS.forEach(event.getRegistry()::register);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -90,7 +90,6 @@ public class CommonProxy {
         FLUID_BLOCKS.forEach(event.getRegistry()::register);
     }
 
-    @SuppressWarnings("unchecked")
     @SubscribeEvent
     public static void registerItems(RegistryEvent.Register<Item> event) {
         GTLog.logger.info("Registering Items...");


### PR DESCRIPTION
**What:**
Fixes potion fluids not having textures when placed.

**How solved:**
Delegated registering fluid blocks to after potions fluids have initialized.

**Outcome:**
They now have textures when placed.
Fixes: #1085 

**Additional info:**
There was some talks on discord about changing potion fluids and how they inherently work.

Most common way being 3 fluids are registered, `normal`, `splash` and `lingering`. And brewing recipes are done via FluidStack differentiation (`PotionType` nbt stuff: see `PotionUtils`). I also haven't checked this commit against #1401 as that may be something different?