### PR TITLE
Adds Quality of Life Zen circuit method for adding recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -7,6 +7,7 @@ import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.RecipeBuilder;
+import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -55,6 +56,12 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder notConsumable(IIngredient ingredient) {
         this.backingBuilder.notConsumable(new CraftTweakerIngredientWrapper(ingredient));
+        return this;
+    }
+
+    @ZenMethod
+    public CTRecipeBuilder circuit(int num) {
+        this.backingBuilder.notConsumable(CraftTweakerIngredientWrapper.fromStacks(IntCircuitIngredient.getIntegratedCircuit(num)));
         return this;
     }
 


### PR DESCRIPTION
**What:**
Adds a Quality of Life method to the CraftTweaker recipe build for specifying Integrated Circuits, that are not consumed, in a recipe.

Previously, the user would have had to have added: `.notConsumable(<gregtech:meta_item_1:32766>.withTag({Configuration: 1}))` to the recipe build to get an integrated circuit of configuration 1, which is not consumed, added to the recipe. 

Now, the users can simply specify: `.circuit(1)` to achieve the same result.

An example script would be

```less
val alloy as RecipeMap = RecipeMap.getByName("alloy_smelter");

alloy.recipeBuilder()
    .inputs(<minecraft:cobblestone>)
    .circuit(4)
    .outputs(<minecraft:stone>)
    .duration(20).EUt(20).buildAndRegister();
```


**How solved:**
Adds a new `ZenMethod` to the CraftTweaker Recipe Builder which takes an input of the circuit configuration number and adds a non-consumed circuit of that configuration to the recipe

**Outcome:**
Adds a Quality of Life parameter for specifying Integrated Circuits in CT Recipe Additions. Now use `.circuit(Configuration number)`.

**Additional info:**
From the example script provided above:

![2021-02-21_19 38 21](https://user-images.githubusercontent.com/31759736/108650714-71911680-747d-11eb-8674-8e46b7d939a3.png)

![2021-02-21_19 38 26](https://user-images.githubusercontent.com/31759736/108650725-78b82480-747d-11eb-9479-1c476297d402.png)


**Possible compatibility issue:**
None expected, as this is a new parameter on the Recipe Builder and the old functionality still exists.


