### PR TITLE
Implement ore weight tooltips

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/FillerConfigUtils.java
+++ b/src/main/java/gregtech/api/worldgen/config/FillerConfigUtils.java
@@ -221,5 +221,10 @@ public class FillerConfigUtils {
         public Collection<IBlockState> getPossibleResults() {
             return blockStates;
         }
+
+        @Override
+        public List<Pair<Integer, FillerEntry>> getEntries() {
+            return randomList;
+        }
     }
 }

--- a/src/main/java/gregtech/api/worldgen/filler/FillerEntry.java
+++ b/src/main/java/gregtech/api/worldgen/filler/FillerEntry.java
@@ -4,8 +4,10 @@ import com.google.common.collect.ImmutableList;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import org.apache.commons.lang3.tuple.Pair;
 import stanhebben.zenscript.annotations.ZenClass;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -18,6 +20,10 @@ public interface FillerEntry {
     List<FillerEntry> getSubEntries();
 
     Collection<IBlockState> getPossibleResults();
+
+    default List<Pair<Integer, FillerEntry>> getEntries() {
+        return new ArrayList<>();
+    }
 
     static FillerEntry createSimpleFiller(IBlockState blockState) {
         List<IBlockState> possibleResults = ImmutableList.of(blockState);

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -2,7 +2,6 @@ package gregtech.integration.jei;
 
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.type.Material;
-import gregtech.api.worldgen.config.FillerConfigUtils;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.filler.BlockFiller;
 import gregtech.api.worldgen.filler.FillerEntry;
@@ -22,6 +21,7 @@ import net.minecraft.world.DimensionType;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fluids.*;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -256,8 +256,7 @@ public class GTOreInfo implements IRecipeWrapper {
             }
         }
         else {
-            //TODO: Support for an individual ore's weight in the vein
-            //tooltip.addAll(createOreWeightingTooltip());
+            tooltip.addAll(createOreWeightingTooltip(slotIndex));
         }
     }
 
@@ -301,19 +300,28 @@ public class GTOreInfo implements IRecipeWrapper {
     }
 
     //Creates a tooltip show the weighting of the individual ores in the ore vein
-    //TODO: Figure out a way to get the individual ore weightings from the BlockFiller
-    public List<String> createOreWeightingTooltip() {
+    public List<String> createOreWeightingTooltip(int slotIndex) {
 
         List<String> tooltip = new ArrayList<>();
+        int totalWeight = 0;
+        double weight;
 
         List<FillerEntry> fillerEntries = blockFiller.getAllPossibleStates();
-        for(FillerEntry entry : fillerEntries) {
-
-            /*if(entry instanceof FillerConfigUtils.WeightRandomMatcherEntry) {
-                ((FillerConfigUtils.WeightRandomMatcherEntry) entry)
-            }*/
+        for (FillerEntry entries : fillerEntries) {
+            if (entries != null && !entries.getEntries().isEmpty()) {
+                for (Pair<Integer, FillerEntry> entry : entries.getEntries()) {
+                    totalWeight = totalWeight + entry.getKey();
+                }
+            }
         }
 
+        for(FillerEntry entry : fillerEntries) {
+            if(entry.getEntries() != null && !entry.getEntries().isEmpty()) {
+                Pair<Integer, FillerEntry> entryWithWeight = entry.getEntries().get(slotIndex - 2);
+                weight = Math.round((entryWithWeight.getKey() / (double) totalWeight) * 100);
+                tooltip.add("Weight in vein: " + weight + "%");
+            }
+        }
 
         return tooltip;
     }


### PR DESCRIPTION
**What:**
This PR implements weighting tooltips for the recently added Ore Generation Page. The weighting tooltip is the percentage weight of a specific ore out of the total weight in the vein.

**How solved:**
A `default` method was added to the `FillerEntry` Interface allowing for retrieving the weight and the contents of the `Filler`. This was the only way that I could see this being implemented without changing some methods in the API.

**Outcome:**
Implements display of an ore's weight in the vein. Closes #1501.

**Additional info:**
![java_2021-04-06_15-20-19](https://user-images.githubusercontent.com/31759736/113786276-abe10b00-96ed-11eb-97ce-de097e711e4e.png)


**Possible compatibility issue:**
There should not be any compatibility issues due to the fact that a default method was used