### PR TITLE
Add recipe using liquid ice

### DIFF
--- a/src/main/java/gregtech/common/MetaFluids.java
+++ b/src/main/java/gregtech/common/MetaFluids.java
@@ -88,6 +88,7 @@ public class MetaFluids {
         setAlternativeFluidName(Materials.Ethanol, FluidType.NORMAL, "bio.ethanol");
         setAlternativeFluidName(Materials.Honey, FluidType.NORMAL, "for.honey");
         setAlternativeFluidName(Materials.SeedOil, FluidType.NORMAL, "seed.oil");
+        setAlternativeFluidName(Materials.Ice, FluidType.NORMAL, "fluid.ice");
 
         setDefaultTexture(Materials.Air, FluidType.NORMAL);
         setDefaultTexture(Materials.Oxygen, FluidType.NORMAL);

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -991,6 +991,11 @@ public class MachineRecipeLoader {
             .inputs(new ItemStack(Items.PUMPKIN_SEEDS, 1, OreDictionary.WILDCARD_VALUE))
             .fluidOutputs(Materials.SeedOil.getFluid(6)).buildAndRegister();
 
+        RecipeMaps.FLUID_HEATER_RECIPES.recipeBuilder().duration(32).EUt(4)
+                .fluidInputs(Materials.Ice.getFluid(144))
+                .circuitMeta(1)
+                .fluidOutputs(Materials.Water.getFluid(144)).buildAndRegister();
+
         List<Tuple<ItemStack, Integer>> seedEntries = GTUtility.getGrassSeedEntries();
         for (Tuple<ItemStack, Integer> seedEntry : seedEntries) {
             RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder()


### PR DESCRIPTION
**What:**
Adds a Fluid Heater recipe for liquid ice, turning it into water, so that the fluid is not a dead end fluid. In addition, registers GTCE's liquid ice as an alternative fluid for Forestry's Crushed Ice Fluid.

**How solved:**
Adds a recipe, and adds the alternative fluid name

**Outcome:**
Adds a Fluid Heater recipe taking liquid ice. Closes #1608.

**Additional info:**
![java_2021-05-24_22-55-31](https://user-images.githubusercontent.com/31759736/119446379-305e0c00-bce3-11eb-818c-dc245af2e9af.png)


**Possible compatibility issue:**
None expected