### PR TITLE
Switching Hay Bale recipe from Compressor to Packager

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -57,6 +57,9 @@ import static gregtech.common.items.MetaItems.*;
 
 public class MachineRecipeLoader {
 
+    private MachineRecipeLoader() {
+    }
+
     public static void init() {
         ChemistryRecipes.init();
         FuelRecipes.registerFuels();
@@ -81,7 +84,13 @@ public class MachineRecipeLoader {
     private static void registerBendingCompressingRecipes() {
         RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.ICE, 2, OreDictionary.WILDCARD_VALUE)).outputs(new ItemStack(Blocks.PACKED_ICE)).buildAndRegister();
         RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder().input(OrePrefix.dust, Materials.Ice, 1).outputs(new ItemStack(Blocks.ICE)).buildAndRegister();
-        RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder().inputs(new ItemStack(Items.WHEAT, 9)).outputs(new ItemStack(Blocks.HAY_BLOCK)).buildAndRegister();
+
+        RecipeMaps.PACKER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Items.WHEAT, 9))
+                .inputs(new CountableIngredient(new IntCircuitIngredient(9), 0))
+                .outputs(new ItemStack(Blocks.HAY_BLOCK))
+                .duration(200).EUt(2)
+                .buildAndRegister();
 
         RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder()
             .input(OrePrefix.dust, Materials.Fireclay)


### PR DESCRIPTION
**What:**
Change Hay Bale recipe from Compressor to Packager to avoid conflict with Plant balls recipe.
Circuit configuration 9 is not consumed but needed for recipe.
Also time for processing was halved.

**Outcome:**
Fixes: #1487 
Supersedes: #1488

**Additional info:**
Before:
![2021-05-08_12 29 48](https://user-images.githubusercontent.com/3093101/117536909-0ed00580-affe-11eb-91ea-3dc75a83e02d.png)

After:
![2021-05-08_12 51 15](https://user-images.githubusercontent.com/3093101/117536915-15f71380-affe-11eb-9252-f652343d6236.png)

**Possible compatibility issue:**
Recipe removed