### PR TITLE
Fix findPlayersUsing's usage of AxisAlignedBB

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -543,11 +543,11 @@ public class GTUtility {
         };
     }
 
-    public static List<EntityPlayerMP> findPlayersUsing(MetaTileEntity metaTileEntity, double radius) {
-        ArrayList<EntityPlayerMP> result = new ArrayList<>();
+    public static List<EntityPlayer> findPlayersUsing(MetaTileEntity metaTileEntity, double radius) {
+        ArrayList<EntityPlayer> result = new ArrayList<>();
         AxisAlignedBB box = new AxisAlignedBB(metaTileEntity.getPos()).expand(radius, radius, radius);
-        List<EntityPlayerMP> entities = metaTileEntity.getWorld().getEntitiesWithinAABB(EntityPlayerMP.class, box);
-        for (EntityPlayerMP player : entities) {
+        List<EntityPlayer> entities = metaTileEntity.getWorld().getEntitiesWithinAABB(EntityPlayer.class, box);
+        for (EntityPlayer player : entities) {
             if (player.openContainer instanceof ModularUIContainer) {
                 ModularUI modularUI = ((ModularUIContainer) player.openContainer).getModularUI();
                 if (modularUI.holder instanceof MetaTileEntityHolder &&

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -54,7 +54,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -543,11 +542,13 @@ public class GTUtility {
         };
     }
 
-    public static List<EntityPlayer> findPlayersUsing(MetaTileEntity metaTileEntity, double radius) {
-        ArrayList<EntityPlayer> result = new ArrayList<>();
-        AxisAlignedBB box = new AxisAlignedBB(metaTileEntity.getPos()).expand(radius, radius, radius);
-        List<EntityPlayer> entities = metaTileEntity.getWorld().getEntitiesWithinAABB(EntityPlayer.class, box);
-        for (EntityPlayer player : entities) {
+    public static List<EntityPlayerMP> findPlayersUsing(MetaTileEntity metaTileEntity, double radius) {
+        ArrayList<EntityPlayerMP> result = new ArrayList<>();
+        AxisAlignedBB box = new AxisAlignedBB(metaTileEntity.getPos())
+            .expand(radius, radius, radius)
+            .expand(-radius, -radius, -radius);
+        List<EntityPlayerMP> entities = metaTileEntity.getWorld().getEntitiesWithinAABB(EntityPlayerMP.class, box);
+        for (EntityPlayerMP player : entities) {
             if (player.openContainer instanceof ModularUIContainer) {
                 ModularUI modularUI = ((ModularUIContainer) player.openContainer).getModularUI();
                 if (modularUI.holder instanceof MetaTileEntityHolder &&

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -76,7 +76,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
         if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
-            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 10.0).size();
+            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 6.0).size();
             if (lastPlayersUsing != numPlayersUsing) {
                 updateNumPlayersUsing();
             }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -76,7 +76,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
         if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
-            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 6.0).size();
+            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 5.0).size();
             if (lastPlayersUsing != numPlayersUsing) {
                 updateNumPlayersUsing();
             }


### PR DESCRIPTION
**What:**
It fixes #1469

**How solved:**
Expand BoundingBox in `GTUtility.findPlayersUsing` in both directions

**Outcome:**
It fixes the issue due to https://github.com/GregTechCE/GregTech/blob/f80e5dcf581f6490126988620ca952cebfd1f754/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java#L77-L83

**Possible compatibility issue:**
Not possible. This method now works better.