### PR TITLE
Make MatFlags Require Unique IDs

### DIFF
--- a/src/main/java/gregtech/api/unification/material/type/Material.java
+++ b/src/main/java/gregtech/api/unification/material/type/Material.java
@@ -48,12 +48,26 @@ public abstract class Material implements Comparable<Material> {
 
     public static final class MatFlags {
 
-        private static Map<String, Entry<Long, Class<? extends Material>>> materialFlagRegistry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        private static final Map<String, Entry<Long, Class<? extends Material>>> materialFlagRegistry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         public static void registerMaterialFlag(String name, long value, Class<? extends Material> classFilter) {
             if (materialFlagRegistry.containsKey(name))
                 throw new IllegalArgumentException("Flag with name " + name + " already registered!");
+
+            for (Map.Entry<Long, Class<? extends Material>> entry : materialFlagRegistry.values()) {
+                if (entry.getKey() == value)
+                    throw new IllegalArgumentException("Flag with ID " + getIntValueOfFlag(value) + " already registered!");
+            }
             materialFlagRegistry.put(name, new SimpleEntry<>(value, classFilter));
+        }
+
+        private static int getIntValueOfFlag(long value) {
+            int index = 0;
+            while (value != 1) {
+                value >>= 1;
+                index++;
+            }
+            return index;
         }
 
         public static void registerMaterialFlagsHolder(Class<?> holder, Class<? extends Material> lowerBounds) {


### PR DESCRIPTION
**What:**
This PR simply enforced that MatFlags need to have a unique ID in order to be registered properly. This PR comes as a result of Gregicality accidentally registering a flag to overlap with another, leading to very unexpected behavior and very difficult debugging.

**How solved:**
Add a check in `MatFlags#registerMaterialFlag` to enforce unique long IDs.

**Outcome:**
MatFlags now require unique IDs

**Possible compatibility issue:**
None expected. Any addons overlapping material flags are almost certainly doing it by accident. As far as I am aware, Shadows of Greg does not attempt to add flags, and none of the flags added by Gregicality are intended to overlap, and currently none do overlap. If this functionality is desired for whatever reason, the flag can instead be created separately, and code can be applied like this:
```java
for (Material material : Material.MATERIAL_REGISTRY) {
    if (material instanceof IngotMaterial && material.hasFlag(GENERATE_METAL_CASING)) {
        material.addFlag(GENERATE_FRAME);
    }
}
```
This code is taken directly from Gregicality, where we handle flags requiring other flags like GTCE does.