### PR TITLE
Optimize Render Bounding Box for Chest and Safe

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -214,7 +214,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @Override
     public void onLoad() {
         super.onLoad();
-        if(metaTileEntity != null) {
+        if (metaTileEntity != null) {
             metaTileEntity.onLoad();
         }
     }
@@ -222,7 +222,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @Override
     public void onChunkUnload() {
         super.onChunkUnload();
-        if(metaTileEntity != null) {
+        if (metaTileEntity != null) {
             metaTileEntity.onUnload();
         }
     }
@@ -248,9 +248,9 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
 
     @Override
     public boolean shouldRenderInPass(int pass) {
-        if(metaTileEntity instanceof IRenderMetaTileEntity) {
+        if (metaTileEntity instanceof IRenderMetaTileEntity) {
             return ((IRenderMetaTileEntity) metaTileEntity).shouldRenderInPass(pass);
-        } else if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
+        } else if (metaTileEntity instanceof IFastRenderMetaTileEntity) {
             return ((IFastRenderMetaTileEntity) metaTileEntity).shouldRenderInPass(pass);
         }
         return false;
@@ -258,9 +258,9 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        if(metaTileEntity instanceof IRenderMetaTileEntity) {
+        if (metaTileEntity instanceof IRenderMetaTileEntity) {
             return ((IRenderMetaTileEntity) metaTileEntity).getRenderBoundingBox();
-        } else if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
+        } else if (metaTileEntity instanceof IFastRenderMetaTileEntity) {
             return ((IFastRenderMetaTileEntity) metaTileEntity).getRenderBoundingBox();
         }
         return new AxisAlignedBB(getPos());

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -263,7 +263,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         } else if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
             return ((IFastRenderMetaTileEntity) metaTileEntity).getRenderBoundingBox();
         }
-        return new AxisAlignedBB(getPos(), getPos().add(1, 1, 1));
+        return new AxisAlignedBB(getPos());
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java
@@ -226,7 +226,7 @@ public class MetaTileEntityChest extends MetaTileEntity implements IFastRenderMe
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        return new AxisAlignedBB(getPos().add(-1, -1, -1), getPos().add(2, 2, 2));
+        return new AxisAlignedBB(getPos().add(-1, 0, -1), getPos().add(2, 2, 2));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
@@ -374,7 +374,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        return new AxisAlignedBB(getPos().add(-1, -1, -1), getPos().add(2, 2, 2));
+        return new AxisAlignedBB(getPos().add(-1, 0, -1), getPos().add(2, 1, 2));
     }
 
     @Override


### PR DESCRIPTION
**What:**
The chest doesn't open downwards so it's not needed to subtract 1 by Y axis in render bounding box
The safe doesn't open nor downwards nor upwards so it's not needed to subtract 1 and add 1 by Y axis in render bounding box

**Outcome:**
Nothing changes except for some small optimization in render mechanism when some chests that are higher than your Field of View won't be rendered. Same for safes (but also some of which were lower than your Field of View).

**Additional info**
For testing I've commented line 98 here, so that the chest was always opened after first opening:
https://github.com/GregTechCE/GregTech/blob/f80e5dcf581f6490126988620ca952cebfd1f754/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityChest.java#L95-L99
After that I checked all possible angles and most importantly looking on chest from below. At first I incorrectly changed it to be `(0, 0, 0), (1, 2, 1)`, but then I understood that chest's top part is actually on the neighbouring block when it is opened, so we need to have bounding box of size 3x2x3 which is done in this pull request.

For safe it's the same but its size should be 3x1x3

For `MetaTileEntityHolder` there is just a refactoring - no logic changed.

**Possible compatibility issue:**
Not possible