### PR TITLE
Don't place the same tile multiple times for JEI multiblock rendering

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockShapeInfo.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockShapeInfo.java
@@ -5,6 +5,7 @@ import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.util.BlockInfo;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 
 import java.util.ArrayList;
@@ -64,6 +65,15 @@ public class MultiblockShapeInfo {
                     BlockInfo[] columnData = new BlockInfo[columnEntry.length()];
                     for (int k = 0; k < columnData.length; k++) {
                         columnData[k] = symbolMap.getOrDefault(columnEntry.charAt(k), BlockInfo.EMPTY);
+                        TileEntity tileEntity = columnData[k].getTileEntity();
+                        if (tileEntity != null) {
+                            MetaTileEntityHolder holder = (MetaTileEntityHolder) tileEntity;
+                            final MetaTileEntity mte = holder.getMetaTileEntity();
+                            holder = new MetaTileEntityHolder();
+                            holder.setMetaTileEntity(mte);
+                            holder.getMetaTileEntity().setFrontFacing(mte.getFrontFacing());
+                            columnData[k] = new BlockInfo(columnData[k].getBlockState(), holder);
+                        }
                     }
                     aisleData[j] = columnData;
                 }


### PR DESCRIPTION
**What:**
Multiblocks not forming in the JEI rendering scene

**How solved:**
Made sure individual tile entites are placed in the dummy world rather placing the same tile in multiple locations.
This allows the recipemap constraints to be satisified and the multiblock will now form.

**Outcome:**
Fixes #1379