### PR TITLE
Filter in pumps

### DIFF
--- a/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
@@ -53,7 +53,7 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
     public void initUI(int y, Consumer<Widget> widgetGroup) {
         widgetGroup.accept(new LabelWidget(10, y, "cover.pump.fluid_filter.title"));
         widgetGroup.accept(new SlotWidget(filterInventory, 0, 10, y + 15)
-            .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.FILTER_SLOT_OVERLAY));
+                .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.FILTER_SLOT_OVERLAY));
         this.filterWrapper.initUI(y + 15, widgetGroup);
     }
 
@@ -61,13 +61,13 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
         ItemStack filterStack = filterInventory.getStackInSlot(0);
         FluidFilter newFluidFilter = FilterTypeRegistry.getFluidFilterForStack(filterStack);
         FluidFilter currentFluidFilter = filterWrapper.getFluidFilter();
-        if(newFluidFilter == null) {
-            if(currentFluidFilter != null) {
+        if (newFluidFilter == null) {
+            if (currentFluidFilter != null) {
                 filterWrapper.setFluidFilter(null);
                 if (notify) filterWrapper.onFilterInstanceChange();
             }
         } else if (currentFluidFilter == null ||
-            newFluidFilter.getClass() != currentFluidFilter.getClass()) {
+                newFluidFilter.getClass() != currentFluidFilter.getClass()) {
             filterWrapper.setFluidFilter(newFluidFilter);
             if (notify) filterWrapper.onFilterInstanceChange();
         }
@@ -82,7 +82,7 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
         NBTTagCompound tagCompound = new NBTTagCompound();
         tagCompound.setTag("FilterInventory", filterInventory.serializeNBT());
         tagCompound.setBoolean("IsBlacklist", filterWrapper.isBlacklistFilter());
-        if(filterWrapper.getFluidFilter() != null) {
+        if (filterWrapper.getFluidFilter() != null) {
             NBTTagCompound filterInventory = new NBTTagCompound();
             filterWrapper.getFluidFilter().writeToNBT(filterInventory);
             tagCompound.setTag("Filter", filterInventory);
@@ -93,15 +93,15 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
     @Override
     public void deserializeNBT(NBTTagCompound tagCompound) {
         //LEGACY SAVE FORMAT SUPPORT
-        if(tagCompound.hasKey("FilterTypeInventory")) {
+        if (tagCompound.hasKey("FilterTypeInventory")) {
             this.filterInventory.deserializeNBT(tagCompound.getCompoundTag("FilterTypeInventory"));
         } else {
             this.filterInventory.deserializeNBT(tagCompound.getCompoundTag("FilterInventory"));
         }
         this.filterWrapper.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
-        if(filterWrapper.getFluidFilter() != null) {
+        if (filterWrapper.getFluidFilter() != null) {
             //LEGACY SAVE FORMAT SUPPORT
-            if(tagCompound.hasKey("FluidFilter")) {
+            if (tagCompound.hasKey("FluidFilter")) {
                 this.filterWrapper.getFluidFilter().readFromNBT(tagCompound);
             } else {
                 NBTTagCompound filterInventory = tagCompound.getCompoundTag("Filter");


### PR DESCRIPTION
**What:**
Added support for liquid filters in pumps (machines) 

**How solved:**
Added a fluid filter widget to the UI, check for liquid type when adding them to the queue and just before pumping the block (to avoid bug in case of block replacement or filter update). Invalidate the queue when switching filter from black/whitelist to white/blacklist and removing/adding the filter.

**Outcome:**
Implement #1532

**Additional info:**
Screenshots of UI : 
![screenshot](https://cdn.discordapp.com/attachments/767558053205508108/823852141474086922/Screenshot_20210323_101729.png)
![screenshot2](https://cdn.discordapp.com/attachments/767558053205508108/823852142951137300/Screenshot_20210323_101755.png)
**Possible compatibility issue:**
None Expected.