### PR TITLE
Use TOP's item label to translate fuel item names

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/ItemFuelInfo.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemFuelInfo.java
@@ -17,4 +17,8 @@ public class ItemFuelInfo extends AbstractFuelInfo {
     public String getFuelName() {
         return itemStack.getTranslationKey();
     }
+
+    public ItemStack getItemStack() {
+        return this.itemStack;
+    }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IFuelInfo;
 import gregtech.api.capability.IFuelable;
+import gregtech.api.capability.impl.ItemFuelInfo;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
@@ -44,7 +45,11 @@ public class FuelableInfoProvider extends CapabilityInfoProvider<IFuelable> {
             final int burnTime = fuelInfo.getFuelBurnTime()/20;
 
             IProbeInfo horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-            horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.fuel_name*} {*" + fuelName + "*}");
+            if (fuelInfo instanceof ItemFuelInfo) {
+                horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.fuel_name*} ").itemLabel(((ItemFuelInfo) fuelInfo).getItemStack());
+            } else {
+                horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.fuel_name*} {*" + fuelName + "*}");
+            }
 
             horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
             horizontalPane.progress(fuelRemaining, fuelCapacity, probeInfo.defaultProgressStyle()


### PR DESCRIPTION
**What:**
I noticed while looking at #1602 that the Fuelable TOP provider wasn't translating item names correctly.
This was especially true for our MetaItems where flawless coal was displayed as "item.metaitem".
But it was also true for things like a block a coal which instead of redirecting to the block name it just displayed something like "tile.coal"

**How solved:**
Made the Fuelable top provider use TOP's "itemLabel" element which invokes itemStack.getDisplayName() on the client which is always going to be correct.

**Outcome:**
![2021-05-18_22 51 44](https://user-images.githubusercontent.com/275258/118728767-9f8fb800-b82c-11eb-8b5f-2e25b484c77f.png)

**Additional info:**
My solution is kind of hacky in that it does special processing for ItemFuelInfo in the top provider.
The alternative would be let to IFuelInfo choose its own behaviour, but that would mean introducing TOP classes into
gregtech.api.capability classes. Something like
````
public interface IFuelInfo {
    // IProbeInfo is a TOP class
    void appendName(IProbeInfo probeInfo);
}
````
