### PR TITLE
Rework Fluid Pipe Item Render

### DIFF
--- a/src/main/java/gregtech/common/pipelike/fluidpipe/FluidPipeType.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/FluidPipeType.java
@@ -6,9 +6,9 @@ import gregtech.api.unification.ore.OrePrefix;
 public enum FluidPipeType implements IMaterialPipeType<FluidPipeProperties> {
 
     TINY_OPAQUE("tiny", 0.20f, 1, OrePrefix.pipeTiny, true),
-    SMALL_OPAQUE("small", 0.30f, 2, OrePrefix.pipeSmall, true),
-    MEDIUM_OPAQUE("medium", 0.35f, 4, OrePrefix.pipeMedium, true),
-    LARGE_OPAQUE("large", 0.40f, 8, OrePrefix.pipeLarge, true);
+    SMALL_OPAQUE("small", 0.35f, 2, OrePrefix.pipeSmall, true),
+    MEDIUM_OPAQUE("medium", 0.50f, 4, OrePrefix.pipeMedium, true),
+    LARGE_OPAQUE("large", 0.65f, 8, OrePrefix.pipeLarge, true);
 
     public final String name;
     public final float thickness;

--- a/src/main/java/gregtech/common/render/FluidPipeRenderer.java
+++ b/src/main/java/gregtech/common/render/FluidPipeRenderer.java
@@ -125,15 +125,17 @@ public class FluidPipeRenderer implements ICCBlockRenderer, IItemRenderer {
         }
         CCRenderState renderState = CCRenderState.instance();
         GlStateManager.enableBlend();
+        GlStateManager.disableCull();
         renderState.reset();
         renderState.startDrawing(GL11.GL_QUADS, DefaultVertexFormats.ITEM);
         BlockFluidPipe blockFluidPipe = (BlockFluidPipe) ((ItemBlockFluidPipe) stack.getItem()).getBlock();
         FluidPipeType pipeType = blockFluidPipe.getItemPipeType(stack);
         Material material = blockFluidPipe.getItemMaterial(stack);
         if (pipeType != null && material != null) {
-            renderPipeBlock(material, pipeType, IPipeTile.DEFAULT_INSULATION_COLOR, renderState, new IVertexOperation[0], 0);
+            renderPipeBlock(material, pipeType, IPipeTile.DEFAULT_INSULATION_COLOR, renderState, new IVertexOperation[0], 0b001100);
         }
         renderState.draw();
+        GlStateManager.enableCull();
         GlStateManager.disableBlend();
     }
 


### PR DESCRIPTION
**What:**
Currently, Fluid Pipes render in the inventory as the "end," showing a small little cube instead of something that looks more like an actual pipe. This PR changes that to show the pipe model instead of the end model.

**How solved:**
I set the `connectMask` in `renderItem()` for Fluid Pipes to show a connection, so that the pipe in the inventory now shows a connection rather than the end. I also had to disable culling temporarily for rendering the item on the `GlStateManager`, but I re-enabled it afterwards. I also resized the pipe thickness slightly to allow the item models to be more visibly different from each other.

**Outcome:**
Fluid Pipes now render more clearly in inventory.

**Additional info:**
Old inventory images:
![olditemmodels](https://user-images.githubusercontent.com/10861407/106521404-cefbfe00-64a3-11eb-8a9c-43f192cabc75.PNG)

New inventory images:
![newitemmodelstake2](https://user-images.githubusercontent.com/10861407/106526336-091cce00-64ab-11eb-9e7d-9e1d6f90129d.PNG)

Pipes in-world, with new thickness:
![inworldold](https://user-images.githubusercontent.com/10861407/106526472-4d0fd300-64ab-11eb-8925-a104a961b890.png)

I am currently working on addressing the odd corner and end blocks for pipes to try and make it more in-line with the rest of the pipe models as well.

**Possible compatibility issue:**
None expected.