### PR TITLE
Allow stone variants to output their respective stone dusts

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -29,6 +29,11 @@ public enum OrePrefix {
 
     ore("Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Regular Ore Prefix. Ore -> Material is a Oneway Operation! Introduced by Eloraam
 
+    oreGranite("Granite Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Granite Ore Prefix. Ore -> Material is a Oneway Operation!
+    oreDiorite("Diorite Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Diorite Ore Prefix. Ore -> Material is a Oneway Operation!
+    oreAndesite("Andesite Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Andesite Ore Prefix. Ore -> Material is a Oneway Operation!
+    oreBedrock("Bedrock Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Bedrock Ore Prefix. Ore -> Material is a Oneway Operation!
+
     oreBlackgranite("Black Granite Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // In case of an End-Ores Mod. Ore -> Material is a Oneway Operation!
     oreRedgranite("Red Granite Ores", -1, null, MaterialIconType.ore, ENABLE_UNIFICATION | DISALLOW_RECYCLING, (mat) -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // In case of an End-Ores Mod. Ore -> Material is a Oneway Operation!
 
@@ -267,6 +272,10 @@ public enum OrePrefix {
         block.setIgnored(Materials.Blaze);
 
         ore.addSecondaryMaterial(new MaterialStack(Materials.Stone, dust.materialAmount));
+        oreGranite.addSecondaryMaterial(new MaterialStack(Materials.Granite, dust.materialAmount));
+        oreDiorite.addSecondaryMaterial(new MaterialStack(Materials.Diorite, dust.materialAmount));
+        oreAndesite.addSecondaryMaterial(new MaterialStack(Materials.Andesite, dust.materialAmount));
+        oreBedrock.addSecondaryMaterial(new MaterialStack(Materials.Stone, dust.materialAmount));
         oreRedgranite.addSecondaryMaterial(new MaterialStack(Materials.GraniteRed, dust.materialAmount));
         oreBlackgranite.addSecondaryMaterial(new MaterialStack(Materials.GraniteBlack, dust.materialAmount));
         oreBasalt.addSecondaryMaterial(new MaterialStack(Materials.Basalt, dust.materialAmount));

--- a/src/main/java/gregtech/api/unification/ore/StoneTypes.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneTypes.java
@@ -22,15 +22,15 @@ public class StoneTypes {
         () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.STONE),
         state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.STONE);
 
-    public static StoneType GRANITE = new StoneType(1, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.ore, Materials.GraniteBlack, "pickaxe", 0,
+    public static StoneType GRANITE = new StoneType(1, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.GraniteBlack, "pickaxe", 0,
         () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.GRANITE),
         state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE);
 
-    public static StoneType DIORITE = new StoneType(2, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.ore, Materials.Diorite, "pickaxe", 0,
+    public static StoneType DIORITE = new StoneType(2, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe", 0,
         () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.DIORITE),
         state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE);
 
-    public static StoneType ANDESITE = new StoneType(3, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.ore, Materials.Andesite, "pickaxe", 0,
+    public static StoneType ANDESITE = new StoneType(3, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe", 0,
         () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE),
         state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE);
 
@@ -38,7 +38,7 @@ public class StoneTypes {
         Blocks.GRAVEL::getDefaultState,
         state -> state.getBlock() instanceof BlockGravel);
 
-    public static StoneType BEDROCK = new StoneType(5, "bedrock", new ResourceLocation("blocks/bedrock"), SoundType.STONE, OrePrefix.ore, Materials.Stone, "pickaxe", UNBREAKABLE,
+    public static StoneType BEDROCK = new StoneType(5, "bedrock", new ResourceLocation("blocks/bedrock"), SoundType.STONE, OrePrefix.oreBedrock, Materials.Stone, "pickaxe", UNBREAKABLE,
         Blocks.BEDROCK::getDefaultState,
         state -> state.getBlock() == Blocks.BEDROCK);
 

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -22,14 +22,18 @@ import net.minecraft.item.ItemStack;
 
 public class OreByProduct implements IRecipeWrapper {
 	private final static ImmutableList<OrePrefix> ORES = ImmutableList.of(
-			OrePrefix.ore, 
+			OrePrefix.ore,
+			OrePrefix.oreGranite,
+			OrePrefix.oreDiorite,
+			OrePrefix.oreAndesite,
+			OrePrefix.oreBedrock,
 			OrePrefix.oreBasalt,
-			OrePrefix.oreBlackgranite, 
-			OrePrefix.oreEndstone, 
-			OrePrefix.oreGravel, 
+			OrePrefix.oreBlackgranite,
+			OrePrefix.oreEndstone,
+			OrePrefix.oreGravel,
 			OrePrefix.oreMarble,
-			OrePrefix.oreNetherrack, 
-			OrePrefix.oreRedgranite, 
+			OrePrefix.oreNetherrack,
+			OrePrefix.oreRedgranite,
 			OrePrefix.oreSand);
 
 	private final List<List<ItemStack>> matchingInputs = new ArrayList<>();

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -17,6 +17,10 @@ public class OreRecipeHandler {
 
     public static void register() {
         OrePrefix.ore.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
+        OrePrefix.oreGranite.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
+        OrePrefix.oreDiorite.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
+        OrePrefix.oreAndesite.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
+        OrePrefix.oreBedrock.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
         OrePrefix.oreBasalt.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
         OrePrefix.oreBlackgranite.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);
         OrePrefix.oreEndstone.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processOre);

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -758,8 +758,8 @@ cover.machine_controller.mode.cover_east=Control Cover (East)
 cover.machine_controller.mode.cover_west=Control Cover (West)
 
 # %s is a localized material name
-item.material.oreprefix.oreBlackgranite=Granite %s Ore
-item.material.oreprefix.oreRedgranite=Granite %s Ore
+item.material.oreprefix.oreBlackgranite=Black Granite %s Ore
+item.material.oreprefix.oreRedgranite=Red Granite %s Ore
 item.material.oreprefix.oreMarble=Marble %s Ore
 item.material.oreprefix.oreBasalt=Basalt %s Ore
 item.material.oreprefix.oreSand=Sand %s Ore
@@ -774,6 +774,10 @@ item.material.oreprefix.orePoor=Poor %s Ore
 item.material.oreprefix.oreEndstone=End %s Ore
 item.material.oreprefix.oreEnd=End %s Ore
 item.material.oreprefix.ore=%s Ore
+item.material.oreprefix.oreGranite=Granite %s Ore
+item.material.oreprefix.oreDiorite=Diorite %s Ore
+item.material.oreprefix.oreAndesite=Andesite %s Ore
+item.material.oreprefix.oreBedrock=Bedrock %s Ore
 item.material.oreprefix.crushedCentrifuged=Centrifuged %s Ore
 item.material.oreprefix.crushedPurified=Purified %s Ore
 item.material.oreprefix.crushed=Crushed %s Ore


### PR DESCRIPTION
What:
The stone variants (granite/diorite/andesite) ores (as well as bedrock ore) all have the same ore dictionary entry (ore<Material>) and thus all output stone dust when macerated, even though their respective stone dusts already exist.

How solved:
Changed the OrePrefix to oreGranite, oreDiorite, and oreAndesite and added their respective stone dusts as secondary materials. Since bedrock ore also has the "ore" OrePrefix, I changed it to oreBedrock but kept the regular stone dust as the secondary material since there is no bedrock dust.

Outcome:
Granite/Diorite/Andesite ores now output Granite/Diorite/Andesite dust, respectively, in the macerator.

Additional info:
Someone else is going to have to update the other language files with the new prefixes.
I have also changed the black/red granite prefixes' names to better differentiate them from regular granite.

Possible compatibility issue:
- Granite/Diorite/Andesite/Bedrock ores can no longer be processed by anything that only accepts ore<Material> ore dictionary entries. Previously, things such as Ender IO's SAG mill could process some granite/diorite/andesite/bedrock ores. If desired, this could be solved by changing the normal stone's OrePrefix to something like oreStone, and then adding a second "ore<Material>" ore dictionary entry to all of them in a similar way to how the dustRegular<Material> entry is handled.
- Any CraftTweaker script that relied on these ores being in the same oreDictEntry will no longer work as intended.
