### PR TITLE
Don't generate orebyproduct recipes when there are no byproducts fixe…

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -151,7 +151,9 @@ public class GTJeiPlugin implements IModPlugin {
         List<OreByProduct> oreByproductList = new CopyOnWriteArrayList<>();
         for (Material material : Material.MATERIAL_REGISTRY) {
             if (material instanceof DustMaterial && OreDictUnifier.get(OrePrefix.ore, material) != ItemStack.EMPTY) {
-                oreByproductList.add(new OreByProduct((DustMaterial) material));
+                final OreByProduct oreByProduct = new OreByProduct((DustMaterial) material);
+                if (oreByProduct.hasByProducts())
+                    oreByproductList.add(oreByProduct);
             }
         }
         String oreByProductId = GTValues.MODID + ":" + "ore_by_product";

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -73,6 +73,10 @@ public class OreByProduct implements IRecipeWrapper {
 		ingredients.setOutputs(ItemStack.class, this.outputs);
 	}
 
+     public boolean hasByProducts() {
+         return !outputs.isEmpty();
+     }
+
 	public void addTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
 		switch (slotIndex) {
 		case 0: // Ore


### PR DESCRIPTION
**What:**
Ore Byproducts recipes showing with no byproducts in JEI.

**How solved:**
Does not add recipes to JEI for materials that have no by products.
A page will still exist if the material is a byproduct of something else.

**Outcome:**
Fixes #1448
