### PR TITLE
Remove Duplicate Dense Plate Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -270,13 +270,6 @@ public class MaterialRecipeHandler {
                     .circuitMeta(5)
                     .EUt(96).duration((int) (material.getAverageMass() * 9))
                     .buildAndRegister();
-
-                RecipeMaps.BENDER_RECIPES.recipeBuilder()
-                    .input(OrePrefix.plate, material, 9)
-                    .outputs(denseStack)
-                    .circuitMeta(5)
-                    .EUt(96).duration((int) (material.getAverageMass() * 2))
-                    .buildAndRegister();
             }
         }
 


### PR DESCRIPTION
**What:**
This PR removes a duplicate recipe for dense plates, as shown below.
![recipe1](https://user-images.githubusercontent.com/10861407/108642789-db54f480-746c-11eb-830e-e089fe0da9c6.PNG)
![recipe2](https://user-images.githubusercontent.com/10861407/108642790-dd1eb800-746c-11eb-89d1-7d8dc6b456cf.PNG)

**How solved:**
I removed the one that took less time, mostly because the other recipe in `PartsRecipeHandler#processDensePlate` felt like the place it made most sense to leave this recipe. If you would rather I adjust its time to be what it was before, I can.

**Outcome:**
- Remove Duplicate Dense Plate Recipes

**Possible compatibility issue:**
None expected.