### PR TITLE
Recipe Properties

### DIFF
--- a/src/main/java/gregtech/api/recipes/DefaultRecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/DefaultRecipeProperty.java
@@ -1,0 +1,21 @@
+package gregtech.api.recipes;
+
+import net.minecraft.client.Minecraft;
+
+/*
+    This Class is used to deal with cases where there was no Recipe Property provided
+ */
+public class DefaultRecipeProperty extends RecipeProperty {
+
+    public DefaultRecipeProperty() {
+    }
+
+    public void drawInfo(Minecraft mc, int x, int y, int color) {
+        mc.fontRenderer.drawString("", x, y, color);
+    }
+
+    @Override
+    public RecipeProperty getRecipeProperty() {
+        return this;
+    }
+}

--- a/src/main/java/gregtech/api/recipes/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/RecipeProperty.java
@@ -1,0 +1,81 @@
+package gregtech.api.recipes;
+
+import net.minecraft.client.Minecraft;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class RecipeProperty<T> {
+
+    protected final Object value;
+    protected final String key;
+    protected RecipeProperty<T> defaultProperty;
+    private static List<RecipeProperty> propertyList = new ArrayList<>();
+
+    public RecipeProperty(RecipeProperty<T> property, Object value) {
+        this.defaultProperty = property;
+        this.key = null;
+        this.value = value;
+        addProperty(this);
+    }
+
+    public RecipeProperty(String key, Object value) {
+        this.key = key;
+        this.value = value;
+        Map<String, Object> prop = new HashMap<String, Object>();
+        prop.put(key, value);
+        List<RecipeProperty> propList = makeProperties(prop);
+        propList.forEach(this::addProperty);
+    }
+
+    //Called for the DefaultRecipeProperty, which will never use the value for any display
+    public RecipeProperty() {
+        this.key = "";
+        this.value = null;
+    }
+
+    //Used to Transform the old Map<String, Object> parameter for Properties into the new format
+    public static List<RecipeProperty> makeProperties(Map<String, Object> recipePropertiesOld) {
+        List<RecipeProperty> appliedProperties = new ArrayList<>();
+
+        if(recipePropertiesOld.isEmpty()) {
+            appliedProperties.add(new DefaultRecipeProperty());
+        }
+        else {
+            for(Map.Entry<String, Object> entry : recipePropertiesOld.entrySet()) {
+                RecipeProperty property = Recipe.getPropertyByKey(entry.getKey());
+                if(property != null) {
+                    appliedProperties.add(property);
+                }
+            }
+        }
+
+        return appliedProperties;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public static List<RecipeProperty> getPropertyList() {
+        return propertyList;
+    }
+
+    public RecipeProperty getRecipeProperty() {
+        return null;
+    }
+
+    public void addProperty(RecipeProperty property) {
+        propertyList.add(property);
+    }
+
+    public abstract void drawInfo(Minecraft mc, int x, int y, int color);
+
+
+}

--- a/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
@@ -1,13 +1,15 @@
 package gregtech.api.recipes.builders;
 
-import com.google.common.collect.ImmutableMap;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.ValidationResult;
+import gregtech.common.properties.TemperatureProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Collections;
 
 public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
 
@@ -51,8 +53,8 @@ public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
             new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                ImmutableMap.of("blast_furnace_temperature", blastFurnaceTemp),
-                duration, EUt, hidden));
+                    Collections.singletonList(new TemperatureProperty("blast_furnace_temperature", blastFurnaceTemp)),
+                    duration, EUt, hidden));
     }
 
     @Override

--- a/src/main/java/gregtech/common/properties/TemperatureProperty.java
+++ b/src/main/java/gregtech/common/properties/TemperatureProperty.java
@@ -1,0 +1,41 @@
+package gregtech.common.properties;
+
+import gregtech.api.recipes.RecipeProperty;
+import gregtech.common.blocks.BlockWireCoil.CoilType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+
+public class TemperatureProperty extends RecipeProperty {
+
+    private String key = "blast_furnace_temperature";
+
+    public TemperatureProperty(RecipeProperty property, Object value) {
+        super(property, value);
+    }
+
+    public TemperatureProperty(String key, Object value) {
+        super(key, value);
+    }
+
+    @Override
+    public void drawInfo(Minecraft mc, int x, int y, int color) {
+        mc.fontRenderer.drawString(I18n.format("gregtech.recipe." + key,
+                value, getCoilForTemperature()), x, y, color);
+
+    }
+
+    private String getCoilForTemperature() {
+        for(CoilType coil : CoilType.values()) {
+            if((Integer) this.value <= coil.getCoilTemperature()) {
+                return coil.getMaterial().getLocalizedName();
+            }
+        }
+
+        return "";
+    }
+
+    @Override
+    public RecipeProperty getRecipeProperty() {
+        return this;
+    }
+}

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -5,6 +5,7 @@ import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.RecipeProperty;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.integration.jei.utils.JEIHelpers;
 import mezz.jei.api.ingredients.IIngredients;
@@ -115,9 +116,8 @@ public class GTRecipeWrapper implements IRecipeWrapper {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
         minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), JEIHelpers.getMinTierForVoltage(recipe.getEUt())), 0, yPosition += lineHeight, 0x111111);
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += lineHeight, 0x111111);
-        for (String propertyKey : recipe.getPropertyKeys()) {
-            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe." + propertyKey,
-                recipe.<Object>getProperty(propertyKey)), 0, yPosition += lineHeight, 0x111111);
+        for(RecipeProperty property : recipe.getRecipeProperties()) {
+            property.drawInfo(minecraft, 0, yPosition += lineHeight, 0x111111);
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2883,7 +2883,7 @@ gregtech.recipe.duration=Duration: %.1f secs
 gregtech.recipe.amperage=Amperage: %d
 gregtech.recipe.not_consumed=Not consumed in process
 gregtech.recipe.chance=Chance: %s%% +%s%%/tier
-gregtech.recipe.blast_furnace_temperature=Temperature: %dK
+gregtech.recipe.blast_furnace_temperature=Temperature: %dK (%s)
 gregtech.recipe.eu_to_start=Energy To Start: %dEU
 
 gregtech.fluid.click_to_fill=§7Click with a empty fluid container to fill it from tank.

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2819,7 +2819,7 @@ gregtech.recipe.duration=Длительность: %.1f сек.
 gregtech.recipe.amperage=Сила тока: %d
 gregtech.recipe.not_consumed=Не расходуется
 gregtech.recipe.chance=Шанс: %s%% +%s%%/уровень
-gregtech.recipe.blast_furnace_temperature=Температура: %dK
+gregtech.recipe.blast_furnace_temperature=Температура: %dK (%s)
 gregtech.recipe.eu_to_start=Энергия для запуска: %dEU
 
 gregtech.fluid.click_to_fill=§7Нажмите с пустым контейнером для жидкости, чтобы заполнить его из бака.

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2798,7 +2798,7 @@ gregtech.recipe.duration=耗时: %.1f 秒
 gregtech.recipe.amperage=电流: %d
 gregtech.recipe.not_consumed=不在加工时消耗
 gregtech.recipe.chance=出产概率: %s%% +%s%%/tier
-gregtech.recipe.blast_furnace_temperature=温度: %d K
+gregtech.recipe.blast_furnace_temperature=温度: %d K (%s)
 gregtech.recipe.eu_to_start=启动耗电: %d EU
 
 gregtech.fluid.click_to_fill=§7手持空的流体容器点击储罐以取走流体.


### PR DESCRIPTION
**What:**
This is an attempt to update PR #1371 as it has gone stale, and I could use the implementation for SoG for the Fusion Reactor.

I have attempted to implement the feedback present in that PR, but I feel like I went somewhat in circles, and so could use some feedback on the implementation.

**How solved:**

I have updated `Recipe` to have a new constructor which takes a `RecipeProperty` List, which offers the ability for multiple properties to be applied to a recipe. The old constructor will have the provided `Map<String, Object>` converted into a `RecipeProperty` of the appropriate type, of which there are two at the moment.

`DefaultRecipeProperty`, which does nothing to the display in JEI, and is used to cover cases where an empty Map was passed into Recipe.

`TemperatureProperty`, which is used to deal with the EBF's `blast_furnace_temperature` and get the corresponding coil level.

I did not implement a Property for the Fusion Reactor, as GTCE currently does not implement anything related to the fusion reactor, which is instead done by addon mods, and so I left the addon mods to write their own `EUToStartProperty`.

I could not find any other properties that needed implementing in based GTCE, besides the ones for the Amplifier, which currently does not look to be implemented in GTCE.

The `RecipeProperties` themselves can be created through a String and Object for the ability to covert the old Map implementation, but can also be created in other ways.

**Outcome:**
Creates Recipe Properties, and implements a Recipe Property for the Electronic Blast Furnace

**Additional info:**
![2021-02-22_19 40 44](https://user-images.githubusercontent.com/31759736/108796423-fba4b200-7545-11eb-918b-6d8a61fb463d.png)


**Possible compatibility issue:**
The old properties should be compatible, and only new API classes were created other than that.