### PR TITLE
Remap MCP Mappings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,6 +118,10 @@ repositories {
         name = "CraftTweaker Maven"
         setUrl("https://maven.blamejared.com/")
     }
+    maven {
+        name = "CCL Maven New"
+        setUrl("https://minecraft.curseforge.com/api/maven")
+    }
 }
 
 dependencies {
@@ -125,8 +129,8 @@ dependencies {
         isTransitive = false
     }
     "deobfCompile"("codechicken:ChickenASM:$shortVersion-$chickenasmVersion")
-    "deobfCompile"("codechicken:CodeChickenLib:$mcVersion-$cclVersion:universal")
-    "deobfCompile"("codechicken:ForgeMultipart:$mcVersion-$multipartVersion:universal")
+    "deobfCompile"("codechicken-lib-1-8:CodeChickenLib-$mcVersion:$cclVersion:universal")
+    "deobfCompile"("forge-multipart-cbe:ForgeMultipart-$mcVersion:$multipartVersion:universal")
     "deobfCompile"("CraftTweaker2:CraftTweaker2-MC$strippedVersion-Main:$crafttweakerVersion")
     "deobfCompile"("mezz.jei:jei_$mcVersion:$jeiVersion")
     "deobfCompile"("mcjty.theoneprobe:TheOneProbe-$shortVersion:$shortVersion-$topVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,9 +83,10 @@ fun minecraft(configure: UserBaseExtension.() -> Unit) = project.configure(confi
 
 minecraft {
     version = mcFullVersion
-    mappings = "snapshot_20170928"
+    mappings = "stable_39"
     runDir = "run"
-    isUseDepAts = true
+    makeObfSourceJar = false
+    //isUseDepAts = true
 }
 
 repositories {
@@ -124,8 +125,8 @@ dependencies {
         isTransitive = false
     }
     "deobfCompile"("codechicken:ChickenASM:$shortVersion-$chickenasmVersion")
-    "deobfCompile"("codechicken:CodeChickenLib:$mcVersion-$cclVersion:deobf")
-    "deobfCompile"("codechicken:ForgeMultipart:$mcVersion-$multipartVersion:deobf")
+    "deobfCompile"("codechicken:CodeChickenLib:$mcVersion-$cclVersion:universal")
+    "deobfCompile"("codechicken:ForgeMultipart:$mcVersion-$multipartVersion:universal")
     "deobfCompile"("CraftTweaker2:CraftTweaker2-MC$strippedVersion-Main:$crafttweakerVersion")
     "deobfCompile"("mezz.jei:jei_$mcVersion:$jeiVersion")
     "deobfCompile"("mcjty.theoneprobe:TheOneProbe-$shortVersion:$shortVersion-$topVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,8 +85,7 @@ minecraft {
     version = mcFullVersion
     mappings = "stable_39"
     runDir = "run"
-    makeObfSourceJar = false
-    //isUseDepAts = true
+    isUseDepAts = true
 }
 
 repositories {

--- a/src/main/java/gregtech/api/block/BuiltInRenderBlock.java
+++ b/src/main/java/gregtech/api/block/BuiltInRenderBlock.java
@@ -11,7 +11,7 @@ public abstract class BuiltInRenderBlock extends BlockCustomParticle {
     }
 
     @Override
-    public BlockRenderLayer getBlockLayer() {
+    public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
     }
 

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -76,7 +76,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         setSoundType(SoundType.METAL);
         setHardness(6.0f);
         setResistance(6.0f);
-        setUnlocalizedName("unnamed");
+        setTranslationKey("unnamed");
         setHarvestLevel("wrench", 1);
         setDefaultState(getDefaultState().withProperty(OPAQUE, true));
     }
@@ -256,7 +256,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         NBTTagCompound tagCompound = new NBTTagCompound();
         metaTileEntity.writeItemStackData(tagCompound);
         //only set item tag if it's not empty, so newly created items will stack with dismantled
-        if (!tagCompound.hasNoTags())
+        if (!tagCompound.isEmpty())
             itemStack.setTagCompound(tagCompound);
         drops.add(itemStack);
         metaTileEntity.getDrops(drops, harvesters.get());

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -35,7 +35,7 @@ public class MachineItemBlock extends ItemBlock {
     }
 
     @Override
-    public String getUnlocalizedName(ItemStack stack) {
+    public String getTranslationKey(ItemStack stack) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(stack);
         return metaTileEntity == null ? "unnamed" : metaTileEntity.getMetaName();
     }
@@ -57,7 +57,7 @@ public class MachineItemBlock extends ItemBlock {
             return GTValues.MODID;
         }
         ResourceLocation metaTileEntityId = metaTileEntity.metaTileEntityId;
-        return metaTileEntityId.getResourceDomain();
+        return metaTileEntityId.getNamespace();
     }
 
     @Nullable

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -121,15 +121,15 @@ public class RecipeLogicSteam extends AbstractRecipeLogic {
                 .getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(ventingBlockPos), EntitySelectors.CAN_AI_TARGET)
                 .forEach(entity -> entity.attackEntityFrom(DamageSources.getHeatDamage(), 6.0f));
             WorldServer world = (WorldServer) metaTileEntity.getWorld();
-            double posX = machinePos.getX() + 0.5 + ventingSide.getFrontOffsetX() * 0.6;
-            double posY = machinePos.getY() + 0.5 + ventingSide.getFrontOffsetY() * 0.6;
-            double posZ = machinePos.getZ() + 0.5 + ventingSide.getFrontOffsetZ() * 0.6;
+            double posX = machinePos.getX() + 0.5 + ventingSide.getXOffset() * 0.6;
+            double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
+            double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
 
             world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
                 7 + world.rand.nextInt(3),
-                ventingSide.getFrontOffsetX() / 2.0,
-                ventingSide.getFrontOffsetY() / 2.0,
-                ventingSide.getFrontOffsetZ() / 2.0, 0.1);
+                ventingSide.getXOffset() / 2.0,
+                ventingSide.getYOffset() / 2.0,
+                ventingSide.getZOffset() / 2.0, 0.1);
             world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
             setNeedsVenting(false);
         } else if (!ventingStuck) {

--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -93,7 +93,7 @@ public interface ICoverable {
                     } else {
                         REVERSE_HORIZONTAL_ROTATION.apply(backTranslation);
                     }
-                    backTranslation.translate(-sideFacing.getFrontOffsetX(), -sideFacing.getFrontOffsetY(), -sideFacing.getFrontOffsetZ());
+                    backTranslation.translate(-sideFacing.getXOffset(), -sideFacing.getYOffset(), -sideFacing.getZOffset());
                     coverBehavior.renderCover(renderState, backTranslation, coverPipeline, plateBox, layer);
                 }
             }

--- a/src/main/java/gregtech/api/items/armor/ArmorRenderHooks.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorRenderHooks.java
@@ -65,7 +65,7 @@ public class ArmorRenderHooks {
 
     private static ResourceLocation getArmorTexture(EntityLivingBase entity, ItemStack itemStack, EntityEquipmentSlot slot, String type) {
         ResourceLocation registryName = itemStack.getItem().getRegistryName();
-        String s1 = String.format("%s:textures/models/armor/%s_layer_%d%s.png", registryName.getResourceDomain(), registryName.getResourcePath(),
+        String s1 = String.format("%s:textures/models/armor/%s_layer_%d%s.png", registryName.getNamespace(), registryName.getPath(),
             (isLegSlot(slot) ? 2 : 1), type == null ? "" : String.format("_%s", type));
         return new ResourceLocation(ForgeHooksClient.getArmorTexture(entity, itemStack, s1, slot, type));
     }

--- a/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
@@ -104,7 +104,7 @@ public class ElectricStats implements IItemComponent, IItemCapabilityProvider, I
             NBTTagCompound tagCompound = itemStack.getTagCompound();
             if(tagCompound != null) {
                 tagCompound.removeTag("DischargeMode");
-                if(tagCompound.hasNoTags()) {
+                if(tagCompound.isEmpty()) {
                     itemStack.setTagCompound(null);
                 }
             }

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -87,7 +87,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     protected final short metaItemOffset;
 
     public MetaItem(short metaItemOffset) {
-        setUnlocalizedName("meta_item");
+        setTranslationKey("meta_item");
         setHasSubtypes(true);
         this.metaItemOffset = metaItemOffset;
         META_ITEMS.add(this);

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -230,7 +230,7 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     public final String getMetaName() {
-        return String.format("%s.machine.%s", metaTileEntityId.getResourceDomain(), metaTileEntityId.getResourcePath());
+        return String.format("%s.machine.%s", metaTileEntityId.getNamespace(), metaTileEntityId.getPath());
     }
 
     public final String getMetaFullName() {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -110,7 +110,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         //try to lookup by different registry IDs
         if (registeredModIDs == null) {
             registeredModIDs = registry.getKeys().stream()
-                .map(ResourceLocation::getResourceDomain)
+                .map(ResourceLocation::getNamespace)
                 .distinct().collect(Collectors.toList());
             registeredModIDs.remove(GTValues.MODID);
         }

--- a/src/main/java/gregtech/api/model/AbstractBlockModelFactory.java
+++ b/src/main/java/gregtech/api/model/AbstractBlockModelFactory.java
@@ -41,18 +41,18 @@ public abstract class AbstractBlockModelFactory implements ResourcePackHook.IRes
 
     @Override
     public boolean resourceExists(ResourceLocation location) {
-        return location.getResourceDomain().equals(GTValues.MODID)
-            && location.getResourcePath().startsWith("blockstates/" + blockNamePrefix)
-            && !location.getResourcePath().contains(".mcmeta");
+        return location.getNamespace().equals(GTValues.MODID)
+            && location.getPath().startsWith("blockstates/" + blockNamePrefix)
+            && !location.getPath().contains(".mcmeta");
     }
 
     @Override
     public InputStream getInputStream(ResourceLocation location) throws IOException {
-        String resourcePath = location.getResourcePath(); // blockstates/compressed_1.json
+        String resourcePath = location.getPath(); // blockstates/compressed_1.json
         resourcePath = resourcePath.substring(0, resourcePath.length() - 5); //remove .json
         resourcePath = resourcePath.substring(12); //remove blockstates/
         if (resourcePath.startsWith(blockNamePrefix)) {
-            Block block = Block.REGISTRY.getObject(new ResourceLocation(location.getResourceDomain(), resourcePath));
+            Block block = Block.REGISTRY.getObject(new ResourceLocation(location.getNamespace(), resourcePath));
             if (block != null && block != Blocks.AIR) {
                 return FileUtility.writeInputStream(fillSample(block, blockStateSample));
             }

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -54,7 +54,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
     public BlockPipe() {
         super(net.minecraft.block.material.Material.IRON);
-        setUnlocalizedName("pipe");
+        setTranslationKey("pipe");
         setCreativeTab(GregTechAPI.TAB_GREGTECH);
         setSoundType(SoundType.METAL);
         setHardness(2.0f);

--- a/src/main/java/gregtech/api/render/CTCubeRenderer.java
+++ b/src/main/java/gregtech/api/render/CTCubeRenderer.java
@@ -63,7 +63,7 @@ public class CTCubeRenderer implements IIconRegister {
             TextureAtlasSprite sideSprite = ctSprites[resultTextureMask];
             Textures.renderFace(renderState, translation, pipeline, renderSide, Cuboid6.full, sideSprite);
             Matrix4 backTranslation = translation.copy();
-            backTranslation.translate(renderSide.getFrontOffsetX(), renderSide.getFrontOffsetY() * 0.999, renderSide.getFrontOffsetZ());
+            backTranslation.translate(renderSide.getXOffset(), renderSide.getYOffset() * 0.999, renderSide.getZOffset());
             int backFaceTextureMask;
             if (renderSide.getAxis().isHorizontal()) {
                 backFaceTextureMask = resultTextureMask & ~(TextureDirection.RIGHT | TextureDirection.LEFT);

--- a/src/main/java/gregtech/api/render/LargeTurbineRenderer.java
+++ b/src/main/java/gregtech/api/render/LargeTurbineRenderer.java
@@ -45,15 +45,15 @@ public class LargeTurbineRenderer implements IIconRegister {
         Matrix4 cornerOffset = null;
         switch (side.getAxis()) {
             case X:
-                cornerOffset = translation.copy().translate(0.01 * side.getFrontOffsetX(), -1.0, -1.0);
+                cornerOffset = translation.copy().translate(0.01 * side.getXOffset(), -1.0, -1.0);
                 cornerOffset.scale(1.0, 3.0, 3.0);
                 break;
             case Z:
-                cornerOffset = translation.copy().translate(-1.0, -1.0, 0.01 * side.getFrontOffsetZ());
+                cornerOffset = translation.copy().translate(-1.0, -1.0, 0.01 * side.getZOffset());
                 cornerOffset.scale(3.0, 3.0, 1.0);
                 break;
             case Y:
-                cornerOffset = translation.copy().translate(-1.0, 0.01 * side.getFrontOffsetY(), -1.0);
+                cornerOffset = translation.copy().translate(-1.0, 0.01 * side.getYOffset(), -1.0);
                 cornerOffset.scale(3.0, 1.0, 3.0);
                 break;
         }

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -49,7 +49,7 @@ public class OreDictUnifier {
                 stackComparator = Collections.reverseOrder(new CustomModPriorityComparator(modPriorities));
             } else {
                 //noinspection ConstantConditions
-                Function<ItemAndMetadata, String> modIdExtractor = stack -> stack.item.getRegistryName().getResourceDomain();
+                Function<ItemAndMetadata, String> modIdExtractor = stack -> stack.item.getRegistryName().getNamespace();
                 stackComparator = Comparator.comparing(modIdExtractor);
             }
         }

--- a/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
@@ -47,7 +47,7 @@ public final class ItemAndMetadata {
 
     @Override
     public String toString() {
-        return this.item.getUnlocalizedName(toItemStack());
+        return this.item.getTranslationKey(toItemStack());
     }
 
 }

--- a/src/main/java/gregtech/api/util/BaseCreativeTab.java
+++ b/src/main/java/gregtech/api/util/BaseCreativeTab.java
@@ -25,7 +25,7 @@ public class BaseCreativeTab extends CreativeTabs {
     }
 
     @Override
-    public ItemStack getTabIconItem() {
+    public ItemStack createIcon() {
         if (iconSupplier == null) {
             GTLog.logger.error("Icon supplier was null for CreativeTab " + getTabLabel());
             return new ItemStack(Blocks.STONE);

--- a/src/main/java/gregtech/api/util/CustomModPriorityComparator.java
+++ b/src/main/java/gregtech/api/util/CustomModPriorityComparator.java
@@ -16,8 +16,8 @@ public class CustomModPriorityComparator implements Comparator<ItemAndMetadata> 
 
     @Override
     public int compare(ItemAndMetadata first, ItemAndMetadata second) {
-        String firstModId = first.item.getRegistryName().getResourceDomain();
-        String secondModId = second.item.getRegistryName().getResourceDomain();
+        String firstModId = first.item.getRegistryName().getNamespace();
+        String secondModId = second.item.getRegistryName().getNamespace();
         int firstModIndex = modPriorityList.indexOf(firstModId);
         int secondModIndex = modPriorityList.indexOf(secondModId);
         if (firstModIndex == -1 && secondModIndex == -1) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -268,7 +268,7 @@ public class GTUtility {
 
         boolean wasRemovedByPlayer = blockState.getBlock().removedByPlayer(blockState, world, pos, player, !player.capabilities.isCreativeMode);
         if(wasRemovedByPlayer) {
-            blockState.getBlock().onBlockDestroyedByPlayer(world, pos, blockState);
+            blockState.getBlock().onPlayerDestroy(world, pos, blockState);
 
             if(!world.isRemote && !player.capabilities.isCreativeMode) {
                 ItemStack stackInHand = player.getHeldItemMainhand();

--- a/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
+++ b/src/main/java/gregtech/api/util/LargeStackSizeItemStackHandler.java
@@ -39,7 +39,7 @@ public class LargeStackSizeItemStackHandler extends ItemStackHandler {
             tagCompound.setTag(BIG_STACK_SIZE_TAG_KEY, stackSizes);
 
             //fix size overflow of existing item tags
-            for (NBTBase itemBase : items.tagList) {
+            for (NBTBase itemBase : items) {
                 NBTTagCompound item = (NBTTagCompound) itemBase;
 
                 byte size = item.getByte(ITEM_COUNT_TAG_KEY);

--- a/src/main/java/gregtech/api/util/ModCompatibility.java
+++ b/src/main/java/gregtech/api/util/ModCompatibility.java
@@ -59,8 +59,8 @@ public class ModCompatibility {
 
         public boolean canHandleItemStack(ItemStack itemStack) {
             ResourceLocation registryName = Objects.requireNonNull(itemStack.getItem().getRegistryName());
-            return registryName.getResourceDomain().equals("refinedstorage") &&
-                registryName.getResourcePath().equals("pattern");
+            return registryName.getNamespace().equals("refinedstorage") &&
+                registryName.getPath().equals("pattern");
         }
 
         public ItemStack getRealItemStack(ItemStack itemStack) {
@@ -83,8 +83,8 @@ public class ModCompatibility {
 
         public boolean canHandleItemStack(ItemStack itemStack) {
             ResourceLocation registryName = Objects.requireNonNull(itemStack.getItem().getRegistryName());
-            return registryName.getResourceDomain().equals("appliedenergistics2") &&
-                registryName.getResourcePath().equals("encoded_pattern");
+            return registryName.getNamespace().equals("appliedenergistics2") &&
+                registryName.getPath().equals("encoded_pattern");
         }
 
         public ItemStack getRealItemStack(ItemStack itemStack) {

--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -92,7 +92,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         this.worldSeaLevel = world.getSeaLevel();
         this.masterEntry = searchMasterOrNull(world);
         if (masterEntry == null) {
-            Chunk primerChunk = world.getChunkFromChunkCoords(primerChunkX, primerChunkZ);
+            Chunk primerChunk = world.getChunk(primerChunkX, primerChunkZ);
             BlockPos heightSpot = findOptimalSpot(gridX, gridZ, primerChunkX, primerChunkZ);
             heightSpot = heightSpot.add(primerChunkX * 16, 0, primerChunkZ * 16);
             int masterHeight = world.getHeight(heightSpot).getY();
@@ -199,7 +199,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
     }
 
     private GTWorldGenCapability retrieveCapability(World world, int chunkX, int chunkZ) {
-        return world.getChunkFromChunkCoords(chunkX, chunkZ).getCapability(GTWorldGenCapability.CAPABILITY, null);
+        return world.getChunk(chunkX, chunkZ).getCapability(GTWorldGenCapability.CAPABILITY, null);
     }
 
     public void triggerVeinsGeneration() {

--- a/src/main/java/gregtech/common/blocks/BlockBoilerCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockBoilerCasing.java
@@ -12,7 +12,7 @@ public class BlockBoilerCasing extends VariantBlock<BlockBoilerCasing.BoilerCasi
 
     public BlockBoilerCasing() {
         super(Material.IRON);
-        setUnlocalizedName("boiler_casing");
+        setTranslationKey("boiler_casing");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockCompressed.java
+++ b/src/main/java/gregtech/common/blocks/BlockCompressed.java
@@ -24,7 +24,7 @@ public final class BlockCompressed extends DelayedStateBlock {
 
     public BlockCompressed(Material[] materials) {
         super(net.minecraft.block.material.Material.IRON);
-        setUnlocalizedName("compressed");
+        setTranslationKey("compressed");
         setHardness(5.0f);
         setResistance(10.0f);
         setCreativeTab(GregTechAPI.TAB_GREGTECH_MATERIALS);

--- a/src/main/java/gregtech/common/blocks/BlockConcrete.java
+++ b/src/main/java/gregtech/common/blocks/BlockConcrete.java
@@ -8,7 +8,7 @@ public class BlockConcrete extends StoneBlock<BlockConcrete.ConcreteVariant> {
 
     public BlockConcrete() {
         super(Material.ROCK);
-        setUnlocalizedName("concrete");
+        setTranslationKey("concrete");
         setHardness(2.0f);
         setResistance(3.0f);
         setSoundType(SoundType.STONE);

--- a/src/main/java/gregtech/common/blocks/BlockCrusherBlade.java
+++ b/src/main/java/gregtech/common/blocks/BlockCrusherBlade.java
@@ -39,7 +39,7 @@ public class BlockCrusherBlade extends Block implements ITileEntityProvider {
 
     public BlockCrusherBlade() {
         super(Material.IRON);
-        setUnlocalizedName("gt.crusher_blade");
+        setTranslationKey("gt.crusher_blade");
         setCreativeTab(GregTechAPI.TAB_GREGTECH);
         setHarvestLevel("pickaxe", 2);
         setHardness(3.0f);
@@ -99,7 +99,7 @@ public class BlockCrusherBlade extends Block implements ITileEntityProvider {
     }
 
     @Override
-    public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         if (state.getValue(ACTIVE)) {
             entityIn.attackEntityFrom(DamageSources.getCrusherDamage(), 5.0f);
             entityIn.motionY *= 0.04;

--- a/src/main/java/gregtech/common/blocks/BlockFireboxCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockFireboxCasing.java
@@ -17,7 +17,7 @@ public class BlockFireboxCasing extends VariantBlock<FireboxCasingType> {
 
     public BlockFireboxCasing() {
         super(Material.IRON);
-        setUnlocalizedName("boiler_casing");
+        setTranslationKey("boiler_casing");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -37,7 +37,7 @@ public final class BlockFrame extends BlockColored {
             net.minecraft.block.material.Material.WOOD :
             net.minecraft.block.material.Material.IRON);
         this.frameMaterial = material;
-        setUnlocalizedName("frame");
+        setTranslationKey("frame");
         setHardness(3.0f);
         setResistance(6.0f);
         setHarvestLevel(ModHandler.isMaterialWood(material) ? "axe" : "pickaxe", 1);
@@ -145,7 +145,7 @@ public final class BlockFrame extends BlockColored {
     }
 
     @Override
-    public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         entityIn.motionX = MathHelper.clamp(entityIn.motionX, -0.15, 0.15);
         entityIn.motionZ = MathHelper.clamp(entityIn.motionZ, -0.15, 0.15);
         entityIn.fallDistance = 0.0F;
@@ -161,7 +161,7 @@ public final class BlockFrame extends BlockColored {
     }
 
     @Override
-    public EnumPushReaction getMobilityFlag(IBlockState state) {
+    public EnumPushReaction getPushReaction(IBlockState state) {
         return EnumPushReaction.DESTROY;
     }
 
@@ -171,7 +171,7 @@ public final class BlockFrame extends BlockColored {
     }
 
     @Override
-    public BlockRenderLayer getBlockLayer() {
+    public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockGranite.java
+++ b/src/main/java/gregtech/common/blocks/BlockGranite.java
@@ -8,7 +8,7 @@ public class BlockGranite extends StoneBlock<BlockGranite.GraniteVariant> {
 
     public BlockGranite() {
         super(Material.ROCK);
-        setUnlocalizedName("granite");
+        setTranslationKey("granite");
         setHardness(7.0f);
         setResistance(12.0f);
         setSoundType(SoundType.STONE);

--- a/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
@@ -12,7 +12,7 @@ public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineC
 
     public BlockMachineCasing() {
         super(Material.IRON);
-        setUnlocalizedName("machine_casing");
+        setTranslationKey("machine_casing");
         setHardness(4.0f);
         setResistance(8.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockMetalCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMetalCasing.java
@@ -12,7 +12,7 @@ public class BlockMetalCasing extends VariantBlock<BlockMetalCasing.MetalCasingT
 
     public BlockMetalCasing() {
         super(Material.IRON);
-        setUnlocalizedName("metal_casing");
+        setTranslationKey("metal_casing");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockMineral.java
+++ b/src/main/java/gregtech/common/blocks/BlockMineral.java
@@ -8,7 +8,7 @@ public class BlockMineral extends StoneBlock<BlockMineral.MineralVariant> {
 
     public BlockMineral() {
         super(Material.ROCK);
-        setUnlocalizedName("mineral");
+        setTranslationKey("mineral");
         setHardness(3.0f);
         setResistance(6.0f);
         setSoundType(SoundType.STONE);

--- a/src/main/java/gregtech/common/blocks/BlockMultiblockCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMultiblockCasing.java
@@ -12,7 +12,7 @@ public class BlockMultiblockCasing extends VariantBlock<BlockMultiblockCasing.Mu
 
     public BlockMultiblockCasing() {
         super(Material.IRON);
-        setUnlocalizedName("multiblock_casing");
+        setTranslationKey("multiblock_casing");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -33,7 +33,7 @@ public class BlockOre extends BlockFalling implements IBlockOre {
 
     public BlockOre(DustMaterial material, StoneType[] allowedValues) {
         super(net.minecraft.block.material.Material.ROCK);
-        setUnlocalizedName("ore_block");
+        setTranslationKey("ore_block");
         setSoundType(SoundType.STONE);
         setHardness(3.0f);
         setResistance(5.0f);
@@ -130,7 +130,7 @@ public class BlockOre extends BlockFalling implements IBlockOre {
     }
 
     @Override
-    public BlockRenderLayer getBlockLayer() {
+    public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockTurbineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockTurbineCasing.java
@@ -12,7 +12,7 @@ public class BlockTurbineCasing extends VariantBlock<BlockTurbineCasing.TurbineC
 
     public BlockTurbineCasing() {
         super(Material.IRON);
-        setUnlocalizedName("turbine_casing");
+        setTranslationKey("turbine_casing");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockWarningSign.java
+++ b/src/main/java/gregtech/common/blocks/BlockWarningSign.java
@@ -8,7 +8,7 @@ public class BlockWarningSign extends VariantBlock<BlockWarningSign.SignType> {
 
     public BlockWarningSign() {
         super(Material.IRON);
-        setUnlocalizedName("warning_sign");
+        setTranslationKey("warning_sign");
         setHardness(2.0f);
         setResistance(3.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -23,7 +23,7 @@ public class BlockWireCoil extends VariantBlock<BlockWireCoil.CoilType> {
 
     public BlockWireCoil() {
         super(net.minecraft.block.material.Material.IRON);
-        setUnlocalizedName("wire_coil");
+        setTranslationKey("wire_coil");
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);

--- a/src/main/java/gregtech/common/blocks/StoneItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/StoneItemBlock.java
@@ -26,9 +26,9 @@ public class StoneItemBlock<R extends Enum<R> & IStringSerializable, T extends S
     }
 
     @Override
-    public String getUnlocalizedName(ItemStack stack) {
+    public String getTranslationKey(ItemStack stack) {
         IBlockState blockState = getBlockState(stack);
-        return super.getUnlocalizedName(stack) + '.' +
+        return super.getTranslationKey(stack) + '.' +
             genericBlock.getVariant(blockState).getName() + "." +
             genericBlock.getChiselingVariant(blockState).getName();
     }

--- a/src/main/java/gregtech/common/blocks/VariantBlock.java
+++ b/src/main/java/gregtech/common/blocks/VariantBlock.java
@@ -66,11 +66,11 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, ITooltipFlag advanced) {
         //tier less tooltip like: tile.turbine_casing.tooltip
-        String unlocalizedVariantTooltip = getUnlocalizedName() + ".tooltip";
+        String unlocalizedVariantTooltip = getTranslationKey() + ".tooltip";
         if (I18n.hasKey(unlocalizedVariantTooltip))
             tooltip.addAll(Arrays.asList(I18n.format(unlocalizedVariantTooltip).split("/n")));
         //item specific tooltip: tile.turbine_casing.bronze_gearbox.tooltip
-        String unlocalizedTooltip = stack.getUnlocalizedName() + ".tooltip";
+        String unlocalizedTooltip = stack.getTranslationKey() + ".tooltip";
         if (I18n.hasKey(unlocalizedTooltip))
             tooltip.addAll(Arrays.asList(I18n.format(unlocalizedTooltip).split("/n")));
     }

--- a/src/main/java/gregtech/common/blocks/VariantItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/VariantItemBlock.java
@@ -26,8 +26,8 @@ public class VariantItemBlock<R extends Enum<R> & IStringSerializable, T extends
     }
 
     @Override
-    public String getUnlocalizedName(ItemStack stack) {
-        return super.getUnlocalizedName(stack) + '.' + genericBlock.getState(getBlockState(stack)).getName();
+    public String getTranslationKey(ItemStack stack) {
+        return super.getTranslationKey(stack) + '.' + genericBlock.getState(getBlockState(stack)).getName();
     }
 
 }

--- a/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
@@ -33,7 +33,7 @@ public class BlockFoam extends BlockColored {
 
     public BlockFoam(boolean isReinforced) {
         super(Material.SAND);
-        setUnlocalizedName(isReinforced ? "gt.reinforced_foam" : "gt.foam");
+        setTranslationKey(isReinforced ? "gt.reinforced_foam" : "gt.foam");
         setSoundType(SoundType.SNOW);
         setResistance(0.3f);
         setHardness(0.5f);
@@ -70,7 +70,7 @@ public class BlockFoam extends BlockColored {
     }
 
     @Override
-    public EnumPushReaction getMobilityFlag(IBlockState state) {
+    public EnumPushReaction getPushReaction(IBlockState state) {
         return EnumPushReaction.DESTROY;
     }
 
@@ -86,7 +86,7 @@ public class BlockFoam extends BlockColored {
     }
 
     @Override
-    public BlockRenderLayer getBlockLayer() {
+    public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
     }
 

--- a/src/main/java/gregtech/common/blocks/foam/BlockPetrifiedFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockPetrifiedFoam.java
@@ -13,7 +13,7 @@ public class BlockPetrifiedFoam extends BlockColored {
 
     public BlockPetrifiedFoam(boolean isReinforced) {
         super(Material.ROCK);
-        setUnlocalizedName(isReinforced ? "gt.reinforced_stone" : "gt.petrified_foam");
+        setTranslationKey(isReinforced ? "gt.reinforced_stone" : "gt.petrified_foam");
         setSoundType(SoundType.SNOW);
         setResistance(isReinforced ? 4.0f : 16.0f);
         setHardness(isReinforced ? 1.0f : 4.0f);

--- a/src/main/java/gregtech/common/blocks/modelfactories/BakedModelHandler.java
+++ b/src/main/java/gregtech/common/blocks/modelfactories/BakedModelHandler.java
@@ -117,7 +117,7 @@ public class BakedModelHandler {
 
         @Override
         public ItemOverrideList getOverrides() {
-            return new ItemOverrideList();
+            return ItemOverrideList.NONE;
         }
 
         @Override

--- a/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRock.java
+++ b/src/main/java/gregtech/common/blocks/surfacerock/BlockSurfaceRock.java
@@ -31,7 +31,7 @@ public abstract class BlockSurfaceRock extends Block {
         super(net.minecraft.block.material.Material.ROCK);
         setHardness(1.5f);
         setSoundType(SoundType.STONE);
-        setUnlocalizedName("surface_rock");
+        setTranslationKey("surface_rock");
         setLightOpacity(1);
     }
 

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregLeaves.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregLeaves.java
@@ -30,7 +30,7 @@ public class BlockGregLeaves extends BlockLeaves {
             .withProperty(VARIANT, LogVariant.RUBBER_WOOD)
             .withProperty(CHECK_DECAY, Boolean.TRUE)
             .withProperty(DECAYABLE, Boolean.TRUE));
-        setUnlocalizedName("gt.leaves");
+        setTranslationKey("gt.leaves");
         this.setCreativeTab(GregTechAPI.TAB_GREGTECH);
         this.leavesFancy = true;
     }

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregLog.java
@@ -30,7 +30,7 @@ public class BlockGregLog extends BlockLog {
             .withProperty(VARIANT, LogVariant.RUBBER_WOOD)
             .withProperty(LOG_AXIS, BlockLog.EnumAxis.Y)
             .withProperty(NATURAL, false));
-        setUnlocalizedName("gt.log");
+        setTranslationKey("gt.log");
         this.setCreativeTab(GregTechAPI.TAB_GREGTECH);
     }
 

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregSapling.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregSapling.java
@@ -36,7 +36,7 @@ public class BlockGregSapling extends BlockBush implements IGrowable, IPlantable
         this.setDefaultState(this.blockState.getBaseState()
             .withProperty(VARIANT, LogVariant.RUBBER_WOOD)
             .withProperty(STAGE, 0));
-        setUnlocalizedName("gt.sapling");
+        setTranslationKey("gt.sapling");
         setCreativeTab(GregTechAPI.TAB_GREGTECH);
         setHardness(0.0F);
         setSoundType(SoundType.PLANT);

--- a/src/main/java/gregtech/common/items/behaviors/ColorSprayBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/ColorSprayBehaviour.java
@@ -66,7 +66,7 @@ public class ColorSprayBehaviour extends AbstractUsableBehaviour {
     @Override
     public void addInformation(ItemStack itemStack, List<String> lines) {
         int remainingUses = getUsesLeft(itemStack);
-        lines.add(I18n.format("behaviour.paintspray." + this.color.getUnlocalizedName() + ".tooltip"));
+        lines.add(I18n.format("behaviour.paintspray." + this.color.getTranslationKey() + ".tooltip"));
         lines.add(I18n.format("behaviour.paintspray.uses", remainingUses));
     }
 }

--- a/src/main/java/gregtech/common/items/behaviors/CrowbarBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/CrowbarBehaviour.java
@@ -68,7 +68,7 @@ public class CrowbarBehaviour implements IItemBehaviour {
             for (ItemStack drops : blockState.getBlock().getDrops(world, blockPos, blockState, 0)) {
                 Block.spawnAsEntity(world, blockPos, drops);
             }
-            blockState.getBlock().onBlockDestroyedByPlayer(world, blockPos, blockState);
+            blockState.getBlock().onPlayerDestroy(world, blockPos, blockState);
             blockState.getBlock().onBlockHarvested(world, blockPos, blockState, player);
             blockState.getBlock().breakBlock(world, blockPos, blockState);
             world.setBlockToAir(blockPos);

--- a/src/main/java/gregtech/common/items/behaviors/FacadeItem.java
+++ b/src/main/java/gregtech/common/items/behaviors/FacadeItem.java
@@ -46,7 +46,7 @@ public class FacadeItem implements IItemNameProvider, ISubItemHandler {
     public String getItemSubType(ItemStack itemStack) {
         ItemStack facadeStack = getFacadeStack(itemStack);
         ResourceLocation registryName = Objects.requireNonNull(facadeStack.getItem().getRegistryName());
-        return String.format("%s:%s@%d", registryName.getResourceDomain(), registryName.getResourcePath(), Items.FEATHER.getDamage(facadeStack));
+        return String.format("%s:%s@%d", registryName.getNamespace(), registryName.getPath(), Items.FEATHER.getDamage(facadeStack));
     }
 
     public static void setFacadeStack(ItemStack itemStack, ItemStack facadeStack) {

--- a/src/main/java/gregtech/common/items/potions/BlockPotionFluid.java
+++ b/src/main/java/gregtech/common/items/potions/BlockPotionFluid.java
@@ -21,7 +21,7 @@ class BlockPotionFluid extends BlockFluidFinite {
     }
 
     @Override
-    public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         if (!(entityIn instanceof EntityLivingBase) ||
             worldIn.getTotalWorldTime() % 20 != 0) return;
         EntityLivingBase entity = (EntityLivingBase) entityIn;

--- a/src/main/java/gregtech/common/items/potions/PotionFluids.java
+++ b/src/main/java/gregtech/common/items/potions/PotionFluids.java
@@ -38,14 +38,14 @@ public class PotionFluids {
     public static void initPotionFluids() {
         MinecraftForge.EVENT_BUS.register(new PotionFluids());
         for (ResourceLocation registryName : ForgeRegistries.POTION_TYPES.getKeys()) {
-            if (registryName.getResourceDomain().equals("minecraft") &&
-                registryName.getResourcePath().equals("empty")) continue;
+            if (registryName.getNamespace().equals("minecraft") &&
+                registryName.getPath().equals("empty")) continue;
 
             PotionType potion = ForgeRegistries.POTION_TYPES.getValue(registryName);
             Preconditions.checkNotNull(potion);
             Fluid potionFluid;
             if (potion != PotionTypes.WATER) {
-                String fluidName = String.format("potion.%s.%s", registryName.getResourceDomain(), registryName.getResourcePath());
+                String fluidName = String.format("potion.%s.%s", registryName.getNamespace(), registryName.getPath());
                 potionFluid = new Fluid(fluidName, AUTO_GENERATED_FLUID_TEXTURE, AUTO_GENERATED_FLUID_TEXTURE) {
                     @Override
                     public String getUnlocalizedName() {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -106,9 +106,9 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
 
     private void addToInventoryOrDropItems(List<ItemStack> drops) {
         EnumFacing outputFacing = getOutputFacing();
-        double itemSpawnX = getPos().getX() + 0.5 + outputFacing.getFrontOffsetX();
-        double itemSpawnY = getPos().getX() + 0.5 + outputFacing.getFrontOffsetX();
-        double itemSpawnZ = getPos().getX() + 0.5 + outputFacing.getFrontOffsetX();
+        double itemSpawnX = getPos().getX() + 0.5 + outputFacing.getXOffset();
+        double itemSpawnY = getPos().getX() + 0.5 + outputFacing.getYOffset();
+        double itemSpawnZ = getPos().getX() + 0.5 + outputFacing.getZOffset();
         for(ItemStack itemStack : drops) {
             ItemStack remainStack = ItemHandlerHelper.insertItemStacked(exportItems, itemStack, false);
             if(!remainStack.isEmpty()) {
@@ -124,7 +124,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
         boolean result = blockState.getBlock().removedByPlayer(blockState, getWorld(), blockPos, entityPlayer, true);
         if(result) {
             getWorld().playEvent(null, 2001, blockPos, Block.getStateId(blockState));
-            blockState.getBlock().onBlockDestroyedByPlayer(getWorld(), blockPos, blockState);
+            blockState.getBlock().onPlayerDestroy(getWorld(), blockPos, blockState);
 
             BlockUtility.startCaptureDrops();
             blockState.getBlock().harvestBlock(getWorld(), entityPlayer, blockPos, blockState, tileEntity, ItemStack.EMPTY);

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -533,10 +533,10 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
             ItemStack itemStack = itemImportInventory.getStackInSlot(slotIndex);
             int burnTime = (int) Math.ceil(TileEntityFurnace.getItemBurnTime(itemStack) / (50.0 * boilerType.fuelConsumptionMultiplier * getThrottleMultiplier()));
             if (burnTime > 0) {
-                ItemFuelInfo itemFuelInfo = (ItemFuelInfo) fuels.get(itemStack.getUnlocalizedName());
+                ItemFuelInfo itemFuelInfo = (ItemFuelInfo) fuels.get(itemStack.getTranslationKey());
                 if (itemFuelInfo == null) {
                     itemFuelInfo = new ItemFuelInfo(itemStack, itemStack.getCount(), itemCapacity, 1, itemStack.getCount() * burnTime);
-                    fuels.put(itemStack.getUnlocalizedName(), itemFuelInfo);
+                    fuels.put(itemStack.getTranslationKey(), itemFuelInfo);
                 }
                 else {
                     itemFuelInfo.addFuelRemaining(itemStack.getCount());

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -344,7 +344,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
         Textures.PRIMITIVE_BLAST_FURNACE_OVERLAY.render(renderState, translation, pipeline, getFrontFacing(), isActive());
         if (isActive() && isStructureFormed()) {
             EnumFacing back = getFrontFacing().getOpposite();
-            Matrix4 offset = translation.copy().translate(back.getFrontOffsetX(), -0.3, back.getFrontOffsetZ());
+            Matrix4 offset = translation.copy().translate(back.getXOffset(), -0.3, back.getZOffset());
             TextureAtlasSprite sprite = TextureUtils.getBlockTexture("lava_still");
             renderState.brightness = 0xF000F0;
             renderState.colour = 0xFFFFFFFF;

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -104,7 +104,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
         boolean damageOnLossless = ConfigHolder.doLosslessWiresDamage;
         if (!worldIn.isRemote && insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -138,7 +138,7 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
     }
 
     @Override
-    public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
         if (entityIn instanceof EntityLivingBase && entityIn.world.getWorldTime() % 20 == 0L) {
             EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
             FluidPipeNet pipeNet = getWorldPipeNet(worldIn).getNetFromPos(pos);

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
@@ -65,12 +65,12 @@ public class TileEntityFluidPipe extends TileEntityMaterialPipeBase<FluidPipeTyp
     public static void spawnParticles(World worldIn, BlockPos pos, EnumFacing direction, EnumParticleTypes particleType, int particleCount, Random rand) {
         for (int i = 0; i < particleCount; i++) {
             worldIn.spawnParticle(particleType,
-                pos.getX() + 0.5 - direction.getFrontOffsetX() / 1.8,
-                pos.getY() + 0.5 - direction.getFrontOffsetY() / 1.8,
-                pos.getZ() + 0.5 - direction.getFrontOffsetZ() / 1.8,
-                direction.getFrontOffsetX() * 0.2 + rand.nextDouble() * 0.1,
-                direction.getFrontOffsetY() * 0.2 + rand.nextDouble() * 0.1,
-                direction.getFrontOffsetZ() * 0.2 + rand.nextDouble() * 0.1);
+                pos.getX() + 0.5 - direction.getXOffset() / 1.8,
+                pos.getY() + 0.5 - direction.getYOffset() / 1.8,
+                pos.getZ() + 0.5 - direction.getZOffset() / 1.8,
+                direction.getXOffset() * 0.2 + rand.nextDouble() * 0.1,
+                direction.getYOffset() * 0.2 + rand.nextDouble() * 0.1,
+                direction.getZOffset() * 0.2 + rand.nextDouble() * 0.1);
         }
     }
 }

--- a/src/main/java/gregtech/common/render/ShapeModelGenerator.java
+++ b/src/main/java/gregtech/common/render/ShapeModelGenerator.java
@@ -23,7 +23,7 @@ public class ShapeModelGenerator {
         for (int i = 0; i < 3; i++) {
             EnumFacing side = EnumFacing.VALUES[i * 2 + 1];
             Transformation rotation = Rotation.sideRotations[i * 2].at(Vector3.center);
-            Transformation translation = new Translation(side.getFrontOffsetX() * translate, side.getFrontOffsetY() * translate, side.getFrontOffsetZ() * translate);
+            Transformation translation = new Translation(side.getXOffset() * translate, side.getYOffset() * translate, side.getZOffset() * translate);
             CCModel negativeModel = originalModel.copy().apply(rotation);
             CCModel positiveModel = negativeModel.copy().apply(translation);
             result[i * 2] = negativeModel;

--- a/src/main/java/gregtech/common/worldgen/TemplateManager.java
+++ b/src/main/java/gregtech/common/worldgen/TemplateManager.java
@@ -26,7 +26,7 @@ public class TemplateManager {
             return templateMap.get(templateId);
         }
         Template template = new Template();
-        String resourcePath = "/assets/" + templateId.getResourceDomain() + "/structures/" + templateId.getResourcePath() + ".nbt";
+        String resourcePath = "/assets/" + templateId.getNamespace() + "/structures/" + templateId.getPath() + ".nbt";
         InputStream inputStream = TemplateManager.class.getResourceAsStream(resourcePath);
         if (inputStream != null) {
             try {

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -288,10 +288,10 @@ public class GTOreInfo implements IRecipeWrapper {
             if(!(entry.getValue() == weight)) {
                 //Cannot Spawn
                 if(entry.getValue() <= 0) {
-                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting_no_spawn", entry.getKey().biomeName));
+                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting_no_spawn", entry.getKey().getBiomeName()));
                 }
                 else {
-                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting", entry.getKey().biomeName, entry.getValue()));
+                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting", entry.getKey().getBiomeName(), entry.getValue()));
                 }
             }
         }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -302,7 +302,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper, SceneRenderC
             EnumRarity rarity = tooltipBlockStack.getRarity();
             for (int k = 0; k < tooltip.size(); ++k) {
                 if (k == 0) {
-                    tooltip.set(k, rarity.rarityColor + tooltip.get(k));
+                    tooltip.set(k, rarity.color + tooltip.get(k));
                 } else {
                     tooltip.set(k, TextFormatting.GRAY + tooltip.get(k));
                 }

--- a/src/main/java/gregtech/integration/jei/utils/CustomItemReturnRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/CustomItemReturnRecipeWrapper.java
@@ -47,12 +47,12 @@ public class CustomItemReturnRecipeWrapper extends ShapedOreRecipeWrapper implem
         ResourceLocation registryName = getRegistryName();
         guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
             if (slotIndex == craftOutputSlot && registryName != null) {
-                String recipeModId = registryName.getResourceDomain();
+                String recipeModId = registryName.getNamespace();
 
                 boolean modIdDifferent = false;
                 ResourceLocation itemRegistryName = ingredient.getItem().getRegistryName();
                 if (itemRegistryName != null) {
-                    String itemModId = itemRegistryName.getResourceDomain();
+                    String itemModId = itemRegistryName.getNamespace();
                     modIdDifferent = !recipeModId.equals(itemModId);
                 }
 
@@ -63,7 +63,7 @@ public class CustomItemReturnRecipeWrapper extends ShapedOreRecipeWrapper implem
 
                 boolean showAdvanced = Minecraft.getMinecraft().gameSettings.advancedItemTooltips || GuiScreen.isShiftKeyDown();
                 if (showAdvanced) {
-                    tooltip.add(TextFormatting.GRAY + registryName.getResourcePath());
+                    tooltip.add(TextFormatting.GRAY + registryName.getPath());
                 }
             }
 

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -238,7 +238,7 @@ public class CraftingRecipeLoader {
 
     private static void registerColoringRecipes(BlockColored block) {
         for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
-            String recipeName = String.format("%s_color_%s", block.getRegistryName().getNamespace(), getColorName(dyeColor));
+            String recipeName = String.format("%s_color_%s", block.getRegistryName().getPath(), getColorName(dyeColor));
             ModHandler.addShapedRecipe(recipeName, new ItemStack(block, 8, dyeColor.getMetadata()), "XXX", "XDX", "XXX",
                 'X', new ItemStack(block, 1, GTValues.W), 'D', getOrdictColorName(dyeColor));
         }

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -238,7 +238,7 @@ public class CraftingRecipeLoader {
 
     private static void registerColoringRecipes(BlockColored block) {
         for (EnumDyeColor dyeColor : EnumDyeColor.values()) {
-            String recipeName = String.format("%s_color_%s", block.getRegistryName().getResourcePath(), getColorName(dyeColor));
+            String recipeName = String.format("%s_color_%s", block.getRegistryName().getNamespace(), getColorName(dyeColor));
             ModHandler.addShapedRecipe(recipeName, new ItemStack(block, 8, dyeColor.getMetadata()), "XXX", "XDX", "XXX",
                 'X', new ItemStack(block, 1, GTValues.W), 'D', getOrdictColorName(dyeColor));
         }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1075,7 +1075,7 @@ public class MachineRecipeLoader {
     }
 
     private static <T extends Enum<T> & IStringSerializable> void registerBrickRecipe(StoneBlock<T> stoneBlock, T normalVariant, T brickVariant) {
-        ModHandler.addShapedRecipe(stoneBlock.getRegistryName().getResourceDomain() + "_" + normalVariant + "_bricks",
+        ModHandler.addShapedRecipe(stoneBlock.getRegistryName().getNamespace() + "_" + normalVariant + "_bricks",
             stoneBlock.getItemVariant(brickVariant, ChiselingVariant.NORMAL, 4),
             "XX", "XX", 'X',
             stoneBlock.getItemVariant(normalVariant, ChiselingVariant.NORMAL));
@@ -1098,7 +1098,7 @@ public class MachineRecipeLoader {
                 .fluidInputs(Materials.Water.getFluid(144))
                 .outputs(stoneBlock.getItemVariant(variant, ChiselingVariant.MOSSY))
                 .buildAndRegister();
-            ModHandler.addShapelessRecipe(stoneBlock.getRegistryName().getResourcePath() + "_chiseling_" + variant,
+            ModHandler.addShapelessRecipe(stoneBlock.getRegistryName().getPath() + "_chiseling_" + variant,
                 stoneBlock.getItemVariant(variant, ChiselingVariant.CHISELED),
                 stoneBlock.getItemVariant(variant, ChiselingVariant.NORMAL));
         }

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -94,7 +94,7 @@ public class WoodMachineRecipes {
                 }
             }
             //noinspection ConstantConditions
-            ModHandler.addShapedRecipe(outputRecipe.getRegistryName().getResourcePath() + "_saw",
+            ModHandler.addShapedRecipe(outputRecipe.getRegistryName().getNamespace() + "_saw",
                 GTUtility.copyAmount(originalOutput, plankStack), "s", "L", 'L', stack);
 
             RecipeMaps.CUTTER_RECIPES.recipeBuilder().inputs(stack)

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -94,7 +94,7 @@ public class WoodMachineRecipes {
                 }
             }
             //noinspection ConstantConditions
-            ModHandler.addShapedRecipe(outputRecipe.getRegistryName().getNamespace() + "_saw",
+            ModHandler.addShapedRecipe(outputRecipe.getRegistryName().getPath() + "_saw",
                 GTUtility.copyAmount(originalOutput, plankStack), "s", "L", 'L', stack);
 
             RecipeMaps.CUTTER_RECIPES.recipeBuilder().inputs(stack)


### PR DESCRIPTION
**What:**
This PR addresses the issue discussed in Discord earlier,
> We ran into a problem with the JEI OrePage where it would crash sometimes, and not consistently. I found out that it was due to the fact that Biome#biomeName changed at some point from public to private access, and an IllegalAccessException was being thrown due to it being private.
> As a result, we think the safest way forward is to update our MCP mappings from snapshot_20170928 to stable_39. I believe that I have fixed all mapping changes in our files (a total of 65 files changed), but I am still working on fixing our build.gradle so that all dependencies compile and run correctly in dev environment.

**How solved:**
I updated our MCP mappings to `stable_39`. Notable method name changes:

**Block:**
- getBlockLayer() -> getRenderLayer()
- onBlockDestroyedByPlayer() -> onPlayerDestroy()
- onEntityCollidedWithBlock() -> onEntityCollision()
- getMobilityFlag() -> getPushReaction()

**World:**:
- getChunkFromChunkCoords() -> getChunk()

**ResourceLocation:**
- getResourceName() -> getNamespace()
- getResourcePath() -> getPath()

**NBTCompound**:
- hasNoTags() -> isEmpty()

**Translation:**
- setUnlocalizedName() -> setTranslationKey()
- getUnlocalizedName() -> getTranslationKey()

**EnumFacing**:
- getFrontOffsetX() -> getXOffset()
- getFrontOffsetY() -> getYOffset()
- getFrontOffsetZ() -> getZOffset()

**CreativeTabs:**
- getTabIconItem() -> createIcon()

**EnumRarity:**
- rarityColor -> color

**Biome:**
- `biomeName` is private, so I changed its references to `getBiomeName()`

**Outcome:**
Update MCP Mapping to stable_39

You can verify my work using the official [MCP Mapping names](https://mcp.thiakil.com/#/search) website, which is what I used to guarantee that we switch to the correct new method names.

**Additional info:**
I have not yet gotten the dev environment working without a crash due to dependencies deobfuscated files being outdated. I know that setting this up is possible, as both SoG and Gregicality are already on `stable_39`, and have successfully remapped SRG->MCP for all of their dependents (same as ours in dev, and more).

**Possible compatibility issue:**
There may be some work needed for developers to refresh their environments, but I am not sure of the extent of it since I haven't finished the build.gradle