### PR TITLE
Fix the caching for container items in the CraftingStation

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -22,7 +22,6 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
-import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -86,14 +85,6 @@ public class GTUtility {
             ItemStack itemStack = src.getStackInSlot(i);
             dest.setStackInSlot(i, itemStack.isEmpty() ? ItemStack.EMPTY : itemStack.copy());
         }
-    }
-
-    public static InventoryCrafting deepCopyInventoryCrafting(final InventoryCrafting source) {
-        final InventoryCrafting result = new InventoryCrafting(new DummyContainer(), source.getWidth(), source.getHeight());
-        for (int i = 0; i < result.getSizeInventory(); ++i) {
-            result.setInventorySlotContents(i, source.getStackInSlot(i).copy());
-        }
-        return result;
     }
 
     public static <T> IntStream indices(T[] array) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -22,6 +22,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
+import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -85,6 +86,14 @@ public class GTUtility {
             ItemStack itemStack = src.getStackInSlot(i);
             dest.setStackInSlot(i, itemStack.isEmpty() ? ItemStack.EMPTY : itemStack.copy());
         }
+    }
+
+    public static InventoryCrafting deepCopyInventoryCrafting(final InventoryCrafting source) {
+        final InventoryCrafting result = new InventoryCrafting(new DummyContainer(), source.getWidth(), source.getHeight());
+        for (int i = 0; i < result.getSizeInventory(); ++i) {
+            result.setInventorySlotContents(i, source.getStackInSlot(i).copy());
+        }
+        return result;
     }
 
     public static <T> IntStream indices(T[] array) {

--- a/src/main/java/gregtech/api/util/InventoryUtils.java
+++ b/src/main/java/gregtech/api/util/InventoryUtils.java
@@ -2,6 +2,7 @@ package gregtech.api.util;
 
 import it.unimi.dsi.fastutil.*;
 import it.unimi.dsi.fastutil.objects.*;
+import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.*;
 import net.minecraftforge.items.*;
 
@@ -209,5 +210,13 @@ public final class InventoryUtils {
         }
 
         return splitStacks;
+    }
+
+    public static InventoryCrafting deepCopyInventoryCrafting(final InventoryCrafting source) {
+        final InventoryCrafting result = new InventoryCrafting(new DummyContainer(), source.getWidth(), source.getHeight());
+        for (int i = 0; i < result.getSizeInventory(); ++i) {
+            result.setInventorySlotContents(i, source.getStackInSlot(i).copy());
+        }
+        return result;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -1,7 +1,7 @@
 package gregtech.common.metatileentities.storage;
 
 import gregtech.api.util.DummyContainer;
-import gregtech.api.util.GTUtility;
+import gregtech.api.util.InventoryUtils;
 import gregtech.api.util.ItemStackKey;
 import gregtech.common.inventory.IItemList.InsertMode;
 import gregtech.common.inventory.itemsource.ItemSourceList;
@@ -42,7 +42,7 @@ public class CachedRecipeData {
             return false;
         }
         ForgeHooks.setCraftingPlayer(player);
-        InventoryCrafting deepCopy = GTUtility.deepCopyInventoryCrafting(inventory);
+        InventoryCrafting deepCopy = InventoryUtils.deepCopyInventoryCrafting(inventory);
         NonNullList<ItemStack> remainingItems = recipe.getRemainingItems(deepCopy);
         ForgeHooks.setCraftingPlayer(null);
         for (ItemStack itemStack : remainingItems) {

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -1,6 +1,7 @@
 package gregtech.common.metatileentities.storage;
 
 import gregtech.api.util.DummyContainer;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.ItemStackKey;
 import gregtech.common.inventory.IItemList.InsertMode;
 import gregtech.common.inventory.itemsource.ItemSourceList;
@@ -41,7 +42,8 @@ public class CachedRecipeData {
             return false;
         }
         ForgeHooks.setCraftingPlayer(player);
-        NonNullList<ItemStack> remainingItems = recipe.getRemainingItems(inventory);
+        InventoryCrafting deepCopy = GTUtility.deepCopyInventoryCrafting(inventory);
+        NonNullList<ItemStack> remainingItems = recipe.getRemainingItems(deepCopy);
         ForgeHooks.setCraftingPlayer(null);
         for (ItemStack itemStack : remainingItems) {
             itemStack = itemStack.copy();


### PR DESCRIPTION
**What:**
The crafting station lets you craft with empty fluid containers when a fluid is specified in the recipe.

The issue is caused because a call to IRecipe.getRemainingItems() can change the cached and validated recipe held in CachedRecipeData. e..g For a fluid container with fluid inside, it can be updated to be the empty fluid container.

Because the data is assumed valid in the cache, it would from then on be using the changed/broken recipe as though it were valid. All it wants is the empty fluid container to process the recipe.

This change also gets copied into the crafting grid displayed to the user when it tries to show what recipe was actually used.

**How solved:**
When calling getRemainingItems(), a deep copy of the recipe is passed. i.e. the item stacks are copied
This avoids any random recipe implementation changing the cache/validated recipe.

**Outcome:**
Fixes #1451

**Additional info:**
The 2nd part of this issue would also lead to other issues like a broken GT tool getting replaced with "air" in the crafting grid and stopping further crafting even if there is a valid tool in the crafting station's inventory.