### PR TITLE
Fix NPE When Placing Covers

### DIFF
--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -114,6 +114,9 @@ public interface ICoverable {
     }
 
     static boolean doesCoverCollide(EnumFacing side, List<IndexedCuboid6> collisionBox, double plateThickness) {
+        if (side == null) {
+            return false;
+        }
         if (plateThickness > 0.0) {
             Cuboid6 coverPlateBox = getCoverPlateBox(side, plateThickness);
             for (Cuboid6 collisionCuboid : collisionBox) {

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -48,8 +48,9 @@ public class PipeCoverableImplementation implements ICoverable {
     }
 
     public final boolean placeCoverOnSide(EnumFacing side, ItemStack itemStack, CoverDefinition coverDefinition) {
-        Preconditions.checkNotNull(side, "side");
-        Preconditions.checkNotNull(coverDefinition, "coverDefinition");
+        if (side == null || coverDefinition == null) {
+            return false;
+        }
         CoverBehavior coverBehavior = coverDefinition.createCoverBehavior(this, side);
         if (!canPlaceCoverOnSide(side) || !coverBehavior.canAttach()) {
             return false;
@@ -171,7 +172,7 @@ public class PipeCoverableImplementation implements ICoverable {
 
     @Override
     public CoverBehavior getCoverAtSide(EnumFacing side) {
-        return coverBehaviors[side.getIndex()];
+        return side == null ? null : coverBehaviors[side.getIndex()];
     }
 
     @Override


### PR DESCRIPTION
**What:**
This PR addresses the issue shown in #1343, where when placing a cover on a cable, your log would be filled with NPE errors.

**How solved:**
I added more robust null checking in a few places. There was a section where previously, we had a `Preconditions.checkNotNull()` call on `side`, but this would get hit and still cause a log error, so I instead changed this to return false if null.

**Outcome:**
Closes #1343 

**Additional info:**
Previously, I was able to get an error in the log following the steps to reproduce very consistently and almost immediately. With these changes, I tested it on 10 sets of cables and was unable to get an error.

**Possible compatibility issue:**
None expected.