### PR TITLE
Drop NBT For JEI Recipe Registration

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -79,7 +79,13 @@ public class GTRecipeWrapper implements IRecipeWrapper {
                 ItemNBTUtils.setInteger(chancedStack, "boost_per_tier", chancedEntry.getBoostPerTier());
                 recipeOutputs.add(chancedStack);
             }
-            recipeOutputs.sort(Comparator.comparing(stack -> ItemNBTUtils.getInteger(stack, "chance")));
+
+            recipeOutputs.sort(Comparator.comparing(stack -> {
+                NBTTagCompound tag = stack.getTagCompound();
+                if (tag != null)
+                    return ItemNBTUtils.getInteger(stack, "chance");
+                else return 0;
+            }));
             ingredients.setOutputs(VanillaTypes.ITEM, recipeOutputs);
         }
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -80,6 +80,8 @@ public class GTRecipeWrapper implements IRecipeWrapper {
                 recipeOutputs.add(chancedStack);
             }
 
+            // For some reason, ItemNBTUtils.getInteger() will create an empty tag if the item has no
+            // NBTTagCompound, instead of null checking. Forge code ¯\_(ツ)_/¯
             recipeOutputs.sort(Comparator.comparing(stack -> {
                 NBTTagCompound tag = stack.getTagCompound();
                 if (tag != null)

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -81,7 +81,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
             }
 
             // For some reason, ItemNBTUtils.getInteger() will create an empty tag if the item has no
-            // NBTTagCompound, instead of null checking. Forge code ¯\_(ツ)_/¯
+            // NBTTagCompound, instead of null checking.
             recipeOutputs.sort(Comparator.comparing(stack -> {
                 NBTTagCompound tag = stack.getTagCompound();
                 if (tag != null)


### PR DESCRIPTION
**What:**
This PR changes our JEI recipe registration to not use NBT data for notConsumed and chanced outputs, and instead store them internally for the tooltips.

**How solved:**
I changed `GTRecipeWrapper#getIngredients()` method to not put NBT data on these items, and instead store them in some custom hashing data structures to use later for adding the JEI tooltips.

**Outcome:**
- Remove NBT data from recipes

**Additional info:**
These screenshots show one example of a recipe that formerly had NBT data attached, but no longer do:
Before:
![image](https://user-images.githubusercontent.com/10861407/110027625-d2c7ae00-7cf7-11eb-8d80-f3e0552dc94f.png)

After:
![image](https://user-images.githubusercontent.com/10861407/110027584-c8a5af80-7cf7-11eb-9fbb-8d8acee9d406.png)

Here is an example of chanced and notConsumed recipes, with no tags:
![image](https://user-images.githubusercontent.com/10861407/110194233-2a037680-7dfd-11eb-87ba-bbb862122721.png)
![image](https://user-images.githubusercontent.com/10861407/110194243-2d96fd80-7dfd-11eb-99f7-517377216399.png)

**Possible compatibility issue:**
Some CraftTweaker scripts will break, but it is for the best, as having to modify NBT in CT is never a good time.