### PR TITLE
Distribute Ticks More Evenly

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -141,7 +141,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic {
     public void update() {
         if (getMetaTileEntity().getWorld().isRemote)
             return;
-        if (this.needsVenting && metaTileEntity.getTimer() % 10 == 0) {
+        if (this.needsVenting && metaTileEntity.getOffsetTimer() % 10 == 0) {
             tryDoVenting();
         }
         super.update();

--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -35,7 +35,10 @@ public interface ICoverable {
 
     BlockPos getPos();
 
+    @Deprecated
     long getTimer();
+
+    long getOffsetTimer();
 
     void markDirty();
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -123,7 +123,21 @@ public abstract class MetaTileEntity implements ICoverable {
         }
     }
 
+    /**
+     * @Deprecated Use {@link MetaTileEntity#getOffsetTimer()} instead for
+     * a better timer that spreads ticks more evenly.
+     * @return Timer value, starting at zero.
+     */
+    @Deprecated
     public long getTimer() {
+        return holder == null ? 0L : holder.getTimer();
+    }
+
+    /**
+     * Replacement for {@link MetaTileEntity#getTimer()}.
+     * @return Timer value, starting at zero, with a random offset [0, 20).
+     */
+    public long getOffsetTimer() {
         return holder == null ? 0L : holder.getOffsetTimer();
     }
 
@@ -568,11 +582,11 @@ public abstract class MetaTileEntity implements ICoverable {
                     ((ITickable) coverBehavior).update();
                 }
             }
-            if (getTimer() % 5 == 0L) {
+            if (getOffsetTimer() % 5 == 0L) {
                 updateComparatorValue();
             }
         }
-        if (getTimer() % 5 == 0L) {
+        if (getOffsetTimer() % 5 == 0L) {
             updateLightValue();
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -124,7 +124,7 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     /**
-     * @Deprecated Use {@link MetaTileEntity#getOffsetTimer()} instead for
+     * @deprecated Use {@link MetaTileEntity#getOffsetTimer()} instead for
      * a better timer that spreads ticks more evenly.
      * @return Timer value, starting at zero.
      */

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -124,7 +124,7 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     public long getTimer() {
-        return holder == null ? 0L : holder.getTimer();
+        return holder == null ? 0L : holder.getOffsetTimer();
     }
 
     public void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter) {

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -102,7 +102,7 @@ public class SimpleGeneratorMetaTileEntity extends TieredMetaTileEntity {
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getTimer() % 5 == 0) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
             fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -126,7 +126,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity {
         super.update();
         if (!getWorld().isRemote) {
             ((EnergyContainerHandler) this.energyContainer).dischargeOrRechargeEnergyContainers(chargerInventory, 0);
-            if (getTimer() % 5 == 0) {
+            if (getOffsetTimer() % 5 == 0) {
                 EnumFacing outputFacing = getOutputFacing();
                 if (autoOutputFluids) {
                     pushFluidsIntoNearbyHandlers(outputFacing);

--- a/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
@@ -8,9 +8,9 @@ public abstract class TickableTileEntityBase extends SyncedTileEntityBase implem
 
     private long timer = 0L;
 
-    // Create an offset [0,20] to distribute ticks more evenly
+    // Create an offset [0,20) to distribute ticks more evenly
     private Random random = new Random();
-    private int offset = random.nextInt(21);
+    private int offset = random.nextInt(20);
 
     /**
      * @deprecated This method distributes ticks unevenly.

--- a/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
@@ -2,12 +2,31 @@ package gregtech.api.metatileentity;
 
 import net.minecraft.util.ITickable;
 
+import java.util.Random;
+
 public abstract class TickableTileEntityBase extends SyncedTileEntityBase implements ITickable {
 
     private long timer = 0L;
 
+    // Create an offset [0,20] to distribute ticks more evenly
+    private Random random = new Random();
+    private int offset = random.nextInt(21);
+
+    /**
+     * @deprecated This method distributes ticks unevenly.
+     * Use {@link TickableTileEntityBase#getOffsetTimer()} instead.
+     */
+    @Deprecated
     public long getTimer() {
         return timer;
+    }
+
+    /**
+     * Replacement for old {@link TickableTileEntityBase#getTimer()}.
+     * @return Timer value with a random offset of [0,20].
+     */
+    public long getOffsetTimer() {
+        return timer + offset;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/TickableTileEntityBase.java
@@ -1,16 +1,14 @@
 package gregtech.api.metatileentity;
 
+import gregtech.api.util.GTUtility;
 import net.minecraft.util.ITickable;
-
-import java.util.Random;
 
 public abstract class TickableTileEntityBase extends SyncedTileEntityBase implements ITickable {
 
     private long timer = 0L;
 
     // Create an offset [0,20) to distribute ticks more evenly
-    private Random random = new Random();
-    private int offset = random.nextInt(20);
+    private final int offset = GTUtility.getRandomIntXSTR(20);
 
     /**
      * @deprecated This method distributes ticks unevenly.

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -47,7 +47,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity {
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            if (getTimer() % 20 == 0) {
+            if (getOffsetTimer() % 20 == 0) {
                 checkStructurePattern();
             }
             if (isStructureFormed()) {

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -332,6 +332,11 @@ public class PipeCoverableImplementation implements ICoverable {
     }
 
     @Override
+    public long getOffsetTimer() {
+        return getTimer();
+    }
+
+    @Override
     public void markDirty() {
         holder.markAsDirty();
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -67,6 +67,8 @@ import static gregtech.api.GTValues.V;
 
 public class GTUtility {
 
+    private static final XSTR random = new XSTR();
+
     public static Runnable combine(Runnable... runnables) {
         return () -> {
             for (Runnable runnable : runnables) {
@@ -702,5 +704,9 @@ public class GTUtility {
             .thenComparing(ItemStack::hasTagCompound)
             .thenComparing(it -> -Objects.hashCode(it.getTagCompound()))
             .thenComparing(ItemStack::getCount);
+    }
+
+    public static int getRandomIntXSTR(int bound) {
+        return random.nextInt(bound);
     }
 }

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -88,7 +88,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
 
     @Override
     public void update() {
-        long timer = coverHolder.getTimer();
+        long timer = coverHolder.getOffsetTimer();
         if (timer % 5 == 0 && isWorkingAllowed && itemsLeftToTransferLastSecond > 0) {
             TileEntity tileEntity = coverHolder.getWorld().getTileEntity(coverHolder.getPos().offset(attachedSide));
             IItemHandler itemHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, attachedSide.getOpposite());

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -100,7 +100,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
 
     @Override
     public void update() {
-        long timer = coverHolder.getTimer();
+        long timer = coverHolder.getOffsetTimer();
         if (isWorkingAllowed && fluidLeftToTransferLastSecond > 0) {
             this.fluidLeftToTransferLastSecond -= doTransferFluids(fluidLeftToTransferLastSecond);
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAirCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAirCollector.java
@@ -48,7 +48,7 @@ public class MetaTileEntityAirCollector extends TieredMetaTileEntity {
 
         if (!getWorld().isRemote) {
             long energyToConsume = GTValues.V[getTier()];
-            if (checkDimension() && checkOpenSides() && getTimer() % PRODUCTION_CYCLE_LENGTH == 0L && energyContainer.getEnergyStored() >= energyToConsume) {
+            if (checkDimension() && checkOpenSides() && getOffsetTimer() % PRODUCTION_CYCLE_LENGTH == 0L && energyContainer.getEnergyStored() >= energyToConsume) {
                 int fluidAmount = getCollectedFluidAmount();
                 FluidStack fluidStack = Materials.Air.getFluid(fluidAmount);
                 if (exportFluids.fill(fluidStack, false) == fluidAmount) {
@@ -56,7 +56,7 @@ public class MetaTileEntityAirCollector extends TieredMetaTileEntity {
                     energyContainer.removeEnergy(energyToConsume);
                 }
             }
-            if (getTimer() % 5 == 0) {
+            if (getOffsetTimer() % 5 == 0) {
                 pushFluidsIntoNearbyHandlers(getFrontFacing());
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -66,7 +66,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
     @Override
     public void update() {
         super.update();
-        if(!getWorld().isRemote && getTimer() % 5 == 0) {
+        if(!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
             pushItemsIntoNearbyHandlers(getOutputFacing());
         }
         if(!getWorld().isRemote) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
@@ -80,7 +80,7 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
     public void update() {
         super.update();
         ItemStack baitStack = importItems.getStackInSlot(0);
-        if (!getWorld().isRemote && energyContainer.getEnergyStored() >= energyAmountPerFish && getTimer() % fishingTicks == 0L && !baitStack.isEmpty()) {
+        if (!getWorld().isRemote && energyContainer.getEnergyStored() >= energyAmountPerFish && getOffsetTimer() % fishingTicks == 0L && !baitStack.isEmpty()) {
             WorldServer world = (WorldServer) this.getWorld();
             int waterCount = 0;
             int edgeSize = (int) Math.sqrt(WATER_CHECK_SIZE);
@@ -104,7 +104,7 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
                 }
             }
         }
-        if(!getWorld().isRemote && getTimer() % 5 == 0) {
+        if(!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
             pushItemsIntoNearbyHandlers(getFrontFacing());
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -159,7 +159,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
                 }
             }
         }
-        if (getTimer() % 5 == 0) {
+        if (getOffsetTimer() % 5 == 0) {
             pushItemsIntoNearbyHandlers(getFrontFacing());
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -81,10 +81,10 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
         if (!(getWorld().provider instanceof WorldProviderEnd)) {
             return; //don't try to do anything outside end dimension
         }
-        if (getTimer() % 20 == 0) {
+        if (getOffsetTimer() % 20 == 0) {
             updateDragonEggStatus();
         }
-        if (getTimer() % 200 == 0) {
+        if (getOffsetTimer() % 200 == 0) {
             updateConnectedCrystals();
         }
         int totalEnergyGeneration = 0;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -181,7 +181,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         }
 
         if (fluidSourceBlocks.isEmpty()) {
-            if (getTimer() % 20 == 0) {
+            if (getOffsetTimer() % 20 == 0) {
                 BlockPos downPos = selfPos.down(1);
                 if (downPos != null && downPos.getY() >= 0) {
                     IBlockState downBlock = getWorld().getBlockState(downPos);
@@ -199,7 +199,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
                 this.initializedQueue = false;
             }
 
-            if (!initializedQueue || getTimer() % 6000 == 0) {
+            if (!initializedQueue || getOffsetTimer() % 6000 == 0) {
                 this.initializedQueue = true;
                 //just add ourselves to check list and see how this will go
                 this.blocksToCheck.add(selfPos);
@@ -265,7 +265,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         pushFluidsIntoNearbyHandlers(getFrontFacing());
         fillContainerFromInternalTank(importItems, exportItems, 0, 0);
         updateQueueState(getTier());
-        if (getTimer() % getPumpingCycleLength() == 0 && !fluidSourceBlocks.isEmpty() &&
+        if (getOffsetTimer() % getPumpingCycleLength() == 0 && !fluidSourceBlocks.isEmpty() &&
             energyContainer.getEnergyStored() >= GTValues.V[getTier()]) {
             tryPumpFirstBlock();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTeslaCoil.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTeslaCoil.java
@@ -59,7 +59,7 @@ public class MetaTileEntityTeslaCoil extends MetaTileEntity {
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && energyContainer.getEnergyStored() > 0L && getWorld().isBlockPowered(getPos()) && getTimer() % 20 == 0L) {
+        if (!getWorld().isRemote && energyContainer.getEnergyStored() > 0L && getWorld().isBlockPowered(getPos()) && getOffsetTimer() % 20 == 0L) {
             double damageRadius = getDamageRadius();
             List<EntityLivingBase> entities = getWorld().getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(getPos()).grow(damageRadius));
             if (entities.isEmpty()) return; //no entities found, return

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityItemBus.java
@@ -45,7 +45,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockPart implemen
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getTimer() % 5 == 0) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
             if (isExportHatch) {
                 pushItemsIntoNearbyHandlers(getFrontFacing());
             } else {

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -72,7 +72,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         if (getWorld().isRemote) {
             return;
         }
-        if (getTimer() % 10 == 0) {
+        if (getOffsetTimer() % 10 == 0) {
             this.frontFaceFree = checkTurbineFaceFree();
         }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -41,7 +41,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getTimer() % 5 == 0L && isAttachedToMultiBlock()) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0L && isAttachedToMultiBlock()) {
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -212,19 +212,19 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase {
     protected void updateFormedValid() {
         if (fuelBurnTicksLeft > 0 && currentTemperature < boilerType.maxTemperature) {
             --this.fuelBurnTicksLeft;
-            if (getTimer() % 20 == 0) {
+            if (getOffsetTimer() % 20 == 0) {
                 this.currentTemperature++;
             }
             if (fuelBurnTicksLeft == 0) {
                 this.wasActiveAndNeedsUpdate = true;
             }
-        } else if (currentTemperature > 0 && getTimer() % 20 == 0) {
+        } else if (currentTemperature > 0 && getOffsetTimer() % 20 == 0) {
             --this.currentTemperature;
         }
 
         this.lastTickSteamOutput = 0;
         if (currentTemperature >= BOILING_TEMPERATURE) {
-            boolean doWaterDrain = getTimer() % 20 == 0;
+            boolean doWaterDrain = getOffsetTimer() % 20 == 0;
             FluidStack drainedWater = fluidImportInventory.drain(ModHandler.getWater(1), doWaterDrain);
             if (drainedWater == null || drainedWater.amount == 0) {
                 drainedWater = fluidImportInventory.drain(ModHandler.getDistilledWater(1), doWaterDrain);

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -156,7 +156,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
             updateCurrentTemperature();
             generateSteam();
 
-            if (getTimer() % 5 == 0) {
+            if (getOffsetTimer() % 5 == 0) {
                 fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
                 pushFluidsIntoNearbyHandlers(STEAM_PUSH_DIRECTIONS);
             }
@@ -179,7 +179,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
 
     private void updateCurrentTemperature() {
         if (fuelMaxBurnTime > 0) {
-            if (getTimer() % 12 == 0) {
+            if (getOffsetTimer() % 12 == 0) {
                 if (fuelBurnTimeLeft % 2 == 0 && currentTemperature < getMaxTemperate())
                     currentTemperature++;
                 fuelBurnTimeLeft -= isHighPressure ? 2 : 1;
@@ -198,7 +198,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
 
     private void generateSteam() {
         if(currentTemperature >= 100) {
-            if (getTimer() % getBoilingCycleLength() == 0) {
+            if (getOffsetTimer() % getBoilingCycleLength() == 0) {
                 int fillAmount = (int) (baseSteamOutput * (currentTemperature / (getMaxTemperate() * 1.0)));
                 boolean hasDrainedWater = waterFluidTank.drain(1, true) != null;
                 int filledSteam = 0;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -74,7 +74,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
         BlockPos blockPos = getPos();
         this.prevLidAngle = this.lidAngle;
 
-        if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
+        if (!getWorld().isRemote && this.numPlayersUsing != 0 && getOffsetTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
             this.numPlayersUsing = GTUtility.findPlayersUsing(this, 10.0).size();
             if (lastPlayersUsing != numPlayersUsing) {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -82,7 +82,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getTimer() % 5 == 0) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
             ItemStack itemStack = containerInventory.getStackInSlot(0);
             Capability<IFluidHandlerItem> capability = CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY;
             if (!itemStack.isEmpty() && itemStack.hasCapability(capability, null)) {


### PR DESCRIPTION
**What:**
This PR attempts to fix the issue highlighted in #1356, that ticks are typically distributed in a way that they line up with eachother often, causing especially expensive ticks.

**How solved:**
As described in the comments of the issue, I created a new method `MetaTileEntity#getOffsetTimer()` that returns the timer value plus a new offset, which is a random number between 0 and 20 exclusive. I chose to use Random and not Math.random() here because it is a better random distribution. The old `MetaTileEntity#getTimer()` still exists, but is deprecated.

**Outcome:**
Closes #1356 

**Additional info:**
I do want to point out that the `TickableTileEntity#update()` method still checks for if `timer == 0` to do first tick behavior, and ignores offset completely in timer incrementation. As a result, I don't see that behavior being an issue with this change.

**Possible compatibility issue:**
None expected. Addons are expected to change to `getOffsetTimer()` if they wish to see this performance increase, otherwise they can stick with the old `getTimer()` without issues.