### PR TITLE
Fix TE bottom side texture being rotated.

### DIFF
--- a/src/main/java/gregtech/api/render/Textures.java
+++ b/src/main/java/gregtech/api/render/Textures.java
@@ -8,6 +8,7 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.TransformationList;
 import codechicken.lib.vec.uv.IconTransformation;
+import codechicken.lib.vec.uv.UVTransformationList;
 import gregtech.api.GTValues;
 import gregtech.api.util.GTLog;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -177,8 +178,12 @@ public class Textures {
     public static void renderFace(CCRenderState renderState, Matrix4 translation, IVertexOperation[] ops, EnumFacing face, Cuboid6 bounds, TextureAtlasSprite sprite) {
         BlockFace blockFace = blockFaces.get();
         blockFace.loadCuboidFace(bounds, face.getIndex());
+        UVTransformationList uvList = new UVTransformationList(new IconTransformation(sprite));
+        if (face.getIndex() == 0) {
+            uvList.prepend(new UVmirror(0, 0, bounds.min.z, bounds.max.z));
+        }
         renderState.setPipeline(blockFace, 0, blockFace.verts.length,
-            ArrayUtils.addAll(ops, new TransformationList(translation), new IconTransformation(sprite)));
+                ArrayUtils.addAll(ops, new TransformationList(translation), uvList));
         renderState.render();
     }
 }

--- a/src/main/java/gregtech/api/render/Textures.java
+++ b/src/main/java/gregtech/api/render/Textures.java
@@ -180,7 +180,7 @@ public class Textures {
         blockFace.loadCuboidFace(bounds, face.getIndex());
         UVTransformationList uvList = new UVTransformationList(new IconTransformation(sprite));
         if (face.getIndex() == 0) {
-            uvList.prepend(new UVmirror(0, 0, bounds.min.z, bounds.max.z));
+            uvList.prepend(new UVMirror(0, 0, bounds.min.z, bounds.max.z));
         }
         renderState.setPipeline(blockFace, 0, blockFace.verts.length,
                 ArrayUtils.addAll(ops, new TransformationList(translation), uvList));

--- a/src/main/java/gregtech/api/render/UVMirror.java
+++ b/src/main/java/gregtech/api/render/UVMirror.java
@@ -3,13 +3,13 @@ package gregtech.api.render;
 import codechicken.lib.vec.uv.UV;
 import codechicken.lib.vec.uv.UVTransformation;
 
-public class UVmirror extends UVTransformation{
+public class UVMirror extends UVTransformation{
     public double minU;
     public double maxU;
     public double minV;
     public double maxV;
 
-    public UVmirror(double minU, double maxU, double minV, double maxV) {
+    public UVMirror(double minU, double maxU, double minV, double maxV) {
         this.minU = minU;
         this.maxU = maxU;
         this.minV = minV;

--- a/src/main/java/gregtech/api/render/UVmirror.java
+++ b/src/main/java/gregtech/api/render/UVmirror.java
@@ -1,0 +1,38 @@
+package gregtech.api.render;
+
+import codechicken.lib.vec.uv.UV;
+import codechicken.lib.vec.uv.UVTransformation;
+
+public class UVmirror extends UVTransformation{
+    public double minU;
+    public double maxU;
+    public double minV;
+    public double maxV;
+
+    public UVmirror(double minU, double maxU, double minV, double maxV) {
+        this.minU = minU;
+        this.maxU = maxU;
+        this.minV = minV;
+        this.maxV = maxV;
+    }
+
+    @Override
+    public void apply(UV vec) {
+        if (vec.u == minU) {
+            vec.u = maxU;
+        } else if (vec.u == maxU){
+            vec.u = minU;
+        }
+        if (vec.v == minV) {
+            vec.v = maxV;
+        } else if (vec.v == maxV){
+            vec.v = minV;
+        }
+    }
+
+    @Override
+    public UVTransformation inverse() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
**What:**
Bottom side of TE had their textures rotated, I could not find within our codebase whether we do something with that side so I assume it is a bug with CCL.

**How solved:**
Applied a new UVTransformation only on that side to fix it.

**Outcome:**
Fixes #1533

**Additional info:**
![2021-04-01_22 14 22](https://user-images.githubusercontent.com/66888526/113370958-834ac100-933b-11eb-89cd-58318a516096.png)
