### PR TITLE
Add NotConsumable Fluids to CT

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -60,6 +60,12 @@ public class CTRecipeBuilder {
     }
 
     @ZenMethod
+    public CTRecipeBuilder notConsumable(ILiquidStack ingredient) {
+        this.backingBuilder.notConsumable(CraftTweakerMC.getLiquidStack(ingredient));
+        return this;
+    }
+
+    @ZenMethod
     public CTRecipeBuilder circuit(int num) {
         this.backingBuilder.notConsumable(CraftTweakerIngredientWrapper.fromStacks(IntCircuitIngredient.getIntegratedCircuit(num)));
         return this;


### PR DESCRIPTION
**What:**
When I wrote the initial PR #1514, I overlooked adding a CT method for this functionality. This PR simply addresses that issue.

**How solved:**
Added an overloaded `notConsumable` method accepting an `ILiquidStack` to allow for notConsumed fluids in CraftTweaker.

**Outcome:**
- Add NotConsumable Fluids to CT

**Possible compatibility issue:**
None expected