### PR TITLE
Remove Duplicate Recipes

### DIFF
--- a/src/main/java/gregtech/common/items/MetaItem2.java
+++ b/src/main/java/gregtech/common/items/MetaItem2.java
@@ -282,20 +282,6 @@ public class MetaItem2 extends MaterialMetaItem {
             .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
-            .inputs(new ItemStack(Items.WHEAT, 1, 0))
-            .outputs(OreDictUnifier.get(OrePrefix.dust, Materials.Wheat, 1))
-            .duration(400)
-            .EUt(2)
-            .buildAndRegister();
-
-        RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
-            .inputs(new ItemStack(Items.STICK, 1))
-            .outputs(OreDictUnifier.get(OrePrefix.dustSmall, Materials.Wood, 2))
-            .duration(400)
-            .EUt(2)
-            .buildAndRegister();
-
-        RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
             .inputs(CountableIngredient.from("blockWool", 1))
             .outputs(new ItemStack(Items.STRING, 3))
             .chancedOutput(new ItemStack(Items.STRING, 1), 2000, 800)


### PR DESCRIPTION
**What:**
This PR removes a couple of duplicate recipes.

**Outcome:**
- Closes #1538
- Closes #1541

**Additional info:**
I removed the recipes with 20s duration since they were not autogenerated where I believe the others were. Additionally, there was a Hay Bale recipe that was exactly 9x the duration of the other Wheat maceration recipe, so it made sense to remove the longer one.

**Possible compatibility issue:**
None expected.