### PR TITLE
made Rotor holder independant from large turbine controller

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -15,7 +15,7 @@ import gregtech.api.render.Textures;
 import gregtech.api.unification.material.type.IngotMaterial;
 import gregtech.common.items.behaviors.TurbineRotorBehavior;
 import gregtech.common.metatileentities.multi.electric.generator.MetaTileEntityLargeTurbine;
-import gregtech.common.metatileentities.multi.electric.generator.TurbineMultiblockController;
+import gregtech.common.metatileentities.multi.electric.generator.RotorHolderMultiblockController;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -77,7 +77,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
             this.frontFaceFree = checkTurbineFaceFree();
         }
 
-        TurbineMultiblockController controller = (TurbineMultiblockController) getController();
+        RotorHolderMultiblockController controller = (RotorHolderMultiblockController) getController();
         boolean isControllerActive = controller != null && controller.isActive();
 
         if (!isHasRotor()) {

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -83,13 +83,9 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         if (!isHasRotor()) {
             resetRotorSpeed();
         } else if (currentRotorSpeed < maxRotorSpeed && isControllerActive) {
-            incrementSpeed(controller.getRotorIncrementSpeed());
+            incrementSpeed(controller.getRotorSpeedIncrement());
         } else if (currentRotorSpeed > 0 && !isControllerActive) {
-            if(controller == null){
-                incrementSpeed( maxRotorSpeed/10);
-            }else {
-                incrementSpeed(controller.getRotorDecrementSpeed());
-            }
+            incrementSpeed(controller.getRotorSpeedDecrement());
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -15,6 +15,7 @@ import gregtech.api.render.Textures;
 import gregtech.api.unification.material.type.IngotMaterial;
 import gregtech.common.items.behaviors.TurbineRotorBehavior;
 import gregtech.common.metatileentities.multi.electric.generator.MetaTileEntityLargeTurbine;
+import gregtech.common.metatileentities.multi.electric.generator.TurbineMultiblockController;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -76,15 +77,19 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
             this.frontFaceFree = checkTurbineFaceFree();
         }
 
-        MetaTileEntityLargeTurbine controller = (MetaTileEntityLargeTurbine) getController();
+        TurbineMultiblockController controller = (TurbineMultiblockController) getController();
         boolean isControllerActive = controller != null && controller.isActive();
 
         if (!isHasRotor()) {
             resetRotorSpeed();
         } else if (currentRotorSpeed < maxRotorSpeed && isControllerActive) {
-            incrementSpeed(1);
+            incrementSpeed(controller.getRotorIncrementSpeed());
         } else if (currentRotorSpeed > 0 && !isControllerActive) {
-            incrementSpeed(-3);
+            if(controller == null){
+                incrementSpeed( maxRotorSpeed/10);
+            }else {
+                incrementSpeed(controller.getRotorDecrementSpeed());
+            }
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -83,12 +83,12 @@ public class MetaTileEntityLargeTurbine extends RotorHolderMultiblockController 
     }
 
     @Override
-    public int getRotorIncrementSpeed() {
+    public int getRotorSpeedIncrement() {
         return 1;
     }
 
     @Override
-    public int getRotorDecrementSpeed() {
+    public int getRotorSpeedDecrement() {
         return -3;
     }
 
@@ -146,6 +146,14 @@ public class MetaTileEntityLargeTurbine extends RotorHolderMultiblockController 
     @Override
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
         return turbineType.casingRenderer;
+    }
+
+    /** Deprecated method please use {@code {@see isRotorFaceFree}} instead
+     *
+     */
+    @Deprecated
+    public boolean isTurbineFaceFree() {
+        return isRotorFaceFree();
     }
 
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -28,9 +28,8 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import java.util.List;
 
-public class MetaTileEntityLargeTurbine extends FueledMultiblockController {
+public class MetaTileEntityLargeTurbine extends TurbineMultiblockController {
 
-    public static final MultiblockAbility<MetaTileEntityRotorHolder> ABILITY_ROTOR_HOLDER = new MultiblockAbility<>();
     private static final int MIN_DURABILITY_TO_WARN = 10;
 
     public enum TurbineType {
@@ -71,17 +70,6 @@ public class MetaTileEntityLargeTurbine extends FueledMultiblockController {
         return new MetaTileEntityLargeTurbine(metaTileEntityId, turbineType);
     }
 
-    public MetaTileEntityRotorHolder getRotorHolder() {
-        return getAbilities(ABILITY_ROTOR_HOLDER).get(0);
-    }
-
-    @Override
-    protected void updateFormedValid() {
-        if (isTurbineFaceFree()) {
-            super.updateFormedValid();
-        }
-    }
-
     @Override
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
@@ -90,24 +78,18 @@ public class MetaTileEntityLargeTurbine extends FueledMultiblockController {
 
     @Override
     public void invalidateStructure() {
-        getRotorHolder().resetRotorSpeed();
         super.invalidateStructure();
         this.exportFluidHandler = null;
     }
 
-    /**
-     * @return true if structure formed, workable is active and front face is free
-     */
-    public boolean isActive() {
-        return isTurbineFaceFree() && workableHandler.isActive() && workableHandler.isWorkingEnabled();
+    @Override
+    public int getRotorIncrementSpeed() {
+        return 1;
     }
 
-    /**
-     * @return true if turbine is formed and it's face is free and contains
-     * only air blocks in front of rotor holder
-     */
-    public boolean isTurbineFaceFree() {
-        return isStructureFormed() && getAbilities(ABILITY_ROTOR_HOLDER).get(0).isFrontFaceFree();
+    @Override
+    public int getRotorDecrementSpeed() {
+        return -3;
     }
 
     @Override
@@ -128,7 +110,7 @@ public class MetaTileEntityLargeTurbine extends FueledMultiblockController {
                     textList.add(new TextComponentTranslation("gregtech.multiblock.turbine.rotor_durability", rotorDurability));
                 } else {
                     textList.add(new TextComponentTranslation("gregtech.multiblock.turbine.low_rotor_durability",
-                        MIN_DURABILITY_TO_WARN, rotorDurability).setStyle(new Style().setColor(TextFormatting.RED)));
+                            MIN_DURABILITY_TO_WARN, rotorDurability).setStyle(new Style().setColor(TextFormatting.RED)));
                 }
             }
         }
@@ -138,23 +120,23 @@ public class MetaTileEntityLargeTurbine extends FueledMultiblockController {
     @Override
     protected BlockPattern createStructurePattern() {
         return turbineType == null ? null :
-            FactoryBlockPattern.start()
-                .aisle("CCCC", "CHHC", "CCCC")
-                .aisle("CHHC", "R##D", "CHHC")
-                .aisle("CCCC", "CSHC", "CCCC")
-                .where('S', selfPredicate())
-                .where('#', isAirPredicate())
-                .where('C', statePredicate(getCasingState()))
-                .where('H', statePredicate(getCasingState()).or(abilityPartPredicate(getAllowedAbilities())))
-                .where('R', abilityPartPredicate(ABILITY_ROTOR_HOLDER))
-                .where('D', abilityPartPredicate(MultiblockAbility.OUTPUT_ENERGY))
-                .build();
+                FactoryBlockPattern.start()
+                        .aisle("CCCC", "CHHC", "CCCC")
+                        .aisle("CHHC", "R##D", "CHHC")
+                        .aisle("CCCC", "CSHC", "CCCC")
+                        .where('S', selfPredicate())
+                        .where('#', isAirPredicate())
+                        .where('C', statePredicate(getCasingState()))
+                        .where('H', statePredicate(getCasingState()).or(abilityPartPredicate(getAllowedAbilities())))
+                        .where('R', abilityPartPredicate(ABILITY_ROTOR_HOLDER))
+                        .where('D', abilityPartPredicate(MultiblockAbility.OUTPUT_ENERGY))
+                        .build();
     }
 
     public MultiblockAbility[] getAllowedAbilities() {
         return turbineType.hasOutputHatch ?
-            new MultiblockAbility[]{MultiblockAbility.IMPORT_FLUIDS, MultiblockAbility.EXPORT_FLUIDS} :
-            new MultiblockAbility[]{MultiblockAbility.IMPORT_FLUIDS};
+                new MultiblockAbility[]{MultiblockAbility.IMPORT_FLUIDS, MultiblockAbility.EXPORT_FLUIDS} :
+                new MultiblockAbility[]{MultiblockAbility.IMPORT_FLUIDS};
     }
 
     public IBlockState getCasingState() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import java.util.List;
 
-public class MetaTileEntityLargeTurbine extends TurbineMultiblockController {
+public class MetaTileEntityLargeTurbine extends RotorHolderMultiblockController {
 
     private static final int MIN_DURABILITY_TO_WARN = 10;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/RotorHolderMultiblockController.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/RotorHolderMultiblockController.java
@@ -25,7 +25,7 @@ public abstract class RotorHolderMultiblockController extends FueledMultiblockCo
 
     @Override
     protected void updateFormedValid() {
-        if (isTurbineFaceFree()) {
+        if (isRotorFaceFree()) {
             super.updateFormedValid();
         }
     }
@@ -40,7 +40,7 @@ public abstract class RotorHolderMultiblockController extends FueledMultiblockCo
      * @return true if turbine is formed and it's face is free and contains
      * only air blocks in front of rotor holder
      */
-    public boolean isTurbineFaceFree() {
+    public boolean isRotorFaceFree() {
         return isStructureFormed() && getAbilities(ABILITY_ROTOR_HOLDER).get(0).isFrontFaceFree();
     }
 
@@ -48,10 +48,10 @@ public abstract class RotorHolderMultiblockController extends FueledMultiblockCo
      * @return true if structure formed, workable is active and front face is free
      */
     public boolean isActive() {
-        return isTurbineFaceFree() && workableHandler.isActive() && workableHandler.isWorkingEnabled();
+        return isRotorFaceFree() && workableHandler.isActive() && workableHandler.isWorkingEnabled();
     }
 
-    public abstract int getRotorIncrementSpeed();
+    public abstract int getRotorSpeedIncrement();
 
-    public abstract int getRotorDecrementSpeed();
+    public abstract int getRotorSpeedDecrement();
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/RotorHolderMultiblockController.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/RotorHolderMultiblockController.java
@@ -7,11 +7,11 @@ import net.minecraft.util.ResourceLocation;
 
 import java.util.List;
 
-public abstract class TurbineMultiblockController extends FueledMultiblockController {
+public abstract class RotorHolderMultiblockController extends FueledMultiblockController {
 
     public static final MultiblockAbility<MetaTileEntityRotorHolder> ABILITY_ROTOR_HOLDER = new MultiblockAbility<>();
 
-    public TurbineMultiblockController(ResourceLocation metaTileEntityId, FuelRecipeMap recipeMap, long maxVoltage) {
+    public RotorHolderMultiblockController(ResourceLocation metaTileEntityId, FuelRecipeMap recipeMap, long maxVoltage) {
         super(metaTileEntityId, recipeMap, maxVoltage);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/TurbineMultiblockController.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/TurbineMultiblockController.java
@@ -1,0 +1,57 @@
+package gregtech.common.metatileentities.multi.electric.generator;
+
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.recipes.machines.FuelRecipeMap;
+import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityRotorHolder;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.List;
+
+public abstract class TurbineMultiblockController extends FueledMultiblockController {
+
+    public static final MultiblockAbility<MetaTileEntityRotorHolder> ABILITY_ROTOR_HOLDER = new MultiblockAbility<>();
+
+    public TurbineMultiblockController(ResourceLocation metaTileEntityId, FuelRecipeMap recipeMap, long maxVoltage) {
+        super(metaTileEntityId, recipeMap, maxVoltage);
+    }
+
+    public MetaTileEntityRotorHolder getRotorHolder() {
+        return getAbilities(ABILITY_ROTOR_HOLDER).get(0);
+    }
+
+    public List<MetaTileEntityRotorHolder> getRotorHolders() {
+        return getAbilities(ABILITY_ROTOR_HOLDER);
+    }
+
+    @Override
+    protected void updateFormedValid() {
+        if (isTurbineFaceFree()) {
+            super.updateFormedValid();
+        }
+    }
+
+    @Override
+    public void invalidateStructure() {
+        getRotorHolder().resetRotorSpeed();
+        super.invalidateStructure();
+    }
+
+    /**
+     * @return true if turbine is formed and it's face is free and contains
+     * only air blocks in front of rotor holder
+     */
+    public boolean isTurbineFaceFree() {
+        return isStructureFormed() && getAbilities(ABILITY_ROTOR_HOLDER).get(0).isFrontFaceFree();
+    }
+
+    /**
+     * @return true if structure formed, workable is active and front face is free
+     */
+    public boolean isActive() {
+        return isTurbineFaceFree() && workableHandler.isActive() && workableHandler.isWorkingEnabled();
+    }
+
+    public abstract int getRotorIncrementSpeed();
+
+    public abstract int getRotorDecrementSpeed();
+}


### PR DESCRIPTION
**What:**
Implement #1425 

**How solved:**
Create new abstract type `TurbineMultiblockController` which extend the `FueledMultiblockController` and refactor code to make the Rotor holder depending on this class.
added two methods `getRotorIncrementSpeed()` and `getRotorDecrementSpeed()` allowing the variation of the rotor speed to not be hard coded.

**Outcome:**
make `MetaTileEntityRotorHolder` depend on `TurbineMultiblockController` instead of `MetaTileEntityLargeTurbine`

**Additional info:**
Multiblocks using turbines are assumed to be energy producer changing this mean recoding some part  of `FueledMultiblockController` in `MetaTileEntityLargeTurbine` or adding another abstract type in between. 
As both options (implemented and presented ) seems good to me tell me if you found that one way is better than another.

**Possible compatibility issue:**
None
