### PR TITLE
Fix wheel action in MouseTweaks and Crafting Station voiding items

### DIFF
--- a/src/main/java/gregtech/api/gui/ModularUI.java
+++ b/src/main/java/gregtech/api/gui/ModularUI.java
@@ -10,7 +10,6 @@ import gregtech.api.util.Position;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.items.IItemHandlerModifiable;
-import net.minecraftforge.items.wrapper.PlayerMainInvWrapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -192,7 +191,7 @@ public final class ModularUI implements ISizeProvider {
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int x, int y) {
             for (int row = 0; row < 3; row++) {
                 for (int col = 0; col < 9; col++) {
-                    this.widget(new SlotWidget(new PlayerMainInvWrapper(inventoryPlayer), col + (row + 1) * 9, x + col * 18, y + row * 18)
+                    this.widget(new SlotWidget(inventoryPlayer, col + (row + 1) * 9, x + col * 18, y + row * 18)
                         .setBackgroundTexture(imageLocation)
                         .setLocationInfo(true, false));
                 }
@@ -202,7 +201,7 @@ public final class ModularUI implements ISizeProvider {
 
         public Builder bindPlayerHotbar(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int x, int y) {
             for (int slot = 0; slot < 9; slot++) {
-                this.widget(new SlotWidget(new PlayerMainInvWrapper(inventoryPlayer), slot, x + slot * 18, y)
+                this.widget(new SlotWidget(inventoryPlayer, slot, x + slot * 18, y)
                     .setBackgroundTexture(imageLocation)
                     .setLocationInfo(true, true));
             }

--- a/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
@@ -251,4 +251,59 @@ public class SlotWidget extends Widget implements INativeWidget {
         }
     }
 
+    /**
+     * @deprecated
+     * Use {@link WidgetSlotItemHandler} instead. <br>
+     * {@link WidgetSlotDelegate} was renamed to {@link WidgetSlotItemHandler} since GregTech 1.15.0.<br>
+     * Explanation of deprecation: In order to fix mouse wheel action a new class was introduced ({@link WidgetSlot}).
+     * To have consistent names {@link WidgetSlotDelegate} was renamed to {@link WidgetSlotItemHandler}.
+     *
+     * @see <a href="https://github.com/GregTechCE/GregTech/pull/1485">GregTech#1495 (Pull request)</a>
+     * @see <a href="https://github.com/GregTechCE/GregTech/issues/1291">GregTech#1291 (Issue)</a>
+     */
+    @Deprecated
+    protected class WidgetSlotDelegate extends SlotItemHandler implements IScissored {
+
+        public WidgetSlotDelegate(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
+            super(itemHandler, index, xPosition, yPosition);
+        }
+
+        @Override
+        public boolean isItemValid(@Nonnull ItemStack stack) {
+            return SlotWidget.this.canPutStack(stack) && super.isItemValid(stack);
+        }
+
+        @Override
+        public boolean canTakeStack(EntityPlayer playerIn) {
+            return SlotWidget.this.canTakeStack(playerIn) && super.canTakeStack(playerIn);
+        }
+
+        @Override
+        public void putStack(@Nonnull ItemStack stack) {
+            super.putStack(stack);
+            if (changeListener != null) {
+                changeListener.run();
+            }
+        }
+
+        @Override
+        public final ItemStack onTake(EntityPlayer thePlayer, ItemStack stack) {
+            return onItemTake(thePlayer, super.onTake(thePlayer, stack), false);
+        }
+
+        @Override
+        public void onSlotChanged() {
+            SlotWidget.this.onSlotChanged();
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return SlotWidget.this.isEnabled();
+        }
+
+        @Override
+        public Rectangle getScissor() {
+            return SlotWidget.this.scissor;
+        }
+    }
 }

--- a/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
@@ -13,6 +13,8 @@ import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ClickType;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -22,7 +24,7 @@ import net.minecraftforge.items.SlotItemHandler;
 
 public class SlotWidget extends Widget implements INativeWidget {
 
-    protected SlotItemHandler slotReference;
+    protected Slot slotReference;
     protected boolean isEnabled = true;
 
     protected boolean canTakeItems;
@@ -34,6 +36,13 @@ public class SlotWidget extends Widget implements INativeWidget {
 
     protected Rectangle scissor;
 
+    public SlotWidget(IInventory inventory, int slotIndex, int xPosition, int yPosition, boolean canTakeItems, boolean canPutItems) {
+        super(new Position(xPosition, yPosition), new Size(18, 18));
+        this.canTakeItems = canTakeItems;
+        this.canPutItems = canPutItems;
+        this.slotReference = createSlot(inventory, slotIndex);
+    }
+
     public SlotWidget(IItemHandler itemHandler, int slotIndex, int xPosition, int yPosition, boolean canTakeItems, boolean canPutItems) {
         super(new Position(xPosition, yPosition), new Size(18, 18));
         this.canTakeItems = canTakeItems;
@@ -41,8 +50,12 @@ public class SlotWidget extends Widget implements INativeWidget {
         this.slotReference = createSlot(itemHandler, slotIndex);
     }
 
-    protected SlotItemHandler createSlot(IItemHandler itemHandler, int index) {
-        return new WidgetSlotDelegate(itemHandler, index, 0, 0);
+    protected Slot createSlot(IInventory inventory, int index) {
+        return new WidgetSlotDelegate(inventory, index, 0, 0);
+    }
+
+    protected Slot createSlot(IItemHandler inventory, int index) {
+        return new WidgetSlotItemHandlerDelegate(inventory, index, 0, 0);
     }
 
     @Override
@@ -87,6 +100,10 @@ public class SlotWidget extends Widget implements INativeWidget {
 
     public SlotWidget(IItemHandlerModifiable itemHandler, int slotIndex, int xPosition, int yPosition) {
         this(itemHandler, slotIndex, xPosition, yPosition, true, true);
+    }
+
+    public SlotWidget(IInventory inventory, int slotIndex, int xPosition, int yPosition) {
+        this(inventory, slotIndex, xPosition, yPosition, true, true);
     }
 
     /**
@@ -141,13 +158,57 @@ public class SlotWidget extends Widget implements INativeWidget {
     }
 
     @Override
-    public final SlotItemHandler getHandle() {
+    public final Slot getHandle() {
         return slotReference;
     }
 
-    protected class WidgetSlotDelegate extends SlotItemHandler implements IScissored {
+    protected class WidgetSlotDelegate extends Slot implements IScissored {
+        public WidgetSlotDelegate(IInventory inventory, int index, int xPosition, int yPosition) {
+            super(inventory, index, xPosition, yPosition);
+        }
 
-        public WidgetSlotDelegate(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
+        @Override
+        public boolean isItemValid(@Nonnull ItemStack stack) {
+            return SlotWidget.this.canPutStack(stack) && super.isItemValid(stack);
+        }
+
+        @Override
+        public boolean canTakeStack(EntityPlayer playerIn) {
+            return SlotWidget.this.canTakeStack(playerIn) && super.canTakeStack(playerIn);
+        }
+
+        @Override
+        public void putStack(@Nonnull ItemStack stack) {
+            super.putStack(stack);
+            if (changeListener != null) {
+                changeListener.run();
+            }
+        }
+
+        @Override
+        public final ItemStack onTake(EntityPlayer thePlayer, ItemStack stack) {
+            return onItemTake(thePlayer, super.onTake(thePlayer, stack), false);
+        }
+
+        @Override
+        public void onSlotChanged() {
+            SlotWidget.this.onSlotChanged();
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return SlotWidget.this.isEnabled();
+        }
+
+        @Override
+        public Rectangle getScissor() {
+            return SlotWidget.this.scissor;
+        }
+    }
+
+    protected class WidgetSlotItemHandlerDelegate extends SlotItemHandler implements IScissored {
+
+        public WidgetSlotItemHandlerDelegate(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
             super(itemHandler, index, xPosition, yPosition);
         }
 

--- a/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
@@ -54,8 +54,8 @@ public class SlotWidget extends Widget implements INativeWidget {
         return new WidgetSlot(inventory, index, 0, 0);
     }
 
-    protected Slot createSlot(IItemHandler inventory, int index) {
-        return new WidgetSlotItemHandler(inventory, index, 0, 0);
+    protected Slot createSlot(IItemHandler itemHandler, int index) {
+        return new WidgetSlotItemHandler(itemHandler, index, 0, 0);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
@@ -51,11 +51,11 @@ public class SlotWidget extends Widget implements INativeWidget {
     }
 
     protected Slot createSlot(IInventory inventory, int index) {
-        return new WidgetSlotDelegate(inventory, index, 0, 0);
+        return new WidgetSlot(inventory, index, 0, 0);
     }
 
     protected Slot createSlot(IItemHandler inventory, int index) {
-        return new WidgetSlotItemHandlerDelegate(inventory, index, 0, 0);
+        return new WidgetSlotItemHandler(inventory, index, 0, 0);
     }
 
     @Override
@@ -162,8 +162,8 @@ public class SlotWidget extends Widget implements INativeWidget {
         return slotReference;
     }
 
-    protected class WidgetSlotDelegate extends Slot implements IScissored {
-        public WidgetSlotDelegate(IInventory inventory, int index, int xPosition, int yPosition) {
+    protected class WidgetSlot extends Slot implements IScissored {
+        public WidgetSlot(IInventory inventory, int index, int xPosition, int yPosition) {
             super(inventory, index, xPosition, yPosition);
         }
 
@@ -206,9 +206,9 @@ public class SlotWidget extends Widget implements INativeWidget {
         }
     }
 
-    protected class WidgetSlotItemHandlerDelegate extends SlotItemHandler implements IScissored {
+    protected class WidgetSlotItemHandler extends SlotItemHandler implements IScissored {
 
-        public WidgetSlotItemHandlerDelegate(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
+        public WidgetSlotItemHandler(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
             super(itemHandler, index, xPosition, yPosition);
         }
 

--- a/src/main/java/gregtech/common/gui/widget/CraftingSlotWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/CraftingSlotWidget.java
@@ -7,10 +7,10 @@ import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.common.metatileentities.storage.CraftingRecipeResolver;
 import mezz.jei.api.gui.IGuiIngredient;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemStackHandler;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -23,13 +23,12 @@ public class CraftingSlotWidget extends SlotWidget implements IRecipeTransferHan
     private boolean canTakeStack = false;
 
     public CraftingSlotWidget(CraftingRecipeResolver recipeResolver, int slotIndex, int xPosition, int yPosition) {
-        //pass delegate here to avoid using IItemHandlerModifiable-related tricks by SlotItemHandler
-        super(createItemHandler(recipeResolver), slotIndex, xPosition, yPosition, true, false);
+        super(createInventory(recipeResolver), slotIndex, xPosition, yPosition, true, false);
         this.recipeResolver = recipeResolver;
     }
 
-    private static IItemHandler createItemHandler(CraftingRecipeResolver resolver) {
-        return resolver == null ? new ItemStackHandler(1) : resolver.getCraftingResultInventory();
+    private static IInventory createInventory(CraftingRecipeResolver resolver) {
+        return resolver == null ? new InventoryCraftResult() : resolver.getCraftingResultInventory();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
@@ -5,6 +5,8 @@ import gregtech.api.util.DummyContainer;
 import gregtech.common.inventory.itemsource.ItemSourceList;
 import gregtech.common.inventory.itemsource.sources.TileItemSource;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
@@ -28,7 +30,7 @@ public class CraftingRecipeResolver {
     private final ItemStackHandler craftingGrid;
     private final InventoryCrafting inventoryCrafting = new InventoryCrafting(new DummyContainer(), 3, 3);
     private IRecipe cachedRecipe = null;
-    private final ItemStackHandler craftingResultInventory = new ItemStackHandler(1);
+    private final IInventory craftingResultInventory = new InventoryCraftResult();
     private long timer = 0L;
     private CachedRecipeData cachedRecipeData = null;
     private int itemsCrafted = 0;
@@ -46,7 +48,7 @@ public class CraftingRecipeResolver {
         return itemSourceList;
     }
 
-    public ItemStackHandler getCraftingResultInventory() {
+    public IInventory getCraftingResultInventory() {
         return craftingResultInventory;
     }
 
@@ -117,7 +119,7 @@ public class CraftingRecipeResolver {
         if (cachedRecipe != null) {
             itemStack = cachedRecipe.getCraftingResult(inventoryCrafting).copy();
         }
-        this.craftingResultInventory.setStackInSlot(0, itemStack);
+        this.craftingResultInventory.setInventorySlotContents(0, itemStack);
     }
 
     public boolean checkRecipeValid() {
@@ -137,12 +139,12 @@ public class CraftingRecipeResolver {
             this.cachedRecipe = newRecipe;
             if (newRecipe != null) {
                 ItemStack resultStack = newRecipe.getCraftingResult(inventoryCrafting).copy();
-                this.craftingResultInventory.setStackInSlot(0, resultStack.copy());
+                this.craftingResultInventory.setInventorySlotContents(0, resultStack.copy());
                 this.cachedRecipeData = new CachedRecipeData(itemSourceList, newRecipe, resultStack.copy());
                 copyInventoryItems(craftingGrid, new InvWrapper(this.cachedRecipeData.inventory));
                 this.cachedRecipeData.attemptMatchRecipe();
             } else {
-                this.craftingResultInventory.setStackInSlot(0, ItemStack.EMPTY);
+                this.craftingResultInventory.setInventorySlotContents(0, ItemStack.EMPTY);
                 this.cachedRecipeData = null;
             }
         }

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -20,6 +20,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.SlotItemHandler;
 
 import java.util.List;
 
@@ -77,18 +78,21 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
 
             if (uiWidget instanceof SlotWidget) {
                 SlotWidget slotWidget = (SlotWidget) uiWidget;
-                if (slotWidget.getHandle().getItemHandler() == importItems) {
+                if (!(slotWidget.getHandle() instanceof SlotItemHandler)) {
+                    continue;
+                }
+                SlotItemHandler handle = (SlotItemHandler) slotWidget.getHandle();
+                if (handle.getItemHandler() == importItems) {
                     //this is input item stack slot widget, so add it to item group
-                    itemStackGroup.init(slotWidget.getHandle().getSlotIndex(), true,
+                    itemStackGroup.init(handle.getSlotIndex(), true,
                         slotWidget.getPosition().x,
                         slotWidget.getPosition().y);
-                } else if (slotWidget.getHandle().getItemHandler() == exportItems) {
+                } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + slotWidget.getHandle().getSlotIndex(), false,
+                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
                         slotWidget.getPosition().x,
                         slotWidget.getPosition().y);
                 }
-
             } else if (uiWidget instanceof TankWidget) {
                 TankWidget tankWidget = (TankWidget) uiWidget;
                 if (importFluids.getFluidTanks().contains(tankWidget.fluidTank)) {


### PR DESCRIPTION
**What:**
Now you can use a wheel action added by MouseTweaks, also fix #1291 

**How solved (full explanation of bug):**
Do not wrap player inventory when passing it to SlotWidget. Consider how it is implemented in `forgeSrc`
![image](https://user-images.githubusercontent.com/9883873/108193411-74f76b80-7126-11eb-8ee4-2fcd79e6f602.png)
I've debugged MouseTweaks and found out that the main problem is that it just doesn't understand which items correspond to the player's inventory and which to some other stuff. We always falling into `continue;` on these lines:

https://github.com/YaLTeR/MouseTweaks/blob/minecraft-1.12.2/src/main/java/yalter/mousetweaks/Main.java#L474-L480

When we create a `SlotItemHandler` it's just connecting all slots to a constant `emptyInventory`:
![image](https://user-images.githubusercontent.com/9883873/108195525-ef28ef80-7128-11eb-90b5-c3cc837e2bef.png)

To be precise, `findInPlayerInventory` is always `false` as `selectedSlot.inventory == SlotItemHandler.emptyInventory`. The same applies for `slot.inventory` as well as for any `Slot` which was created with usage of `SlotWidget`.

All we need to do is just fix this stuff by providing correct `IInventory`.

**UPD:** Now also fixes #1291 by changing `IItemHandler` to `IInventory` in `CraftingSlotWidget`.

**Outcome:**

https://user-images.githubusercontent.com/9883873/108194144-4f1e9680-7127-11eb-83b9-90b2e35293a7.mp4


**Possible compatibility issues**:
~Now `SlotWidget.getHandle()` returns `SlotDelegate` instead of `SlotItemHandler` **which may lead to logical errors when checking result of `getHandle()` with `instanceof`** (see https://github.com/GregTechCE/GregTech/pull/1485#issuecomment-780576223)~ Fixed this
Renamed `SlotWidget.WidgetSlotDelegate` to `SlotWidget.WidgetSlotItemHandler`.
`SlotWidget.WidgetSlotDelegate` is now deprecated.
Now `SlotWidget.getHandle()` may return either `SlotWidget.WidgetSlot` or `SlotWidget.WidgetSlotItemHandler` instead of previous `SlotWidget.WidgetSlotItemHandler` so now it returns `Slot` instead of `SlotItemHandler`.