### PR TITLE
Fix Tooltips in JEI Recipes

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -119,7 +119,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
             throw new IllegalArgumentException("Unknown ingredient type: " + ingredient.getClass());
         }
 
-        if (entry != null) {
+        if (entry != null && !input) {
             double chance = entry.getChance() / 100.0;
             double boost = entry.getBoostPerTier() / 100.0;
             tooltip.add(I18n.format("gregtech.recipe.chance", chance, boost));

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -123,7 +123,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
             double chance = entry.getChance() / 100.0;
             double boost = entry.getBoostPerTier() / 100.0;
             tooltip.add(I18n.format("gregtech.recipe.chance", chance, boost));
-        } else if (notConsumed) {
+        } else if (notConsumed && input) {
             tooltip.add(I18n.format("gregtech.recipe.not_consumed"));
         }
     }


### PR DESCRIPTION
**What:**
This PR fixes a very minor visual issue in JEI where, if a recipe has a not consumed input, and that same ingredient as an output, the output will also have the "notConsumed" tooltip applied to it. This could also occur if a chanced output was also an input.

**How solved:**
Added checks to make sure chanced and not consumed tooltips are only applied to the correct side ingredient side.

**Outcome:**
- Fix not consumed and chance tooltips on wrong ingredients in JEI

**Possible compatibility issue:**
None expected.