### PR TITLE
Update JEI Multiblocks to show block counts and allow bookmarking

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.integration.jei.multiblock.infos.*;
 import mezz.jei.api.IJeiHelpers;
+import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -20,11 +21,13 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
 
     private final IDrawable background;
     private final IDrawable icon;
+    private final IGuiHelper guiHelper;
 
     public MultiblockInfoCategory(IJeiHelpers helpers) {
-        this.background = helpers.getGuiHelper().createBlankDrawable(176, 166);
+        this.guiHelper = helpers.getGuiHelper();
+        this.background = this.guiHelper.createBlankDrawable(176, 166);
         ResourceLocation iconLocation = new ResourceLocation(GTValues.MODID, "textures/gui/icon/coke_oven.png");
-        this.icon = helpers.getGuiHelper().createDrawable(iconLocation, 0, 0, 16, 16, 16, 16);
+        this.icon = this.guiHelper.createDrawable(iconLocation, 0, 0, 16, 16, 16, 16);
     }
 
     public static final Map<String, MultiblockInfoRecipeWrapper> multiblockRecipes = new HashMap<String, MultiblockInfoRecipeWrapper>() {{
@@ -78,7 +81,7 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
 
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout);
+        recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, this.guiHelper);
     }
 
 }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -212,7 +212,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper, SceneRenderC
         WorldSceneRenderer renderer = getCurrentRenderer();
         int scenePosY = 0;
         //noinspection UnnecessaryLocalVariable,SuspiciousNameCombination
-        int sceneHeight = recipeWidth;
+        int sceneHeight = recipeHeight-36;
         renderer.render(recipeLayout.getPosX(), recipeLayout.getPosY() + scenePosY, recipeWidth, sceneHeight, 0xC6C6C6);
         drawText(minecraft, recipeWidth);
         for (int i = 0; i < MAX_PARTS; ++i) {


### PR DESCRIPTION
**What:**
This shows the number of blocks required to build the currently shown pattern in the JEI multiblock view and allows bookmarking of those blocks.

**How solved:**
Added 20 slots at the bottom of the screen. 
These are filled from the block drops of the multiblock in the dummy world, which was sort of already being collected (just not the amounts).
The new slots are part of an IGuiItemStackGroup to enable all the extra JEI features like bookmarking and r/u behaviour. 
The left/right buttons to switch between multiblock variants have been moved to the right hand side below the layer switch button.

![2021-02-09_00 26 12](https://user-images.githubusercontent.com/275258/107298841-0f441900-6a6e-11eb-9a4c-e62a10bad835.png)

**Outcome:**
Closes #1393 
and does part 1 of #1211

**Possible compatibility issue:**
I made it 20 slots because I know gregicality has some complicated multiblocks. 