### PR TITLE
Fix 12th layer for DT

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -54,7 +54,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
         Predicate<PatternMatchContext> exactlyOneHatch = context -> context.getInt("HatchesAmount") == 1;
         return FactoryBlockPattern.start(RIGHT, FRONT, UP)
             .aisle("YSY", "YZY", "YYY")
-            .aisle("XXX", "X#X", "XXX").setRepeatable(0, 10)
+            .aisle("XXX", "X#X", "XXX").setRepeatable(0, 11)
             .aisle("XXX", "XXX", "XXX")
             .where('S', selfPredicate())
             .where('Z', abilityPartPredicate(MultiblockAbility.IMPORT_FLUIDS))


### PR DESCRIPTION
**What:**
This PR fixes an issue where the Distillation Tower would not form with 12 layers for fluid output hatches, despite the RecipeMap supporting up to 12 outputs. This was not an issue for us, since none of our recipes use all 12 fluid outputs, but this could easily be an issue for addons and modpacks.

**Outcome:**
- DT can now properly have 12 layers

**Possible compatibility issue:**
None expected.