### PR TITLE
Don't set held item for non player listeners

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIContainer.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIContainer.java
@@ -121,8 +121,10 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
     @Override
     public void sendHeldItemUpdate() {
         for (IContainerListener listener : listeners) {
-            EntityPlayerMP player = (EntityPlayerMP) listener;
-            player.connection.sendPacket(new SPacketSetSlot(-1, -1, player.inventory.getItemStack()));
+            if (listener instanceof EntityPlayerMP) {
+                EntityPlayerMP player = (EntityPlayerMP) listener;
+                player.connection.sendPacket(new SPacketSetSlot(-1, -1, player.inventory.getItemStack()));
+            }
         }
     }
 


### PR DESCRIPTION
**What:**
Crash when FTB Quests is installed and any ModularUIContainer is used, e.g. the crafting station

**How solved:**
Don't try to set the player's held item when the container listener is not a player.

**Outcome:**
Fixes #1020
