### PR TITLE
Allow using Right mouse button to cycle some widgets in reverse

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
@@ -132,7 +132,14 @@ public class CycleButtonWidget extends Widget {
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
         super.mouseClicked(mouseX, mouseY, button);
         if (isMouseOverElement(mouseX, mouseY)) {
-            this.currentOption = (currentOption + 1) % optionNames.length;
+            //Allow only the RMB to reverse cycle
+            if(button == 1) {
+                //Wrap from the first option to the last if needed
+                this.currentOption = currentOption - 1 < 0 ? currentOption + optionNames.length - 1 : currentOption - 1;
+            }
+            else {
+                this.currentOption = (currentOption + 1) % optionNames.length;
+            }
             writeClientAction(1, buf -> buf.writeVarInt(currentOption));
             playButtonClickSound();
             return true;

--- a/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
@@ -31,6 +31,7 @@ public class CycleButtonWidget extends Widget {
     private int textColor = 0xFFFFFF;
     private IntSupplier currentOptionSupplier;
     private IntConsumer setOptionExecutor;
+    private final int RIGHT_MOUSE = 1;
     protected int currentOption;
     protected String tooltipHoverString;
     protected long hoverStartTime = -1L;
@@ -133,9 +134,9 @@ public class CycleButtonWidget extends Widget {
         super.mouseClicked(mouseX, mouseY, button);
         if (isMouseOverElement(mouseX, mouseY)) {
             //Allow only the RMB to reverse cycle
-            if(button == 1) {
+            if(button == RIGHT_MOUSE) {
                 //Wrap from the first option to the last if needed
-                this.currentOption = currentOption - 1 < 0 ? currentOption + optionNames.length - 1 : currentOption - 1;
+                this.currentOption = currentOption == 0 ? optionNames.length - 1 : currentOption - 1;
             }
             else {
                 this.currentOption = (currentOption + 1) % optionNames.length;


### PR DESCRIPTION
**What:**
Brought up in #1522, this PR allows for cycling `CycleButtonWidgets` in reverse by clicking them with the Right Mouse Button.

**How solved:**
Checks if the button used for the event is the RMB, and if it is cycles the options in reverse, wrapping from the first to the last option if needed.

Note, I check for if `button == 1` because during my testing that was what the RMB was. If there is a better way to detect if it was the RMB that was pressed, please let me know

**Outcome:**
Allows for cycling some widgets in reverse using the right mouse button


**Possible compatibility issue:**
None expected