### PR TITLE
Use material color in particle texture, optimize color convertion

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -54,7 +54,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -130,18 +129,25 @@ public class GTUtility {
     }
 
     public static int convertRGBtoRGBA_CL(int colorValue, int opacity) {
-        int r = (colorValue >> 16) & 0xFF;
-        int g = (colorValue >> 8) & 0xFF;
-        int b = (colorValue & 0xFF);
-        return (r & 0xFF) << 24 | (g & 0xFF) << 16 | (b & 0xFF) << 8 | (opacity & 0xFF);
+        return colorValue << 8 | (opacity & 0xFF);
+    }
+
+    public static int convertOpaqueRGBA_CLtoRGB(int colorAlpha) {
+        return colorAlpha >> 8;
     }
 
     //0xAARRGGBB
     public static int convertRGBtoOpaqueRGBA_MC(int colorValue) {
-        int r = (colorValue >> 16) & 0xFF;
-        int g = (colorValue >> 8) & 0xFF;
-        int b = (colorValue & 0xFF);
-        return 0xFF << 24 | (r & 0xFF) << 16 | (g & 0xFF) << 8 | (b & 0xFF);
+        return convertRGBtoOpaqueRGBA_MC(colorValue, 255);
+    }
+
+    //0xAARRGGBB
+    public static int convertRGBtoOpaqueRGBA_MC(int colorValue, int opacity) {
+        return opacity << 24 | colorValue;
+    }
+
+    public static int convertOpaqueRGBA_MCtoRGB(int alphaColor) {
+        return alphaColor & 0xFFFFFF;
     }
 
     public static void setItem(ItemStack itemStack, ItemStack newStack) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -54,6 +54,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -141,7 +141,6 @@ public class GTUtility {
         return convertRGBtoOpaqueRGBA_MC(colorValue, 255);
     }
 
-    //0xAARRGGBB
     public static int convertRGBtoOpaqueRGBA_MC(int colorValue, int opacity) {
         return opacity << 24 | colorValue;
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -134,7 +134,7 @@ public class GTUtility {
     }
 
     public static int convertOpaqueRGBA_CLtoRGB(int colorAlpha) {
-        return colorAlpha >> 8;
+        return colorAlpha >>> 8;
     }
 
     //0xAARRGGBB

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -42,6 +42,8 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static gregtech.api.util.GTUtility.convertOpaqueRGBA_CLtoRGB;
+
 public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMetaTileEntity {
 
     private static final IndexedCuboid6 CHEST_COLLISION = new IndexedCuboid6(null, new Cuboid6(1 / 16.0, 0 / 16.0, 1 / 16.0, 15 / 16.0, 14 / 16.0, 15 / 16.0));
@@ -195,7 +197,12 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
         if(ModHandler.isMaterialWood(material)) {
             return Pair.of(Textures.WOODEN_CHEST.getParticleTexture(), getPaintingColor());
         } else {
-            return Pair.of(Textures.METAL_CHEST.getParticleTexture(), getPaintingColor());
+            int color = ColourRGBA.multiply(
+                GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+                GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColor())
+            );
+            color = convertOpaqueRGBA_CLtoRGB(color);
+            return Pair.of(Textures.METAL_CHEST.getParticleTexture(), color);
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.storage;
 
+import codechicken.lib.colour.ColourRGBA;
 import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
@@ -58,6 +59,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.*;
+
+import static gregtech.api.util.GTUtility.convertOpaqueRGBA_CLtoRGB;
 
 public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMetaTileEntity {
 
@@ -610,11 +613,12 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
 
     @SideOnly(Side.CLIENT)
     private int getActualPaintingColor() {
-        int paintingColor = getPaintingColorForRendering();
-        if (paintingColor == DEFAULT_PAINTING_COLOR) {
-            return material.materialRGB;
-        }
-        return paintingColor;
+        int color = ColourRGBA.multiply(
+            GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+            GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering())
+        );
+        color = convertOpaqueRGBA_CLtoRGB(color);
+        return color;
     }
 
     @Override


### PR DESCRIPTION
**What:**
Now material color is used in particle texture the same way as for rendering.

**How solved:**
Multiply `material.materialRGB` to previous result with converting RGB to RGBA and vice versa.

**Outcome:**
Fix #1480 

**Screenshots:**
![image](https://user-images.githubusercontent.com/9883873/107985568-5fc1f600-6fdb-11eb-9ed5-0d8a09a0433e.png)

**Possible compatibility issue:**
Not possible, only new methods appeared. Old methods return the same result.

Take into account that we don't need to do and operation `& 0xFFFFFF` when doing right shift for 8 bits due to `int` overflow.
Also consider that in `convertOpaqueRGBA_CLtoRGB` we need a zero right shift instead of simple right shift in order not to get 1s in first 8 bits in case first bit of OpaqueRGBA_CL would be 1 (which is possible when red channel >= 128).