### PR TITLE
Rewrite inventory sorting for O(n log n)

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -701,6 +701,6 @@ public class GTUtility {
             .thenComparing(ItemStack::getItemDamage)
             .thenComparing(ItemStack::hasTagCompound)
             .thenComparing(it -> -Objects.hashCode(it.getTagCompound()))
-            .thenComparing(ItemStack::getCount);
+            .thenComparing(it -> -it.getCount());
     }
 }


### PR DESCRIPTION
**What:**
Currently inventory sorting uses kinda bubble sort method to stack items. It's not effective, leads to O(n^2) time complexity which leads to lags when sorting big inventories

**How solved:**
We can firstly sort the inventory and then stack items as they will be always consequent and we can deal with it using two pointer technic. Also we can on-the-fly delete trim empty spaces in the inventory. So we will change O(n^2) part to O(n) part which will lead us to the whole complexity of O(n log n) (due to sorting)

**Outcome:**
Sorting chest inventories works much faster.

**Possible compatibility issue:**
Now `createItemStackComparator` sorts items by their amount in descending order (which should be done even before but it wasn't a case).