### PR TITLE
Fix Item Collector duplicating items

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -134,6 +134,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
     protected void moveItemsInEffectRange() {
         List<EntityItem> itemsInRange = getWorld().getEntitiesWithinAABB(EntityItem.class, areaBoundingBox);
         for (EntityItem entityItem : itemsInRange) {
+            if(entityItem.isDead) continue;
             double distanceX = (areaCenterPos.getX() + 0.5) - entityItem.posX;
             double distanceZ = (areaCenterPos.getZ() + 0.5) - entityItem.posZ;
             double distance = MathHelper.sqrt(distanceX * distanceX + distanceZ * distanceZ);


### PR DESCRIPTION
**What:**
Fixes the item collector duplicating items if the stacks were depleted, as mentioned in #1578. This fix is copied from #1563, where it was implemented briefly, before being reverted for being off topic.

**How solved:**
Checks if the stack is dead, which occurs when the stack is empty (Which is the applicable case).

**Outcome:**
Fixes item collector duplicating items. Closes #1578.


**Possible compatibility issue:**
None expected