### PR TITLE
Fix NPE when something proxies a fluid pipe, e.g. a compact machine

### DIFF
--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -131,7 +131,11 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
         boolean isDestPipe = destinationHandler instanceof FluidPipeFluidHandler;
         if(isSourcePipe && isDestPipe) {
             float sourceThickness = selfTileEntity.getPipeType().getThickness();
-            float destThickness = getPipeTileEntity(otherTileEntity).getPipeType().getThickness();
+            IPipeTile<FluidPipeType, FluidPipeProperties> otherPipe = getPipeTileEntity(otherTileEntity);
+            if (otherPipe == null) {
+                return false;
+            }
+            float destThickness = otherPipe.getPipeType().getThickness();
             return sourceThickness > destThickness;
         }
         return true;


### PR DESCRIPTION
**What:**
There is an NPE when something proxies capabilities of a fluid pipe, e.g. a compact machine.
This is in the code that checks the size of the pipes to see if it can push fluid. 
The size is not obtained through the capability and is obviously unavailable from the proxy tile entity.

**How solved:**
When something proxies the fluid pipe capability, simply disallow pushing  fluids across the proxy from one pipe to another.
In the case of the compact machine tunnel, allowing it would likely lead to recursive death as fluid is pushed back and forth both ways.

**Outcome:**
Fixes #1551

**Additional info:**
I checked the other places that call getPipeTileEntity() and all the others have null checks, except for those that are doing self references which should never return null. e.g. getting the "insulation" of a cable when a mob walks into it to see if damage should be inflicted.

**Possible compatibility issue:**
None. This never could have worked before. So disabling the push instead of crashing is the better solution.
