### PR TITLE
Using MetaItems using FoodStats with a Non-Null containerItem now return that ItemStack to the Player

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/FoodStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodStats.java
@@ -67,22 +67,32 @@ public class FoodStats implements IFoodBehavior {
     }
 
     @Override
-    public void onEaten(ItemStack itemStack, EntityPlayer player) {
+    public ItemStack onEaten(ItemStack itemStack, EntityPlayer player) {
         if (!player.world.isRemote) {
             for (RandomPotionEffect potionEffect : potionEffects) {
                 if (Math.random() * 100 > potionEffect.chance) {
                     player.addPotionEffect(GTUtility.copyPotionEffect(potionEffect.effect));
                 }
             }
-        }
-        else {
+
             if (containerItem != null) {
-                ItemStack containerItemCopy = containerItem.copy();
-                if (!(player.inventory.hasItemStack(containerItemCopy) /* The following function deletes the item if this is false. */ && player.inventory.addItemStackToInventory(GTUtility.withEmptyTag(containerItemCopy)))) {
-                    player.dropItem(containerItemCopy, false, true);
+                ItemStack containerItemCopy = containerItem.copy(); // Get the copy
+                if (player == null || !player.capabilities.isCreativeMode)
+                {
+                    if (itemStack.isEmpty())
+                    {
+                        return containerItemCopy;
+                    }
+
+                    if (player != null)
+                    {
+                        if (!player.inventory.addItemStackToInventory(containerItemCopy))
+                            player.dropItem(containerItemCopy, false, false);
+                    }
                 }
             }
         }
+        return itemStack;
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/metaitem/FoodStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodStats.java
@@ -74,6 +74,11 @@ public class FoodStats implements IFoodBehavior {
                     player.addPotionEffect(GTUtility.copyPotionEffect(potionEffect.effect));
                 }
             }
+            if (containerItem != null) {
+                if (player.inventory.addItemStackToInventory(containerItem)) {
+                    player.dropItem(containerItem, true, true);
+                }
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/items/metaitem/FoodStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodStats.java
@@ -74,9 +74,12 @@ public class FoodStats implements IFoodBehavior {
                     player.addPotionEffect(GTUtility.copyPotionEffect(potionEffect.effect));
                 }
             }
+        }
+        else {
             if (containerItem != null) {
-                if (player.inventory.addItemStackToInventory(containerItem)) {
-                    player.dropItem(containerItem, true, true);
+                ItemStack containerItemCopy = containerItem.copy();
+                if (!(player.inventory.hasItemStack(containerItemCopy) /* The following function deletes the item if this is false. */ && player.inventory.addItemStackToInventory(GTUtility.withEmptyTag(containerItemCopy)))) {
+                    player.dropItem(containerItemCopy, false, true);
                 }
             }
         }

--- a/src/main/java/gregtech/api/items/metaitem/FoodStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodStats.java
@@ -67,7 +67,13 @@ public class FoodStats implements IFoodBehavior {
     }
 
     @Override
-    public ItemStack onEaten(ItemStack itemStack, EntityPlayer player) {
+    @Deprecated
+    public void onEaten(ItemStack itemStack, EntityPlayer player) {
+        onFoodEaten(itemStack, player);
+    }
+
+    @Override
+    public ItemStack onFoodEaten(ItemStack itemStack, EntityPlayer player) {
         if (!player.world.isRemote) {
             for (RandomPotionEffect potionEffect : potionEffects) {
                 if (Math.random() * 100 > potionEffect.chance) {
@@ -77,10 +83,8 @@ public class FoodStats implements IFoodBehavior {
 
             if (containerItem != null) {
                 ItemStack containerItemCopy = containerItem.copy(); // Get the copy
-                if (player == null || !player.capabilities.isCreativeMode)
-                {
-                    if (itemStack.isEmpty())
-                    {
+                if (player == null || !player.capabilities.isCreativeMode) {
+                    if (itemStack.isEmpty()) {
                         return containerItemCopy;
                     }
 

--- a/src/main/java/gregtech/api/items/metaitem/FoodUseManager.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodUseManager.java
@@ -52,7 +52,7 @@ public class FoodUseManager implements IItemBehaviour, IItemUseManager {
     public ItemStack onItemUseFinish(ItemStack stack, EntityPlayer player) {
         stack.shrink(1);
         player.getFoodStats().addStats(foodStats.getFoodLevel(stack, player), foodStats.getSaturation(stack, player));
-        return foodStats.onEaten(stack, player);
+        return foodStats.onFoodEaten(stack, player);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/metaitem/FoodUseManager.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodUseManager.java
@@ -52,8 +52,7 @@ public class FoodUseManager implements IItemBehaviour, IItemUseManager {
     public ItemStack onItemUseFinish(ItemStack stack, EntityPlayer player) {
         stack.shrink(1);
         player.getFoodStats().addStats(foodStats.getFoodLevel(stack, player), foodStats.getSaturation(stack, player));
-        foodStats.onEaten(stack, player);
-        return stack;
+        return foodStats.onEaten(stack, player);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
@@ -17,7 +17,15 @@ public interface IFoodBehavior extends IItemComponent {
 
     EnumAction getFoodAction(ItemStack itemStack);
 
-    ItemStack onEaten(ItemStack itemStack, EntityPlayer player);
+    // Please call onFoodEaten instead.
+    @Deprecated
+    void onEaten(ItemStack stack, EntityPlayer player);
+
+    default ItemStack onFoodEaten(ItemStack stack, EntityPlayer player) {
+        onEaten(stack, player);
+
+        return stack;
+    }
 
     void addInformation(ItemStack itemStack, List<String> lines);
 

--- a/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
@@ -17,7 +17,7 @@ public interface IFoodBehavior extends IItemComponent {
 
     EnumAction getFoodAction(ItemStack itemStack);
 
-    void onEaten(ItemStack itemStack, EntityPlayer player);
+    ItemStack onEaten(ItemStack itemStack, EntityPlayer player);
 
     void addInformation(ItemStack itemStack, List<String> lines);
 

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -243,6 +243,10 @@ public class GTUtility {
         return merged;
     }
 
+    public static ItemStack withEmptyTag(ItemStack stack) {
+        return new ItemStack(stack.getItem(), 1, stack.getItemDamage());
+    }
+
     public static boolean harvestBlock(World world, BlockPos pos, EntityPlayer player) {
         IBlockState blockState = world.getBlockState(pos);
         TileEntity tileEntity = world.getTileEntity(pos);

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -243,10 +243,6 @@ public class GTUtility {
         return merged;
     }
 
-    public static ItemStack withEmptyTag(ItemStack stack) {
-        return new ItemStack(stack.getItem(), 1, stack.getItemDamage());
-    }
-
     public static boolean harvestBlock(World world, BlockPos pos, EntityPlayer player) {
         IBlockState blockState = world.getBlockState(pos);
         TileEntity tileEntity = world.getTileEntity(pos);


### PR DESCRIPTION
**What:**
Previously, although containerItem was one of the fields within FoodStats, it was not used in any way, thus causing the player to not receive the ItemStack once it was eaten. This PR intends to fix this issue.

**How solved:**
After looking through vanilla ItemPotion code, I found the suitable portion of logic required to correctly return the container to the player, which indicated that the resulting stack would need to be passed through onItemUseFinish, which unfortunately made it a requirement that onEaten would need to return an ItemStack, thus causing a minor API change.

**Outcome:**
Using FoodStats with Non-Null containerItems return the container to the player.
Most notably, this now means that Purple Drink will now return a bottle after being consumed.
I do not believe there are any previous issues mentioning this problem previously, nor could I find any.

**Additional info:**
https://user-images.githubusercontent.com/80226372/117707562-5092b480-b194-11eb-81d6-7739e98503dd.mp4
This showcases this PR working upon Purple Drink.

**Possible compatibility issue:**
Any addons that do implement their own onEaten methods will require them to return an ItemStack now, although I do not believe there are any that do so, considering that the method is implemented already through the common implementation of IFoodBehavior.