### PR TITLE
Fixed Global Renderer in MetaTileEntityTESR

### DIFF
--- a/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
@@ -125,15 +125,22 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
 
     @Override
     public boolean isGlobalRenderer(MetaTileEntityHolder te) {
-        if(te instanceof IRenderMetaTileEntity && ((IRenderMetaTileEntity) te).isGlobalRenderer()) {
-            return true;
-        } else if(te instanceof IFastRenderMetaTileEntity && ((IFastRenderMetaTileEntity) te).isGlobalRenderer()) {
-            return true;
+        if (te instanceof IRenderMetaTileEntity) {
+            if (((IRenderMetaTileEntity) te).isGlobalRenderer()) {
+                return true;
+            }
+        } else if (te instanceof IFastRenderMetaTileEntity) {
+            if (((IFastRenderMetaTileEntity) te).isGlobalRenderer()) {
+                return true;
+            }
         }
-        if (te.getMetaTileEntity() instanceof IRenderMetaTileEntity && ((IRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer()) {
-            return true;
-        } else {
-            return te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity && ((IFastRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer();
+        if (te.getMetaTileEntity() instanceof IRenderMetaTileEntity) {
+            if (((IRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer()) {
+                return true;
+            }
+        } else if (te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity){
+            return ((IFastRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer();
         }
+        return false;
     }
 }

--- a/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/api/render/MetaTileEntityTESR.java
@@ -125,11 +125,15 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
 
     @Override
     public boolean isGlobalRenderer(MetaTileEntityHolder te) {
-        if(te instanceof IRenderMetaTileEntity) {
-            return ((IRenderMetaTileEntity) te).isGlobalRenderer();
-        } else if(te instanceof IFastRenderMetaTileEntity) {
-            return ((IFastRenderMetaTileEntity) te).isGlobalRenderer();
+        if(te instanceof IRenderMetaTileEntity && ((IRenderMetaTileEntity) te).isGlobalRenderer()) {
+            return true;
+        } else if(te instanceof IFastRenderMetaTileEntity && ((IFastRenderMetaTileEntity) te).isGlobalRenderer()) {
+            return true;
         }
-        return false;
+        if (te.getMetaTileEntity() instanceof IRenderMetaTileEntity && ((IRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer()) {
+            return true;
+        } else {
+            return te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity && ((IFastRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer();
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -134,6 +134,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
     protected void moveItemsInEffectRange() {
         List<EntityItem> itemsInRange = getWorld().getEntitiesWithinAABB(EntityItem.class, areaBoundingBox);
         for (EntityItem entityItem : itemsInRange) {
+            if (entityItem.isDead) continue;
             double distanceX = (areaCenterPos.getX() + 0.5) - entityItem.posX;
             double distanceZ = (areaCenterPos.getZ() + 0.5) - entityItem.posZ;
             double distance = MathHelper.sqrt(distanceX * distanceX + distanceZ * distanceZ);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -134,7 +134,6 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
     protected void moveItemsInEffectRange() {
         List<EntityItem> itemsInRange = getWorld().getEntitiesWithinAABB(EntityItem.class, areaBoundingBox);
         for (EntityItem entityItem : itemsInRange) {
-            if (entityItem.isDead) continue;
             double distanceX = (areaCenterPos.getX() + 0.5) - entityItem.posX;
             double distanceZ = (areaCenterPos.getZ() + 0.5) - entityItem.posZ;
             double distance = MathHelper.sqrt(distanceX * distanceX + distanceZ * distanceZ);


### PR DESCRIPTION
**What:**
1. Fixed an issue where the original logic only checked the MTEHolder but ignored the metatileEntity it held. The final rendering is still performed by a metatileEntity instead of its' holder, so I think this is an oversight. Some additional mods may require this function to be executed correctly when rendering block (e.g. the central monitor of gregicality)

2. Fixed an issue that ItemCollector has a bug which can copy item. #1578 

**How solved:**
1. added checking logic.

2. check whether EntityItem has been killed.