### PR TITLE
Take Fluids Out Of Input Hatch

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
@@ -36,12 +36,14 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
     private ItemStackHandler containerInventory;
+    private FluidTank fluidTank;
     private boolean isExportHatch;
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
         super(metaTileEntityId, tier);
         this.containerInventory = new ItemStackHandler(2);
         this.isExportHatch = isExportHatch;
+        this.fluidTank = new FluidTank(getInventorySize());
         initializeInventory();
     }
 
@@ -73,8 +75,8 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
+            fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
             if (isExportHatch) {
-                fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
                 pushFluidsIntoNearbyHandlers(getFrontFacing());
             } else {
                 fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
@@ -98,12 +100,12 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
 
     @Override
     protected FluidTankList createImportFluidHandler() {
-        return isExportHatch ? new FluidTankList(false) : new FluidTankList(false, new FluidTank(getInventorySize()));
+        return isExportHatch ? new FluidTankList(false) : new FluidTankList(false, fluidTank);
     }
 
     @Override
     protected FluidTankList createExportFluidHandler() {
-        return isExportHatch ? new FluidTankList(false, new FluidTank(getInventorySize())) : new FluidTankList(false);
+        return new FluidTankList(false, fluidTank);
     }
 
     @Override
@@ -132,7 +134,7 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
         builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
         return builder.label(6, 6, title)
-            .widget(new FluidContainerSlotWidget(containerInventory, 0, 90, 17, !isExportHatch)
+            .widget(new FluidContainerSlotWidget(containerInventory, 0, 90, 17, false)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))
             .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
             .widget(new SlotWidget(containerInventory, 1, 90, 54, true, false)


### PR DESCRIPTION
**What:**
As a revitalization of #1295, I implemented the Input Hatches to allow for fluids to be drained via a Fluid Container. Hope I made it in time with this one for the next release :)

**How solved:**
Allow the `FluidContainerSlotWidget` to accept an empty container and put fluids into it as it does for Export Hatch.

**Outcome:**
Closes #1277 
Allow for taking fluids out of import hatches

**Additional info:**
Input Hatch with a fluid in it:
![initialState](https://user-images.githubusercontent.com/10861407/105802322-8357ca80-5f60-11eb-869f-2cbb29402312.PNG)

Input Hatch after being drained:
![finalState](https://user-images.githubusercontent.com/10861407/105802338-8e125f80-5f60-11eb-8bf7-bd132f068dcf.PNG)

Some peace of mind that the Output Hatch hasn't changed:
![outputHatchNoChange](https://user-images.githubusercontent.com/10861407/105802356-98ccf480-5f60-11eb-8c1b-c30cd4ec79f1.PNG)

**Possible compatibility issue:**
None expected.