### PR TITLE
Fix Issues with Dust Uncrafting

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -62,8 +62,8 @@ public enum OrePrefix {
     gemFlawless("Flawless Gemstones", M * 2, null, MaterialIconType.gemFlawless, ENABLE_UNIFICATION, mat -> mat instanceof GemMaterial), // A regular Gem worth two Dusts. Introduced by TerraFirmaCraft
     gemExquisite("Exquisite Gemstones", M * 4, null, MaterialIconType.gemExquisite, ENABLE_UNIFICATION, mat -> mat instanceof GemMaterial), // A regular Gem worth four Dusts. Introduced by TerraFirmaCraft
 
-    dustTiny("Tiny Dusts", M / 9, null, MaterialIconType.dustTiny, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial), // 1/9th of a Dust.
     dustSmall("Small Dusts", M / 4, null, MaterialIconType.dustSmall, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial), // 1/4th of a Dust.
+    dustTiny("Tiny Dusts", M / 9, null, MaterialIconType.dustTiny, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial), // 1/9th of a Dust.
     dustImpure("Impure Dusts", M, null, MaterialIconType.dustImpure, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)), // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
     dustPure("Purified Dusts", M, null, MaterialIconType.dustPure, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial && mat.hasFlag(GENERATE_ORE)),
     dust("Dusts", M, null, MaterialIconType.dust, ENABLE_UNIFICATION | DISALLOW_RECYCLING, mat -> mat instanceof DustMaterial), // Pure Dust worth of one Ingot or Gem. Introduced by Alblaka.

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -145,7 +145,7 @@ public class MaterialRecipeHandler {
         ItemStack dustStack = OreDictUnifier.get(OrePrefix.dust, material);
 
         ModHandler.addShapedRecipe(String.format("small_dust_disassembling_%s", material.toString()),
-            GTUtility.copyAmount(4, smallDustStack), "  ", " X", 'X', new UnificationEntry(OrePrefix.dust, material));
+            GTUtility.copyAmount(4, smallDustStack), " X", "  ", 'X', new UnificationEntry(OrePrefix.dust, material));
         ModHandler.addShapedRecipe(String.format("small_dust_assembling_%s", material.toString()),
             dustStack, "XX", "XX", 'X', new UnificationEntry(orePrefix, material));
 


### PR DESCRIPTION
**What:**
GTCE registers 2x2 recipes for Tiny and Small Dusts so that the player can do these recipes in their internal inventory without needing a Crafting Table. GTCE registers:
- `(Dust -> 9 Tiny Dust)` in the top left of the 2x2
- `(Dust -> 4 Small Dust)` in the bottom right of the 2x2

Now, when Minecraft tries to expand this out for a 3x3, it will cause weird issues making JEI display a wrong recipe for a 3x3.
![image](https://user-images.githubusercontent.com/10861407/117884723-96be4580-b272-11eb-9cdd-214359eac692.png)
On top of this, SoG/Gregicality tries to fix the problem by removing GTCE's `(Dust -> 4 Small Dust)` recipe and register its own in the top right of the 2x2. This only partially fixes the problem, however.

**How solved:**
Minecraft will search for a Crafting Table recipe in a first-encounter basis. Because these recipes are handled through the `OrePrefix` Material Handlers, the recipes are registered in the order of the `OrePrefixes` themselves. This leads to Tiny Dust recipes being done before Small Dust, taking priority and overriding the recipe that JEI shows.

This PR changes the order of the `OrePrefixes` to resolve this. I am not totally sure of the implications this has, but from my (admittedly brief) testing, this does not display any issues and also resolves the JEI issue.

**Outcome:**
- Fix Small Dust recipe showing wrong in JEI

After images:
JEI:
![image](https://user-images.githubusercontent.com/10861407/117885694-c15cce00-b273-11eb-89f9-c924a290ad48.png)

Crafting Table:
![image](https://user-images.githubusercontent.com/10861407/117885709-c7eb4580-b273-11eb-8b71-e6fbb956686a.png)
![image](https://user-images.githubusercontent.com/10861407/117885703-c4f05500-b273-11eb-829d-635850016721.png)

**Additional info:**
Additionally, I changed our Small Dust recipe to be the top right of the 2x2 rather than bottom right. I did this because both major addons are doing this, so I think it makes sense to just pull this change up into GTCE to save them the hassle of removing and re-registering recipes. Considering GTCE is almost always used with one of these two major addons, this should not be particularly disruptive. However, if anyone disagrees that we should make this change, I will happily reverse the recipe change.

**Possible compatibility issue:**
None expected