### PR TITLE
Adjust the EU/t of the Rotors

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
@@ -270,7 +270,7 @@ public class PartsRecipeHandler {
                 .fluidInputs(material.getFluid(L * 4))
                 .outputs(OreDictUnifier.get(rotorPrefix, material))
                 .duration(120)
-                .EUt(120)
+                .EUt(20)
                 .buildAndRegister();
         }
     }


### PR DESCRIPTION
**What:**
Adjusts the Eu/t of Rotor Recipes to bring them into LV

**How solved:**
Adjusts the EU/t of the recipe

**Outcome:**
Adjusts the EU/t of the Rotor Solidification recipes so that it is LV. Closes #1491.

**Possible compatibility issue:**
This could mess up CT scripts that adjusted the EU/t on their own, but those scripts would most likely not even be needed after this.