### PR TITLE
Expose Some Fields to CraftTweaker

### DIFF
--- a/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
@@ -64,9 +64,11 @@ public class IngotMaterial extends SolidMaterial {
     /**
      * Blast furnace temperature of this material
      * Equal to zero if material doesn't use blast furnace
-     * If below 1000C, primitive blast furnace recipes will be also added
+     * If below 1000C, primitive blast furnace recipes will be also added.
+     * If above 1750C, a Hot Ingot and its Vacuum Freezer recipe will be also added.
      */
-    public final int blastFurnaceTemperature;
+    @ZenProperty("blastFurnaceTemp")
+    public int blastFurnaceTemperature;
 
     /**
      * If set, cable will be generated for this material with base stats

--- a/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
@@ -67,8 +67,8 @@ public class IngotMaterial extends SolidMaterial {
      * If below 1000K, primitive blast furnace recipes will be also added.
      * If above 1750K, a Hot Ingot and its Vacuum Freezer recipe will be also added.
      */
-    @ZenProperty("blastFurnaceTemp")
-    public int blastFurnaceTemperature;
+    @ZenProperty
+    public final int blastFurnaceTemperature;
 
     /**
      * If set, cable will be generated for this material with base stats

--- a/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/type/IngotMaterial.java
@@ -64,8 +64,8 @@ public class IngotMaterial extends SolidMaterial {
     /**
      * Blast furnace temperature of this material
      * Equal to zero if material doesn't use blast furnace
-     * If below 1000C, primitive blast furnace recipes will be also added.
-     * If above 1750C, a Hot Ingot and its Vacuum Freezer recipe will be also added.
+     * If below 1000K, primitive blast furnace recipes will be also added.
+     * If above 1750K, a Hot Ingot and its Vacuum Freezer recipe will be also added.
      */
     @ZenProperty("blastFurnaceTemp")
     public int blastFurnaceTemperature;

--- a/src/main/java/gregtech/api/unification/material/type/SolidMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/type/SolidMaterial.java
@@ -49,6 +49,7 @@ public abstract class SolidMaterial extends DustMaterial {
      * Attack damage of tools made from this material
      * Usually equal to material's harvest level
      */
+    @ZenProperty
     public final float toolAttackDamage;
 
     /**


### PR DESCRIPTION
**What:**
This PR simply exposes `IngotMaterial#blastFurnaceTemperature` and `SolidMaterial#toolAttackDamage` to CraftTweaker as ZenProperties.

Blast furnace temperature was requested via issue #1526, and tool attack damage was requested in Discord, and was the only field in `SolidMaterial` to not have a ZenProperty annotation, so it makes sense to apply it.

**Outcome:**
- Blast Furnace Temperature and Tool Attack Damage exposed to CraftTweaker.
- Closes #1526

**Possible compatibility issue:**
None expected.