### PR TITLE
Give Lossless Cables Loss as Wires (with Config)

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -105,6 +105,10 @@ public class ConfigHolder {
     @Config.Comment("If true, powered zero loss wires will damage the player. Default: false")
     public static boolean doLosslessWiresDamage = false;
 
+    @Config.Comment("If true, lossless cables will have lossy wires. Default: false")
+    @Config.RequiresMcRestart
+    public static boolean doLosslessWiresMakeLossyCables = false;
+
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf the paper crafting recipe. Default: true")

--- a/src/main/java/gregtech/common/pipelike/cable/Insulation.java
+++ b/src/main/java/gregtech/common/pipelike/cable/Insulation.java
@@ -53,7 +53,9 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
     public WireProperties modifyProperties(WireProperties baseProperties) {
         return new WireProperties(baseProperties.voltage,
             baseProperties.amperage * amperage,
-            baseProperties.lossPerBlock * lossMultiplier);
+                baseProperties.lossPerBlock == 0 ?
+                        (int)(0.75 * lossMultiplier) : // Lossless cables still have lossy wires
+                        baseProperties.lossPerBlock * lossMultiplier);
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/cable/Insulation.java
+++ b/src/main/java/gregtech/common/pipelike/cable/Insulation.java
@@ -2,6 +2,7 @@ package gregtech.common.pipelike.cable;
 
 import gregtech.api.pipenet.block.material.IMaterialPipeType;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.common.ConfigHolder;
 
 public enum Insulation implements IMaterialPipeType<WireProperties> {
 
@@ -51,11 +52,13 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
 
     @Override
     public WireProperties modifyProperties(WireProperties baseProperties) {
-        return new WireProperties(baseProperties.voltage,
-            baseProperties.amperage * amperage,
-                baseProperties.lossPerBlock == 0 ?
-                        (int)(0.75 * lossMultiplier) : // Lossless cables still have lossy wires
-                        baseProperties.lossPerBlock * lossMultiplier);
+
+        int lossPerBlock;
+        if (ConfigHolder.doLosslessWiresMakeLossyCables && baseProperties.lossPerBlock == 0)
+            lossPerBlock = (int)(0.75 * lossMultiplier);
+        else lossPerBlock = baseProperties.lossPerBlock * lossMultiplier;
+
+        return new WireProperties(baseProperties.voltage, baseProperties.amperage * amperage, lossPerBlock);
     }
 
     @Override


### PR DESCRIPTION
**What:**
This PR simply makes lossless cables now have loss as wires with a config value default to false. This incentivizes the player to cover their cables.

**How solved:**
I changed the calculation for cable loss to now check for if the cable is set to be lossless, and will now have the wires with loss at the given rates:
1x: 1V/block
2x: 1V/block
4x: 2V/block
8x: 2V/block
16x: 2V/block

**Outcome:**
- Lossless cables now have lossless wires if configured

**Additional info:**
This has been a concern of mine when creating lossless cables through CraftTweaker, as I wanted lossless cables, but also wanted them to still respect the loss multipliers specified in the `Insulation` enum.

**Possible compatibility issue:**
None expected.