### PR TITLE
Fix chests rendering invisibly in some cases

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.machines.BlockMachine;
+import gregtech.api.cover.CoverBehavior;
 import gregtech.api.gui.IUIHolder;
 import gregtech.api.util.GTControlledRegistry;
 import gregtech.api.util.GTLog;
@@ -248,6 +249,15 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
 
     @Override
     public boolean shouldRenderInPass(int pass) {
+        if (metaTileEntity == null) return false;
+        for (EnumFacing side: EnumFacing.VALUES){
+            CoverBehavior cover = metaTileEntity.getCoverAtSide(side);
+            if (cover instanceof IFastRenderMetaTileEntity && ((IFastRenderMetaTileEntity) cover).shouldRenderInPass(pass)) {
+                return true;
+            } else if(cover instanceof IRenderMetaTileEntity && ((IRenderMetaTileEntity) cover).shouldRenderInPass(pass)) {
+                return true;
+            }
+        }
         if (metaTileEntity instanceof IRenderMetaTileEntity) {
             return ((IRenderMetaTileEntity) metaTileEntity).shouldRenderInPass(pass);
         } else if (metaTileEntity instanceof IFastRenderMetaTileEntity) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -267,12 +267,6 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     }
 
     @Override
-    public boolean hasFastRenderer() {
-        return metaTileEntity instanceof IFastRenderMetaTileEntity &&
-            !(metaTileEntity instanceof IRenderMetaTileEntity);
-    }
-
-    @Override
     public boolean canRenderBreaking() {
         return false;
     }

--- a/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
@@ -116,9 +116,7 @@ public class MetaTileEntityRenderer implements ICCBlockRenderer, IItemRenderer {
             if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
                 ((IFastRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityFast(renderState, translation.copy(), Minecraft.getMinecraft().getRenderPartialTicks());
             }
-            else {
-                metaTileEntity.renderMetaTileEntity(renderState, translation.copy(), pipeline);
-            }
+            metaTileEntity.renderMetaTileEntity(renderState, translation.copy(), pipeline);
         }
         Matrix4 coverTranslation = new Matrix4().translate(pos.getX(), pos.getY(), pos.getZ());
         metaTileEntity.renderCovers(renderState, coverTranslation, renderLayer);

--- a/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
@@ -113,9 +113,6 @@ public class MetaTileEntityRenderer implements ICCBlockRenderer, IItemRenderer {
         if (metaTileEntity.canRenderInLayer(renderLayer)) {
             renderState.lightMatrix.locate(world, pos);
             IVertexOperation[] pipeline = new IVertexOperation[]{renderState.lightMatrix};
-            if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
-                ((IFastRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityFast(renderState, translation.copy(), Minecraft.getMinecraft().getRenderPartialTicks());
-            }
             metaTileEntity.renderMetaTileEntity(renderState, translation.copy(), pipeline);
         }
         Matrix4 coverTranslation = new Matrix4().translate(pos.getX(), pos.getY(), pos.getZ());

--- a/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityRenderer.java
@@ -113,7 +113,12 @@ public class MetaTileEntityRenderer implements ICCBlockRenderer, IItemRenderer {
         if (metaTileEntity.canRenderInLayer(renderLayer)) {
             renderState.lightMatrix.locate(world, pos);
             IVertexOperation[] pipeline = new IVertexOperation[]{renderState.lightMatrix};
-            metaTileEntity.renderMetaTileEntity(renderState, translation.copy(), pipeline);
+            if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
+                ((IFastRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityFast(renderState, translation.copy(), Minecraft.getMinecraft().getRenderPartialTicks());
+            }
+            else {
+                metaTileEntity.renderMetaTileEntity(renderState, translation.copy(), pipeline);
+            }
         }
         Matrix4 coverTranslation = new Matrix4().translate(pos.getX(), pos.getY(), pos.getZ());
         metaTileEntity.renderCovers(renderState, coverTranslation, renderLayer);

--- a/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
@@ -46,36 +46,44 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
                     ((IRenderMetaTileEntity) cover).renderMetaTileEntityDynamic(x, y, z, partialTicks);
                 }
             }
-            if (coverFast.size() > 0) {
-                Matrix4 translation = (new Matrix4()).translate(x, y, z);
-                Tessellator tessellator = Tessellator.getInstance();
-                BufferBuilder buffer = tessellator.getBuffer();
-                this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
-                RenderHelper.disableStandardItemLighting();
-                GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                GlStateManager.enableBlend();
-
-                if (Minecraft.isAmbientOcclusionEnabled()) {
-                    GlStateManager.shadeModel(GL11.GL_SMOOTH);
-                }
-                else {
-                    GlStateManager.shadeModel(GL11.GL_FLAT);
-                }
-                buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
-
-                for (Tuple<IFastRenderMetaTileEntity, EnumFacing> tuple : coverFast) {
-                    CCRenderState renderState = CCRenderState.instance();
-                    renderState.reset();
-                    renderState.bind(buffer);
-                    renderState.setBrightness(te.getWorld(), te.getPos().offset(tuple.getSecond()));
-                    tuple.getFirst().renderMetaTileEntityFast(renderState, translation, partialTicks);
-                }
-
-                buffer.setTranslation(0, 0, 0);
-                tessellator.draw();
-                RenderHelper.enableStandardItemLighting();
+            if (!coverFast.isEmpty()) {
+                renderCoverFast(te, x, y, x, partialTicks, destroyStage, alpha, coverFast);
             }
         }
+    }
+
+    /** Used Specifically to render covers that are IFastRenderMetaTileEntity
+     * Adapted from renderTileEntityFastPart
+     * **/
+    private void renderCoverFast(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, List<Tuple<IFastRenderMetaTileEntity, EnumFacing>> coverList) {
+
+        Matrix4 translation = (new Matrix4()).translate(x, y, z);
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder buffer = tessellator.getBuffer();
+        this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+        RenderHelper.disableStandardItemLighting();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.enableBlend();
+
+        if (Minecraft.isAmbientOcclusionEnabled()) {
+            GlStateManager.shadeModel(GL11.GL_SMOOTH);
+        }
+        else {
+            GlStateManager.shadeModel(GL11.GL_FLAT);
+        }
+        buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
+
+        for (Tuple<IFastRenderMetaTileEntity, EnumFacing> tuple : coverList) {
+            CCRenderState renderState = CCRenderState.instance();
+            renderState.reset();
+            renderState.bind(buffer);
+            renderState.setBrightness(te.getWorld(), te.getPos().offset(tuple.getSecond()));
+            tuple.getFirst().renderMetaTileEntityFast(renderState, translation, partialTicks);
+        }
+
+        buffer.setTranslation(0, 0, 0);
+        tessellator.draw();
+        RenderHelper.enableStandardItemLighting();
     }
 
     private void renderTileEntityFastPart(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage) {

--- a/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
@@ -23,7 +23,7 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
 
     @Override
     public void render(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
-        if(te instanceof IFastRenderMetaTileEntity) {
+        if(te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity) {
             renderTileEntityFastPart(te, x, y, z, partialTicks, destroyStage);
         }
         if(te instanceof IRenderMetaTileEntity) {

--- a/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
@@ -2,6 +2,7 @@ package gregtech.api.render;
 
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.cover.CoverBehavior;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.IRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -14,22 +15,65 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.Tuple;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @SideOnly(Side.CLIENT)
 public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntityHolder> {
 
     @Override
     public void render(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
-        if(te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity) {
+        MetaTileEntity metaTileEntity = te.getMetaTileEntity();
+        if(metaTileEntity instanceof IFastRenderMetaTileEntity) {
             renderTileEntityFastPart(te, x, y, z, partialTicks, destroyStage);
         }
-        if(te instanceof IRenderMetaTileEntity) {
-            MetaTileEntity metaTileEntity = te.getMetaTileEntity();
-            if (metaTileEntity instanceof IRenderMetaTileEntity) {
-                ((IRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityDynamic(x, y, z, partialTicks);
+        if(metaTileEntity instanceof IRenderMetaTileEntity) {
+            ((IRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityDynamic(x, y, z, partialTicks);
+        }
+        if(metaTileEntity != null) {
+            List<Tuple<IFastRenderMetaTileEntity, EnumFacing>> coverFast = new ArrayList<>();
+            for (EnumFacing side: EnumFacing.VALUES){
+                CoverBehavior cover = metaTileEntity.getCoverAtSide(side);
+                if (cover instanceof IFastRenderMetaTileEntity) {
+                    coverFast.add(new Tuple<>((IFastRenderMetaTileEntity) cover, side));
+                } else if (cover instanceof IRenderMetaTileEntity){
+                    ((IRenderMetaTileEntity) cover).renderMetaTileEntityDynamic(x, y, z, partialTicks);
+                }
+            }
+            if (coverFast.size() > 0) {
+                Matrix4 translation = (new Matrix4()).translate(x, y, z);
+                Tessellator tessellator = Tessellator.getInstance();
+                BufferBuilder buffer = tessellator.getBuffer();
+                this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+                RenderHelper.disableStandardItemLighting();
+                GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GlStateManager.enableBlend();
+
+                if (Minecraft.isAmbientOcclusionEnabled()) {
+                    GlStateManager.shadeModel(GL11.GL_SMOOTH);
+                }
+                else {
+                    GlStateManager.shadeModel(GL11.GL_FLAT);
+                }
+                buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
+
+                for (Tuple<IFastRenderMetaTileEntity, EnumFacing> tuple : coverFast) {
+                    CCRenderState renderState = CCRenderState.instance();
+                    renderState.reset();
+                    renderState.bind(buffer);
+                    renderState.setBrightness(te.getWorld(), te.getPos().offset(tuple.getSecond()));
+                    tuple.getFirst().renderMetaTileEntityFast(renderState, translation, partialTicks);
+                }
+
+                buffer.setTranslation(0, 0, 0);
+                tessellator.draw();
+                RenderHelper.enableStandardItemLighting();
             }
         }
     }
@@ -54,7 +98,7 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
         renderTileEntityFast(te, x, y, z, partialTicks, destroyStage, partialTicks, buffer);
         buffer.setTranslation(0, 0, 0);
         tessellator.draw();
-
+        GlStateManager.enableCull();
         RenderHelper.enableStandardItemLighting();
     }
 


### PR DESCRIPTION
**What:**
This PR fixes chests rendering invisible in some cases.

**How solved:**
In `MetaTileEntityRenderer#renderBlock`, all block rendering was getting called using `renderMetaTileEntity`. However, the chests override this method and have an empty method body, so nothing was getting rendered for the chests.

To fix this, I first check if the MTE is an instance of an `IFastRenderMetaTileEntity` and if it is I call the specific render method for those blocks, and then `renderMTE`

**Outcome:**
Fixes chests rendering invisibly in some cases. Closes #1235, Closes #1117, Closes #853 (Some parts)

**Additional info:**

https://user-images.githubusercontent.com/31759736/111386493-9128f280-8669-11eb-8cef-a67174dc00bd.mp4

**Possible compatibility issue:**
With this most recent set of changes, there would be issues if someone was doing anything with the `hasFastRenderer` method