### PR TITLE
Open Up Machine Base Texture API Method

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
@@ -50,7 +50,7 @@ public abstract class SteamMetaTileEntity extends MetaTileEntity {
     }
 
     @SideOnly(Side.CLIENT)
-    private SimpleSidedCubeRenderer getBaseRenderer() {
+    protected SimpleSidedCubeRenderer getBaseRenderer() {
         if (isHighPressure) {
             if (isBrickedCasing()) {
                 return Textures.STEAM_BRICKED_CASING_STEEL;

--- a/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
@@ -52,7 +52,7 @@ public abstract class TieredMetaTileEntity extends MetaTileEntity implements IEn
     }
 
     @SideOnly(Side.CLIENT)
-    private SimpleSidedCubeRenderer getBaseRenderer() {
+    protected SimpleSidedCubeRenderer getBaseRenderer() {
         return Textures.VOLTAGE_CASINGS[tier];
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -77,7 +77,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
     }
 
     @SideOnly(Side.CLIENT)
-    private SimpleSidedCubeRenderer getBaseRenderer() {
+    protected SimpleSidedCubeRenderer getBaseRenderer() {
         if (isHighPressure) {
             return Textures.STEAM_BRICKED_CASING_STEEL;
         } else {


### PR DESCRIPTION
**What:**
This PR is extremely simple; all it does is set the method `getBaseRenderer` to protected instead of private in:
- `TieredMetaTileEntity`
- `SteamMetaTileEntity`
- `SteamBoiler`

Addons and other machines we choose to add can now override the base texture of these types of MetaTileEntity if they so choose.

**Outcome:**
- Open up machine base texture method to API

**Possible compatibility issue:**
None expected.