### PR TITLE
Allow Fluid to be Plasma and Placeable

### DIFF
--- a/src/main/java/gregtech/common/MetaFluids.java
+++ b/src/main/java/gregtech/common/MetaFluids.java
@@ -186,7 +186,7 @@ public class MetaFluids {
 
         FluidRegistry.addBucketForFluid(fluid);
 
-        if (material.hasFlag(MatFlags.GENERATE_FLUID_BLOCK) && fluid.getBlock() == null) {
+        if (material.hasFlag(MatFlags.GENERATE_FLUID_BLOCK) && fluid.getBlock() == null && fluidType != FluidType.PLASMA) {
             BlockFluidBase fluidBlock = new BlockFluidClassic(fluid, net.minecraft.block.material.Material.WATER);
             fluidBlock.setRegistryName("fluid." + materialName);
             MetaBlocks.FLUID_BLOCKS.add(fluidBlock);


### PR DESCRIPTION
**What:**
This PR fixes the crash demonstrated in #1358 and revitalizes the PR #1359. You are now able to generate a FluidMaterial with both flags `GENERATE_FLUID_BLOCK` and `GENERATE_PLASMA`.

**How solved:**
I simply added a check to `registerFluid()` that checks for if the current fluid type is Plasma. This does not block the fluid from being placeable, but instead just prevents it from being registered twice, which was causing the crash.

**Outcome:**
Closes #1358 

**Additional info:**
Demonstration of a test fluid being placed:
![placeFluid](https://user-images.githubusercontent.com/10861407/105806384-80ada300-5f69-11eb-946d-f126fb10e86a.png)

Demonstration showing that a Plasma form of the same material exists, and cannot be placed:
![cantPlacePlasma](https://user-images.githubusercontent.com/10861407/105806413-8efbbf00-5f69-11eb-9e19-1e8efe55ca0c.png)

This solution fixes the issue very simply, but it does close the door on having a Plasma able to be placed in the world. I don't expect that to be a problem, though, based on discussion in the issue and the old PR.

**Possible compatibility issue:**
None expected.