### PR TITLE
Not count spectators in MetaTileEntityChest

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -78,7 +78,7 @@ public class GTUtility {
     }
 
     public static Stream<Object> flatten(Object[] array) {
-        return Arrays.stream(array).flatMap(o -> o instanceof Object[] ? flatten((Object[]) o) : Stream.of(o));
+        return Arrays.stream(array).flatMap(o -> o instanceof Object[] ? flatten((Object[]) o): Stream.of(o));
     }
 
     public static void copyInventoryItems(IItemHandler src, IItemHandlerModifiable dest) {
@@ -172,7 +172,6 @@ public class GTUtility {
      * field is used, and ItemStack.getItemDamage() can be overriden,
      * giving incorrect results for itemstack equality comparisons,
      * which still use raw ItemStack.itemDamage field
-     *
      * @return actual value of ItemStack.itemDamage field
      */
     public static int getActualItemDamageFromStack(ItemStack itemStack) {
@@ -184,7 +183,7 @@ public class GTUtility {
      * If it's not possible to merge it fully, it will attempt to insert it into first empty slots
      *
      * @param itemStack item stack to merge. It WILL be modified.
-     * @param simulate  if true, stack won't actually modify items in other slots
+     * @param simulate if true, stack won't actually modify items in other slots
      * @return if merging of at least one item succeed, false otherwise
      */
     public static boolean mergeItemStack(ItemStack itemStack, List<Slot> slots, boolean simulate) {
@@ -242,19 +241,19 @@ public class GTUtility {
         IBlockState blockState = world.getBlockState(pos);
         TileEntity tileEntity = world.getTileEntity(pos);
 
-        if (blockState.getBlock().isAir(blockState, world, pos)) {
+        if(blockState.getBlock().isAir(blockState, world, pos)) {
             return false;
         }
 
-        if (!blockState.getBlock().canHarvestBlock(world, pos, player)) {
+        if(!blockState.getBlock().canHarvestBlock(world, pos, player)) {
             return false;
         }
 
         int expToDrop = 0;
-        if (!world.isRemote) {
+        if(!world.isRemote) {
             EntityPlayerMP playerMP = (EntityPlayerMP) player;
             expToDrop = ForgeHooks.onBlockBreakEvent(world, playerMP.interactionManager.getGameType(), playerMP, pos);
-            if (expToDrop == -1) {
+            if(expToDrop == -1) {
                 //notify client if block can't be removed because of BreakEvent cancelled on server side
                 playerMP.connection.sendPacket(new SPacketBlockChange(world, pos));
                 return false;
@@ -264,19 +263,19 @@ public class GTUtility {
         world.playEvent(player, 2001, pos, Block.getStateId(blockState));
 
         boolean wasRemovedByPlayer = blockState.getBlock().removedByPlayer(blockState, world, pos, player, !player.capabilities.isCreativeMode);
-        if (wasRemovedByPlayer) {
+        if(wasRemovedByPlayer) {
             blockState.getBlock().onBlockDestroyedByPlayer(world, pos, blockState);
 
-            if (!world.isRemote && !player.capabilities.isCreativeMode) {
+            if(!world.isRemote && !player.capabilities.isCreativeMode) {
                 ItemStack stackInHand = player.getHeldItemMainhand();
                 blockState.getBlock().harvestBlock(world, player, pos, blockState, tileEntity, stackInHand);
-                if (expToDrop > 0) {
+                if(expToDrop > 0) {
                     blockState.getBlock().dropXpOnBlockBreak(world, pos, expToDrop);
                 }
             }
         }
 
-        if (!world.isRemote) {
+        if(!world.isRemote) {
             EntityPlayerMP playerMP = (EntityPlayerMP) player;
             playerMP.connection.sendPacket(new SPacketBlockChange(world, pos));
         } else {
@@ -388,7 +387,7 @@ public class GTUtility {
                 return (byte) Math.max(0, tier - 1);
             }
         }
-        return (byte) Math.min(V.length - 1, tier);
+        return (byte) Math.min(V.length -1, tier);
     }
 
     public static BiomeDictionary.Type getBiomeTypeTagByName(String name) {
@@ -644,10 +643,7 @@ public class GTUtility {
 
     public static <T> Collector<T, ?, ImmutableList<T>> toImmutableList() {
         return Collector.of(ImmutableList::builder, Builder::add,
-            (b1, b2) -> {
-                b1.addAll(b2.build());
-                return b2;
-            },
+            (b1, b2) -> { b1.addAll(b2.build()); return b2; },
             ImmutableList.Builder<T>::build);
     }
 
@@ -698,7 +694,7 @@ public class GTUtility {
             return worldPower;
         } else {
             IBlockState offsetState = world.getBlockState(offsetPos);
-            if (offsetState.getBlock() instanceof BlockRedstoneWire) {
+            if(offsetState.getBlock() instanceof BlockRedstoneWire) {
                 int wirePower = offsetState.getValue(BlockRedstoneWire.POWER);
                 return Math.max(worldPower, wirePower);
             }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -77,10 +77,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
         if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
-            this.numPlayersUsing = (int) GTUtility.findPlayersUsing(this, 10.0)
-                .stream()
-                .filter(entityPlayer -> !entityPlayer.isSpectator())
-                .count();
+            this.numPlayersUsing = (int) GTUtility.findPlayersUsing(this, 10.0, false).size();
             if (lastPlayersUsing != numPlayersUsing) {
                 updateNumPlayersUsing();
             }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -21,6 +21,7 @@ import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -76,7 +77,10 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
         if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
-            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 10.0).size();
+            this.numPlayersUsing = (int) GTUtility.findPlayersUsing(this, 10.0)
+                .stream()
+                .filter(entityPlayer -> !entityPlayer.isSpectator())
+                .count();
             if (lastPlayersUsing != numPlayersUsing) {
                 updateNumPlayersUsing();
             }
@@ -192,7 +196,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
     @Override
     @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-        if(ModHandler.isMaterialWood(material)) {
+        if (ModHandler.isMaterialWood(material)) {
             return Pair.of(Textures.WOODEN_CHEST.getParticleTexture(), getPaintingColor());
         } else {
             return Pair.of(Textures.METAL_CHEST.getParticleTexture(), getPaintingColor());

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -21,7 +21,6 @@ import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -77,7 +76,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
         if (!getWorld().isRemote && this.numPlayersUsing != 0 && getTimer() % 200 == 0) {
             int lastPlayersUsing = numPlayersUsing;
-            this.numPlayersUsing = (int) GTUtility.findPlayersUsing(this, 10.0, false).size();
+            this.numPlayersUsing = GTUtility.findPlayersUsing(this, 10.0, false).size();
             if (lastPlayersUsing != numPlayersUsing) {
                 updateNumPlayersUsing();
             }


### PR DESCRIPTION
**What:**
Do not count spectators in MetaTileEntityChest each 10 seconds.

**Outcome:**
Effectively nothing changed due to Spectators can not use Chests (see #1022)

**Possible compatibility issue:**
Not possible