### PR TITLE
Properly implementing fluid tooltips

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -139,9 +139,9 @@ public class TankWidget extends Widget implements IIngredientSlot {
                 tooltips.add(fluid.getLocalizedName(lastFluidInTank));
 
                 // Add chemical formula tooltip
-                String formula = FluidTooltipUtil.getFluidTooltip(lastFluidInTank);
+                List<String> formula = FluidTooltipUtil.getFluidTooltip(lastFluidInTank);
                 if (formula != null && !formula.isEmpty())
-                    tooltips.add(ChatFormatting.GRAY.toString() + formula);
+                    tooltips.addAll(formula);
 
                 tooltips.add(I18n.format("gregtech.fluid.amount", lastFluidInTank.amount, lastTankCapacity));
                 tooltips.add(I18n.format("gregtech.fluid.temperature", fluid.getTemperature(lastFluidInTank)));

--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -141,7 +141,7 @@ public class TankWidget extends Widget implements IIngredientSlot {
                 // Add chemical formula tooltip
                 List<String> formula = FluidTooltipUtil.getFluidTooltip(lastFluidInTank);
                 if (formula != null && !formula.isEmpty())
-                    tooltips.addAll(formula);
+                    tooltips.addAll(1, formula);
 
                 tooltips.add(I18n.format("gregtech.fluid.amount", lastFluidInTank.amount, lastTankCapacity));
                 tooltips.add(I18n.format("gregtech.fluid.temperature", fluid.getTemperature(lastFluidInTank)));

--- a/src/main/java/gregtech/api/util/FluidTooltipUtil.java
+++ b/src/main/java/gregtech/api/util/FluidTooltipUtil.java
@@ -1,5 +1,7 @@
 package gregtech.api.util;
 
+import com.google.common.collect.Lists;
+import com.mojang.realmsclient.gui.ChatFormatting;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.stack.MaterialStack;
 import net.minecraftforge.fluids.Fluid;
@@ -7,6 +9,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FluidTooltipUtil {
@@ -14,7 +17,7 @@ public class FluidTooltipUtil {
     /**
      * Registry Mapping of <Fluid, Tooltip>
      */
-    private static final Map<Fluid, String> tooltips = new HashMap<>();
+    private static final Map<Fluid, List<String>> tooltips = new HashMap<>();
 
     /**
      * Used to register a tooltip to a Fluid. A Fluid can only have one tooltip, on one line.
@@ -25,13 +28,31 @@ public class FluidTooltipUtil {
      * @param tooltip The tooltip.
      * @return        False if either parameter is null or if tooltip is empty, true otherwise.
      */
-    public static boolean registerTooltip(Fluid fluid, String tooltip) {
+    public static boolean registerTooltip(Fluid fluid, List<String> tooltip) {
         if (fluid != null && tooltip != null && !tooltip.isEmpty()) {
-            tooltips.put(fluid, tooltip);
-            return true;
+            if(tooltips.containsKey(fluid)) {
+                tooltips.get(fluid).addAll(tooltip);
+            } else {
+                tooltips.put(fluid, tooltip);
+                return true;
+            }
         }
         return false;
     }
+
+    public static boolean registerTooltip(Fluid fluid, String tooltip) {
+        if (fluid != null && tooltip != null && !tooltip.isEmpty()) {
+            if(tooltips.containsKey(fluid)) {
+                tooltips.get(fluid).add(tooltip);
+            } else {
+                tooltips.put(fluid, Lists.newArrayList(tooltip));
+                return true;
+            }
+        }
+        return false;
+    }
+
+
 
     /**
      * Used to get a Fluid's tooltip.
@@ -39,7 +60,7 @@ public class FluidTooltipUtil {
      * @param fluid The Fluid to get the tooltip of.
      * @return      The tooltip.
      */
-    public static String getFluidTooltip(Fluid fluid) {
+    public static List<String> getFluidTooltip(Fluid fluid) {
         if (fluid == null)
             return null;
 
@@ -52,7 +73,7 @@ public class FluidTooltipUtil {
      * @param stack A FluidStack, containing the Fluid to get the tooltip of.
      * @return      The tooltip.
      */
-    public static String getFluidTooltip(FluidStack stack) {
+    public static List<String> getFluidTooltip(FluidStack stack) {
         if (stack == null)
             return null;
 
@@ -65,7 +86,7 @@ public class FluidTooltipUtil {
      * @param fluidName A String representing a Fluid to get the tooltip of.
      * @return          The tooltip.
      */
-    public static String getFluidTooltip(String fluidName) {
+    public static List<String> getFluidTooltip(String fluidName) {
         if (fluidName == null || fluidName.isEmpty())
             return null;
 
@@ -79,6 +100,6 @@ public class FluidTooltipUtil {
      */
     public static String getWaterTooltip() {
         // Done like this to not return parenthesis around the tooltip
-        return (new MaterialStack(Materials.Hydrogen, 2)).toString() + "O";
+        return (ChatFormatting.GRAY + (new MaterialStack(Materials.Hydrogen, 2)).toString() + "O");
     }
 }

--- a/src/main/java/gregtech/common/ClientProxy.java
+++ b/src/main/java/gregtech/common/ClientProxy.java
@@ -178,7 +178,7 @@ public class ClientProxy extends CommonProxy {
                 chemicalFormula = Lists.newArrayList(FluidTooltipUtil.getWaterTooltip());
             }
             if (chemicalFormula != null && !chemicalFormula.isEmpty())
-                event.getToolTip().addAll(chemicalFormula);
+                event.getToolTip().addAll(1, chemicalFormula);
         }
     }
 

--- a/src/main/java/gregtech/common/ClientProxy.java
+++ b/src/main/java/gregtech/common/ClientProxy.java
@@ -3,6 +3,7 @@ package gregtech.common;
 import codechicken.lib.texture.TextureUtils;
 import codechicken.lib.util.ItemNBTUtils;
 import codechicken.lib.util.ResourceUtils;
+import com.google.common.collect.Lists;
 import com.mojang.authlib.minecraft.MinecraftProfileTexture.Type;
 import com.mojang.realmsclient.gui.ChatFormatting;
 import gregtech.api.GTValues;
@@ -56,10 +57,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @SideOnly(Side.CLIENT)
 @Mod.EventBusSubscriber(Side.CLIENT)
@@ -154,12 +152,12 @@ public class ClientProxy extends CommonProxy {
 
         // Handles Item tooltips
         if (!(itemStack.getItem() instanceof ItemBlock)) {
-            String chemicalFormula = null;
+            List<String> chemicalFormula = null;
 
             // Test for Items
             UnificationEntry unificationEntry = OreDictUnifier.getUnificationEntry(itemStack);
             if (unificationEntry != null && unificationEntry.material != null) {
-                chemicalFormula = unificationEntry.material.chemicalFormula;
+                chemicalFormula = Lists.newArrayList(ChatFormatting.GRAY + unificationEntry.material.chemicalFormula);
 
             // Test for Fluids
             } else if (ItemNBTUtils.hasTag(itemStack)) {
@@ -177,10 +175,10 @@ public class ClientProxy extends CommonProxy {
 
             // Water buckets have a separate registry name from other buckets
             } else if(itemStack.getItem().equals(Items.WATER_BUCKET)) {
-                chemicalFormula = FluidTooltipUtil.getWaterTooltip();
+                chemicalFormula = Lists.newArrayList(FluidTooltipUtil.getWaterTooltip());
             }
             if (chemicalFormula != null && !chemicalFormula.isEmpty())
-                event.getToolTip().add(1, ChatFormatting.GRAY.toString() + chemicalFormula);
+                event.getToolTip().addAll(chemicalFormula);
         }
     }
 

--- a/src/main/java/gregtech/common/MetaFluids.java
+++ b/src/main/java/gregtech/common/MetaFluids.java
@@ -1,5 +1,6 @@
 package gregtech.common;
 
+import com.mojang.realmsclient.gui.ChatFormatting;
 import gregtech.api.GTValues;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.FluidMaterial;
@@ -145,12 +146,12 @@ public class MetaFluids {
                 int temperature = fluidMaterial.getFluidTemperature();
                 Fluid fluid = registerFluid(fluidMaterial, FluidType.NORMAL, temperature);
                 fluidMaterial.setMaterialFluid(fluid);
-                FluidTooltipUtil.registerTooltip(fluid, fluidMaterial.chemicalFormula);
+                FluidTooltipUtil.registerTooltip(fluid, ChatFormatting.GRAY + fluidMaterial.chemicalFormula);
             }
             if (fluidMaterial.shouldGeneratePlasma() && fluidMaterial.getMaterialPlasma() == null) {
                 Fluid fluid = registerFluid(fluidMaterial, FluidType.PLASMA, 30000);
                 fluidMaterial.setMaterialPlasma(fluid);
-                FluidTooltipUtil.registerTooltip(fluid, fluidMaterial.chemicalFormula);
+                FluidTooltipUtil.registerTooltip(fluid, ChatFormatting.GRAY + fluidMaterial.chemicalFormula);
             }
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -682,9 +682,9 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
             if (fluidStack != null) {
                 tooltip.add(I18n.format("gregtech.machine.fluid_tank.fluid", fluidStack.amount, fluidStack.getLocalizedName()));
             }
-            String formula = FluidTooltipUtil.getFluidTooltip(fluidStack);
-            if (formula != null)
-                tooltip.add(TextFormatting.GRAY + formula);
+            List<String> tooltips = FluidTooltipUtil.getFluidTooltip(fluidStack);
+            if (tooltips != null)
+                tooltip.addAll(tooltips);
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -684,7 +684,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
             }
             List<String> tooltips = FluidTooltipUtil.getFluidTooltip(fluidStack);
             if (tooltips != null)
-                tooltip.addAll(tooltips);
+                tooltip.addAll(1, tooltips);
         }
     }
 

--- a/src/main/java/gregtech/integration/jei/utils/JEIHooks.java
+++ b/src/main/java/gregtech/integration/jei/utils/JEIHooks.java
@@ -21,7 +21,7 @@ public class JEIHooks {
         if (ingredient instanceof FluidStack) {
             List<String> formula = FluidTooltipUtil.getFluidTooltip(((FluidStack) ingredient).getFluid());
             if (formula != null && !formula.isEmpty()) {
-                tooltip.addAll(formula);
+                tooltip.addAll(1, formula);
             }
         }
     }

--- a/src/main/java/gregtech/integration/jei/utils/JEIHooks.java
+++ b/src/main/java/gregtech/integration/jei/utils/JEIHooks.java
@@ -19,9 +19,9 @@ public class JEIHooks {
      */
     public static void addFluidTooltip(List<String> tooltip, Object ingredient) {
         if (ingredient instanceof FluidStack) {
-            String formula = FluidTooltipUtil.getFluidTooltip(((FluidStack) ingredient).getFluid());
+            List<String> formula = FluidTooltipUtil.getFluidTooltip(((FluidStack) ingredient).getFluid());
             if (formula != null && !formula.isEmpty()) {
-                tooltip.add(1, ChatFormatting.GRAY + formula);
+                tooltip.addAll(formula);
             }
         }
     }


### PR DESCRIPTION
What:  
This PR allows for people to implement their own tooltips, with more than one line. 

How solved:  
This is solved by allowing for the user to pass a list through the argument, and storing them as a list.

Additional Info:  
GTCE formula tooltips should still be put at index of one and show up in machine slots, and tank tooltips.
