### PR TITLE
Adjust Biome Name tooltip to use getter

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -288,10 +288,10 @@ public class GTOreInfo implements IRecipeWrapper {
             if(!(entry.getValue() == weight)) {
                 //Cannot Spawn
                 if(entry.getValue() <= 0) {
-                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting_no_spawn", entry.getKey().biomeName));
+                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting_no_spawn", entry.getKey().getBiomeName()));
                 }
                 else {
-                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting", entry.getKey().biomeName, entry.getValue()));
+                    tooltip.add(I18n.format("gregtech.jei.ore.biome_weighting", entry.getKey().getBiomeName(), entry.getValue()));
                 }
             }
         }


### PR DESCRIPTION
**What:**
This PR brings the important fix of changing the Biome Name tooltip to use the biome name getter out of PR #1506. This is done so that it can be merged without having the finalize the issues in that PR and reviewing the entire PR.

**How solved:**
In future MCP mappings, the `biomeName` field changed to private, which caused some players to get access errors when viewing the tooltip on the ore spawn page. This PR simply switches from using the field to using the getter.

**Outcome:**
Fixes crash when viewing tooltip on JEI Ore page.

**Possible compatibility issue:**
There should be none