### PR TITLE
Fix MCP Mapping Issue

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/ItemFuelInfo.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemFuelInfo.java
@@ -15,6 +15,6 @@ public class ItemFuelInfo extends AbstractFuelInfo {
     }
 
     public String getFuelName() {
-        return itemStack.getUnlocalizedName();
+        return itemStack.getTranslationKey();
     }
 }


### PR DESCRIPTION
There was only one place that the mapping was wrong, `ItemFuelInfo#getFuelName` using `getUnlocalizedName` still. Otherwise, I was able to setup my environment and launch the game just fine.
