### PR TITLE
Fix Two Tanks in TOP for Input Hatch

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
@@ -36,14 +36,14 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
     private ItemStackHandler containerInventory;
-    private FluidTank fluidTank;
+    private FluidTankList fluidTankHandler;
     private boolean isExportHatch;
+
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
         super(metaTileEntityId, tier);
         this.containerInventory = new ItemStackHandler(2);
         this.isExportHatch = isExportHatch;
-        this.fluidTank = new FluidTank(getInventorySize());
         initializeInventory();
     }
 
@@ -99,13 +99,13 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockPart imple
     }
 
     @Override
-    protected FluidTankList createImportFluidHandler() {
-        return isExportHatch ? new FluidTankList(false) : new FluidTankList(false, fluidTank);
-    }
-
-    @Override
-    protected FluidTankList createExportFluidHandler() {
-        return new FluidTankList(false, fluidTank);
+    protected void initializeInventory() {
+        super.initializeInventory();
+        FluidTank fluidTank = new FluidTank(getInventorySize());
+        this.fluidTankHandler = new FluidTankList(false, fluidTank);
+        this.exportFluids = fluidTankHandler;
+        this.importFluids = isExportHatch ? new FluidTankList(false) : fluidTankHandler;
+        this.fluidInventory = fluidTankHandler;
     }
 
     @Override


### PR DESCRIPTION
**What:**
After PR #1427, there was an issue found where the Input Hatch showed two tanks in the TOP overlay. This didn't cause any functional issues, but was nonetheless a visual issue that needed addressing.

**How solved:**
I refactored the fluid handler creation to stop multiple instances of `FluidTankList` being created.

**Outcome:**
Input Hatch shows only one tank in TOP

**Additional info:**
Before:
![Old](https://user-images.githubusercontent.com/10861407/107107770-dea77980-67f8-11eb-91fc-25574fe84f0c.png)

After:
![new](https://user-images.githubusercontent.com/10861407/107107775-e830e180-67f8-11eb-85dc-1126308cb0f2.png)

**Possible compatibility issue:**
None expected.