### PR TITLE
Add some descriptors to the machine controller

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -122,7 +122,8 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
             .widget(new SlotWidget(displayInventory, 0, 141, 47, false, false)
                 .setBackgroundTexture(GuiTextures.SLOT))
             .widget(new CycleButtonWidget(10, 70, 75, 20, this::isInverted, this::setInverted,
-                "cover.machine_controller.normal", "cover.machine_controller.inverted"))
+                "cover.machine_controller.normal", "cover.machine_controller.inverted")
+                .setTooltipHoverString("cover.machine_controller.inverted.description"))
             .build(this, player);
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -740,6 +740,7 @@ cover.bucket.mode.milli_bucket=mB/s
 cover.machine_controller.name=Machine Controller Settings
 cover.machine_controller.normal=Normal
 cover.machine_controller.inverted=Inverted
+cover.machine_controller.inverted.description=§eNormal§r - in this mode, the cover will require a signal weaker than the set redstone level to run/n§eInverted§r - in this mode, the cover will require a signal stronger than the set redstone level to run
 cover.machine_controller.redstone=Min Redstone Strength: %d
 cover.machine_controller.mode.machine=Control Machine
 cover.machine_controller.mode.cover_up=Control Cover (Top)


### PR DESCRIPTION
**What:**
Add some description tooltips to the machine controller explaining the difference between `inverted` and `normal` mode

**How solved:**
Simply adds a localized tooltip to the inverted/normal button

**Outcome:**
Adds some descriptors to the machine controller

**Additional info:**
![2021-02-09_15 48 41](https://user-images.githubusercontent.com/31759736/107438767-4bb75980-6aee-11eb-9ba4-137e4e185636.png)

**Possible compatibility issue:**
None expected


