### PR TITLE
Do not spawn rubber trees in water, looks ugly

### DIFF
--- a/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
+++ b/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
@@ -46,6 +46,11 @@ public class WorldGenRubberTree implements IWorldGenerator {
             BlockGregSapling sapling = MetaBlocks.SAPLING;
             if (solidBlockState.getBlock().canSustainPlant(solidBlockState, world, randomPos, EnumFacing.UP, sapling)) {
                 BlockPos abovePos = randomPos.up();
+                IBlockState aboveState = world.getBlockState(abovePos);
+                if (aboveState.getBlock() instanceof BlockLiquid) {
+                    return;
+                }
+                
                 IBlockState saplingState = sapling.getDefaultState()
                     .withProperty(BlockGregSapling.VARIANT, LogVariant.RUBBER_WOOD);
                 world.setBlockState(abovePos, saplingState);

--- a/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
+++ b/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
@@ -3,6 +3,7 @@ package gregtech.common.worldgen;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.wood.BlockGregLog.LogVariant;
 import gregtech.common.blocks.wood.BlockGregSapling;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;


### PR DESCRIPTION
**What:**
Prevents rubber trees from spawning in water. Looks fugly otherwise: (see screenshot below)

**How solved:**
Prevent spawning by checking if the above block is a liquid. We wouldn't want them to spawn in lava or oil, too.

**Outcome:**
Changed rubber tree spawning to not spawn in water (or any other liquid)

**Additional info:**
![2021-05-07_17 32 13](https://user-images.githubusercontent.com/75377/117475705-a846db00-af5c-11eb-8670-2e062cf31943.png)

By the way, the so called `randomPos` is used in `WorldGenRubberTree` is not, well, really random... but that's another story.

**Possible compatibility issue:**
I don't see any.
