### PR TITLE
Mechanism to copy text to the player's clipboard

### DIFF
--- a/src/main/java/gregtech/api/net/NetworkHandler.java
+++ b/src/main/java/gregtech/api/net/NetworkHandler.java
@@ -7,8 +7,8 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.gui.impl.ModularUIContainer;
 import gregtech.api.gui.impl.ModularUIGui;
+import gregtech.api.util.ClipboardUtil;
 import gregtech.api.util.GTLog;
-import gregtech.api.util.GTUtility;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.state.IBlockState;
@@ -236,7 +236,7 @@ public class NetworkHandler {
         });
 
         registerClientExecutor(PacketClipboard.class, (packet, handler) -> {
-            GTUtility.copyToClipboard(packet.text);
+            ClipboardUtil.copyToClipboard(packet.text);
         });
     }
 

--- a/src/main/java/gregtech/api/net/NetworkHandler.java
+++ b/src/main/java/gregtech/api/net/NetworkHandler.java
@@ -8,6 +8,7 @@ import gregtech.api.gui.UIFactory;
 import gregtech.api.gui.impl.ModularUIContainer;
 import gregtech.api.gui.impl.ModularUIGui;
 import gregtech.api.util.GTLog;
+import gregtech.api.util.GTUtility;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.state.IBlockState;
@@ -187,6 +188,13 @@ public class NetworkHandler {
                 buf.readVarInt())
         ));
 
+        registerPacket(5, PacketClipboard.class, new PacketCodec<>(
+            (packet, buf) -> {
+                buf.writeString(packet.text);
+            },
+            (buf) -> new PacketClipboard(buf.readString(32767))
+        ));
+
         registerServerExecutor(PacketUIClientAction.class, (packet, handler) -> {
             Container openContainer = handler.player.openContainer;
             if (openContainer instanceof ModularUIContainer &&
@@ -225,6 +233,10 @@ public class NetworkHandler {
             IBlockState blockState = world.getBlockState(packet.blockPos);
             ParticleManager particleManager = Minecraft.getMinecraft().effectRenderer;
             ((ICustomParticleBlock) blockState.getBlock()).handleCustomParticle(world, packet.blockPos, particleManager, packet.entityPos, packet.particlesAmount);
+        });
+
+        registerClientExecutor(PacketClipboard.class, (packet, handler) -> {
+            GTUtility.copyToClipboard(packet.text);
         });
     }
 

--- a/src/main/java/gregtech/api/net/PacketClipboard.java
+++ b/src/main/java/gregtech/api/net/PacketClipboard.java
@@ -1,0 +1,12 @@
+package gregtech.api.net;
+
+import gregtech.api.net.NetworkHandler.Packet;
+
+public class PacketClipboard implements Packet {
+
+    public final String text;
+
+    public PacketClipboard(final String text) {
+        this.text = text;
+    }
+}

--- a/src/main/java/gregtech/api/util/ClipboardUtil.java
+++ b/src/main/java/gregtech/api/util/ClipboardUtil.java
@@ -1,0 +1,26 @@
+package gregtech.api.util;
+
+import gregtech.api.net.NetworkHandler;
+import gregtech.api.net.PacketClipboard;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import java.awt.Desktop;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+
+public class ClipboardUtil {
+
+    public static void copyToClipboard(final String text) {
+        if (Desktop.isDesktopSupported()) {
+            final StringSelection selection = new StringSelection(text);
+            final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(selection, null);
+        }
+    }
+
+    public static void copyToClipboard(final EntityPlayerMP player, final String text) {
+        PacketClipboard packet = new PacketClipboard(text);
+        NetworkHandler.channel.sendTo(packet.toFMLPacket(), player);
+    }
+}

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -11,8 +11,6 @@ import gregtech.api.gui.impl.ModularUIContainer;
 import gregtech.api.items.IToolItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
-import gregtech.api.net.NetworkHandler;
-import gregtech.api.net.PacketClipboard;
 import gregtech.common.ConfigHolder;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRedstoneWire;
@@ -53,10 +51,6 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
 
-import java.awt.Desktop;
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -302,19 +296,6 @@ public class GTUtility {
         GlStateManager.translate(-textWidth * sizeMultiplier / 2.0, -textHeight * sizeMultiplier / 2.0, 0);
         fontRenderer.drawString(string, x, y, color);
         GlStateManager.popMatrix();
-    }
-
-    public static void copyToClipboard(final String text) {
-        if (Desktop.isDesktopSupported()) {
-            final StringSelection selection = new StringSelection(text);
-            final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(selection, null);
-        }
-    }
-
-    public static void copyToClipboard(final EntityPlayerMP player, final String text) {
-        PacketClipboard packet = new PacketClipboard(text);
-        NetworkHandler.channel.sendTo(packet.toFMLPacket(), player);
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -11,6 +11,8 @@ import gregtech.api.gui.impl.ModularUIContainer;
 import gregtech.api.items.IToolItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.net.NetworkHandler;
+import gregtech.api.net.PacketClipboard;
 import gregtech.common.ConfigHolder;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRedstoneWire;
@@ -50,6 +52,11 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
+
+import java.awt.Desktop;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -295,6 +302,19 @@ public class GTUtility {
         GlStateManager.translate(-textWidth * sizeMultiplier / 2.0, -textHeight * sizeMultiplier / 2.0, 0);
         fontRenderer.drawString(string, x, y, color);
         GlStateManager.popMatrix();
+    }
+
+    public static void copyToClipboard(final String text) {
+        if (Desktop.isDesktopSupported()) {
+            final StringSelection selection = new StringSelection(text);
+            final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(selection, null);
+        }
+    }
+
+    public static void copyToClipboard(final EntityPlayerMP player, final String text) {
+        PacketClipboard packet = new PacketClipboard(text);
+        NetworkHandler.channel.sendTo(packet.toFMLPacket(), player);
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -50,7 +50,6 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/src/main/java/gregtech/common/command/util/CommandHand.java
+++ b/src/main/java/gregtech/common/command/util/CommandHand.java
@@ -11,7 +11,7 @@ import gregtech.api.items.toolitem.ToolMetaItem.MetaToolValueItem;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
-import gregtech.api.util.GTUtility;
+import gregtech.api.util.ClipboardUtil;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -91,7 +91,7 @@ public class CommandHand extends CommandBase {
                         IToolStats toolStats = ((MetaToolValueItem) metaValueItem).getToolStats();
                         player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.tool_stats", toolStats.getClass().getName()));
                     }
-                    GTUtility.copyToClipboard(player, metaValueItem.unlocalizedName);
+                    ClipboardUtil.copyToClipboard(player, metaValueItem.unlocalizedName);
                     ClickEvent metaItemEvent = new ClickEvent(Action.OPEN_URL, metaValueItem.unlocalizedName);
                     player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.meta_item", metaValueItem.unlocalizedName, metaValueItem)
                         .setStyle(new Style().setClickEvent(metaItemEvent)));

--- a/src/main/java/gregtech/common/command/util/CommandHand.java
+++ b/src/main/java/gregtech/common/command/util/CommandHand.java
@@ -11,6 +11,7 @@ import gregtech.api.items.toolitem.ToolMetaItem.MetaToolValueItem;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.util.GTUtility;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -90,6 +91,7 @@ public class CommandHand extends CommandBase {
                         IToolStats toolStats = ((MetaToolValueItem) metaValueItem).getToolStats();
                         player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.tool_stats", toolStats.getClass().getName()));
                     }
+                    GTUtility.copyToClipboard(player, metaValueItem.unlocalizedName);
                     ClickEvent metaItemEvent = new ClickEvent(Action.OPEN_URL, metaValueItem.unlocalizedName);
                     player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.meta_item", metaValueItem.unlocalizedName, metaValueItem)
                         .setStyle(new Style().setClickEvent(metaItemEvent)));


### PR DESCRIPTION
**What:**
Add a generic mechanism to copy text to the player's clipboard and use it in the "gt util hand" command for the metavalueitem's name

**How solved:**
Created a new gregtech.api.net.PacketClipboard which is just a string.

Added 2 new util methods
ClipboardUtil.copyToClipboard(String) - copies the string to the clipboard if the AWT desktop is available
ClipboardUtil.copyToClipboard(EntityPlayerMP, String) - sends the network packet to the client which will invoke the other method

When "/gt util hand" sends the chat message to display the MetaValueItem.unlocalizedName it now also sends that value to the player's clipboard

**Outcome:**
Closes #1391