### PR TITLE
Open Up Multiblock Overlay

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -14,6 +14,7 @@ import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.multiblock.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.render.OrientedOverlayRenderer;
 import gregtech.api.render.Textures;
 import gregtech.api.util.GTUtility;
 import net.minecraft.util.ResourceLocation;
@@ -157,6 +158,14 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     @Override
     public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
         super.renderMetaTileEntity(renderState, translation, pipeline);
-        Textures.MULTIBLOCK_WORKABLE_OVERLAY.render(renderState, translation, pipeline, getFrontFacing(), recipeMapWorkable.isActive());
+        this.getFrontOverlay().render(renderState, translation, pipeline, getFrontFacing(), recipeMapWorkable.isActive());
+    }
+
+    /**
+     * Override this method to change the Controller overlay
+     * @return The overlay to render on the Multiblock Controller
+     */
+    protected OrientedOverlayRenderer getFrontOverlay() {
+        return Textures.MULTIBLOCK_WORKABLE_OVERLAY;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -26,6 +26,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +166,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
      * Override this method to change the Controller overlay
      * @return The overlay to render on the Multiblock Controller
      */
+    @Nonnull
     protected OrientedOverlayRenderer getFrontOverlay() {
         return Textures.MULTIBLOCK_WORKABLE_OVERLAY;
     }


### PR DESCRIPTION
**What:**
This PR is a simple one, that allows subclasses of `RecipeMapMultiblockController` to set their own custom overlay for the multiblock controller.

**How solved:**
I created a protected method `getFrontOverlay()` that is called by `RecipeMapMultiblockController#renderMetaTileEntity()` so that a multiblock controller can have any overlay. It still defaults to `MULTIBLOCK_WORKABLE_OVERLAY` as before.

**Outcome:**
- Allow custom Multiblock Controller overlays

**Possible compatibility issue:**
None expected.