### PR TITLE
fix TOP showing wring burn time

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
@@ -21,10 +21,9 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
-
-import javax.annotation.Nonnull;
 
 public class SteamCoalBoiler extends SteamBoiler implements IFuelable {
 
@@ -86,21 +85,21 @@ public class SteamCoalBoiler extends SteamBoiler implements IFuelable {
             return Collections.emptySet();
         final int fuelRemaining = fuelInSlot.getCount();
         final int fuelCapacity = importItems.getSlotLimit(0);
-        final int burnTime = fuelRemaining * TileEntityFurnace.getItemBurnTime(fuelInSlot);
+        final int burnTime = fuelRemaining * TileEntityFurnace.getItemBurnTime(fuelInSlot) * (isHighPressure ? 6 : 12);
         return Collections.singleton(new ItemFuelInfo(fuelInSlot, fuelRemaining, fuelCapacity, 1, burnTime));
     }
 
     @Override
     public ModularUI createUI(EntityPlayer player) {
         return createUITemplate(player)
-            .widget(new SlotWidget(this.importItems, 0, 115, 54)
-                .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, SLOT_FURNACE_BACKGROUND))
-            .widget(new SlotWidget(this.exportItems, 0, 115, 18, true, false)
-                .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE))
-            .widget(new ProgressWidget(this::getFuelLeftPercent, 114, 35, 18, 18)
-                .setProgressBar(getGuiTexture("boiler_%s_fuel"),
-                    getGuiTexture("boiler_%s_fuel_full"),
-                    MoveType.VERTICAL))
-            .build(getHolder(), player);
+                .widget(new SlotWidget(this.importItems, 0, 115, 54)
+                        .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, SLOT_FURNACE_BACKGROUND))
+                .widget(new SlotWidget(this.exportItems, 0, 115, 18, true, false)
+                        .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE))
+                .widget(new ProgressWidget(this::getFuelLeftPercent, 114, 35, 18, 18)
+                        .setProgressBar(getGuiTexture("boiler_%s_fuel"),
+                                getGuiTexture("boiler_%s_fuel_full"),
+                                MoveType.VERTICAL))
+                .build(getHolder(), player);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -1,8 +1,5 @@
 package gregtech.common.metatileentities.steam.boiler;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IFuelInfo;
 import gregtech.api.capability.IFuelable;
@@ -22,6 +19,9 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
 
     private FluidTank lavaFluidTank;
@@ -39,7 +39,7 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
     protected FluidTankList createImportFluidHandler() {
         FluidTankList superHandler = super.createImportFluidHandler();
         this.lavaFluidTank = new FilteredFluidHandler(16000)
-            .setFillPredicate(ModHandler::isLava);
+                .setFillPredicate(ModHandler::isLava);
         return new FluidTankList(false, superHandler, lavaFluidTank);
 
     }
@@ -71,15 +71,15 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
             return Collections.emptySet();
         final int fuelRemaining = lava.amount;
         final int fuelCapacity = lavaFluidTank.getCapacity();
-        final int burnTime = fuelRemaining; // 100 mb lasts 100 ticks
+        final int burnTime = fuelRemaining * (isHighPressure ? 6 : 12); // 100 mb lasts 600 or 1200 ticks
         return Collections.singleton(new FluidFuelInfo(lava, fuelRemaining, fuelCapacity, LAVA_PER_OPERATION, burnTime));
     }
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         return createUITemplate(entityPlayer)
-            .widget(new TankWidget(lavaFluidTank, 108, 17, 11, 55)
-                .setBackgroundTexture(getGuiTexture("bar_%s_empty")))
-            .build(getHolder(), entityPlayer);
+                .widget(new TankWidget(lavaFluidTank, 108, 17, 11, 55)
+                        .setBackgroundTexture(getGuiTexture("bar_%s_empty")))
+                .build(getHolder(), entityPlayer);
     }
 }


### PR DESCRIPTION
**What:**
Just found while playing that the one prob doesn't show correct burn time remaining on steam lava boilers, it appears that the same problem occur with the coals one. 100mb of Lava produce 100 burn time but burn time is consumed every 12 ticks and not every ticks has the first person who did this code thought. How much burn time is consume depends on if the machine is high pressure.

**How solved:**
Simply add a  factor depending on if the boiler is high pressure

**Outcome:**
Fixes: Wrong remaining burn time showed by the one prob on small steam boilers

**Possible compatibility issue:**
None