### PR TITLE
Fix chest placement render problem (Fix #1474)

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -18,7 +18,6 @@ import gregtech.api.cover.IFacadeCover;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.render.MetaTileEntityRenderer;
-import gregtech.api.util.GTLog;
 import gregtech.common.tools.DamageValues;
 import gregtech.api.render.IBlockAppearance;
 import gregtech.integration.ctm.IFacadeWrapper;
@@ -400,7 +399,6 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     public int getLightOpacity(IBlockState state, IBlockAccess world, BlockPos pos) {
         //why mc is so fucking retarded to call this method on fucking NEIGHBOUR BLOCKS!
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
-        GTLog.logger.info(metaTileEntity == null);
         return metaTileEntity == null ? 0 : metaTileEntity.getLightOpacity();
     }
 

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -18,6 +18,7 @@ import gregtech.api.cover.IFacadeCover;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.render.MetaTileEntityRenderer;
+import gregtech.api.util.GTLog;
 import gregtech.common.tools.DamageValues;
 import gregtech.api.render.IBlockAppearance;
 import gregtech.integration.ctm.IFacadeWrapper;
@@ -399,7 +400,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     public int getLightOpacity(IBlockState state, IBlockAccess world, BlockPos pos) {
         //why mc is so fucking retarded to call this method on fucking NEIGHBOUR BLOCKS!
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
-        return metaTileEntity == null ? 255 : metaTileEntity.getLightOpacity();
+        GTLog.logger.info(metaTileEntity == null);
+        return metaTileEntity == null ? 0 : metaTileEntity.getLightOpacity();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -154,7 +154,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
     @Override
     public int getLightOpacity() {
-        return 1;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
**What:**
Fix chest placement render problem

**How solved:**
Change default light opacity to 0 which means that it's the same as air (and basically we can say that nothing is air)

**Outcome:**
Fix #1474 

**Possible compatibility issue:**
Chest's light opacity now is 0 instead of 1 (the same as for Vanilla Chest)
If we on current position there is no `MetaTileEntityHolder` then we assume that it is air, so return opacity of 0 instead of 255.

Basically this problem occurs with any transparent block in Gregtech like Tank etc.