### PR TITLE
Allow Stacks of Fluid Containers in Quantum Tank

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -82,19 +82,9 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getTimer() % 5 == 0) {
-            ItemStack itemStack = containerInventory.getStackInSlot(0);
-            Capability<IFluidHandlerItem> capability = CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY;
-            if (!itemStack.isEmpty() && itemStack.hasCapability(capability, null)) {
-                //if we can't drain anything, try filling container. Otherwise, drain it into the quantum chest tank
-                if (itemStack.getCapability(capability, null).drain(Integer.MAX_VALUE, false) == null) {
-                    fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
-                    pushFluidsIntoNearbyHandlers(getFrontFacing());
-                } else {
-                    fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
-                    pullFluidsFromNearbyHandlers(getFrontFacing());
-                }
-            }
+        if (!getWorld().isRemote) {
+            fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
+            fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
         }
     }
 


### PR DESCRIPTION
**What:**
This PR fixes the issue where you must put fluid containers 1 item at a time into Quantum Tanks. It also removes the 5 tick timer check, so it is in line with Fluid Input Hatches.
https://user-images.githubusercontent.com/10861407/111842276-2e379580-88cd-11eb-92ed-e6be72f1dc51.mp4

**How solved:**
Remove some checks in the code and allow the helper methods to do it for us.

**Outcome:**
- Allow Stacks of Fluid Containers in Quantum Tank
- Closes #1534

**Additional info:**
This PR also addresses the issue in #1534 where Quantum Tanks had hidden push/pull mechanics on its front face. This removes a hidden mechanic and fixes a duping issue.

**Possible compatibility issue:**
None expected.