### PR TITLE
Update to Forked ForgeGradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,16 +27,16 @@ buildscript {
     repositories {
         jcenter()
         maven {
+            name = "jitpack"
+            setUrl("https://jitpack.io")
+        }
+        maven {
             name = "forge"
             setUrl("https://maven.minecraftforge.net/")
         }
-        maven {
-            name = "MC"
-            setUrl("https://libraries.minecraft.net/")
-        }
     }
     dependencies {
-        classpath("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT")
+        classpath("com.github.GregTechCE:ForgeGradle:FG_2.3-SNAPSHOT")
         classpath("org.eclipse.jgit:org.eclipse.jgit:5.5.0.201909110433-r")
     }
 }
@@ -124,15 +124,6 @@ repositories {
         name = "CCL Maven New"
         setUrl("https://minecraft.curseforge.com/api/maven")
     }
-    maven {
-        name = "forge"
-        setUrl("https://maven.minecraftforge.net/")
-    }
-    maven {
-        name = "MC"
-        setUrl("https://libraries.minecraft.net/")
-    }
-    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
**What:**
This PR updates our `build.gradle.kts` to use our newly forked copy of ForgeGradle 2.3. This means that our fork is technically functional, though I have not yet fixed some of the other bugs that are present in FG2.3. This should mean a return to where things were before the Forge Maven repository relocation.

When testing, make sure to run:
```
./gradlew --refresh-dependencies
```
before doing your normal setup tasks.

**How solved:**
Used [Jitpack](https://jitpack.io/) to package our forked ForgeGradle 2.3 and use it in GregTechCE itself.

**Outcome:**
- Fix build.gradle.kts

**Additional info:**
I updated the README of our forked ForgeGradle 2.3 so that if others found it, it would be clear on both:
- How to use it for themselves without needing to ask, and
- The fact that we hold zero responsibility to fix issues other users of the fork have with it

Like we discussed, we should not "advertise" this fork to other mod developers, but on the chance they find it, I believe that README should be descriptive enough to help them if they want to use it, and inform them of our stance on its usage.

**Possible compatibility issue:**
None expected.