### PR TITLE
Fix CME from Accessing World in onLoad

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -484,10 +484,6 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     public void onLoad() {
-        this.cachedComparatorValue = getActualComparatorValue();
-        for (EnumFacing side : EnumFacing.VALUES) {
-            this.sidedRedstoneInput[side.getIndex()] = GTUtility.getRedstonePower(getWorld(), getPos(), side);
-        }
     }
 
     public void onUnload() {
@@ -582,6 +578,14 @@ public abstract class MetaTileEntity implements ICoverable {
     }
 
     public void update() {
+
+        if (getTimer() == 0L) {
+            this.cachedComparatorValue = getActualComparatorValue();
+            for (EnumFacing side : EnumFacing.VALUES) {
+                this.sidedRedstoneInput[side.getIndex()] = GTUtility.getRedstonePower(getWorld(), getPos(), side);
+            }
+        }
+
         for (MTETrait mteTrait : this.mteTraits) {
             if (shouldUpdate(mteTrait)) {
                 mteTrait.update();


### PR DESCRIPTION
**What:**
This PR simply moves the check for redstone power out of `MetaTileEntity#onLoad` into `MetaTileEntity#update` with a check ensuring it only runs on first tick. As it was before, it caused a ConcurrentModificationException in some cases, detailed in #1256, caused by a known bug in Forge: https://github.com/MinecraftForge/MinecraftForge/issues/2365.
 
**How solved:**
I moved the redstone check from `onLoad` to `update` with a check for first tick.

**Outcome:**
- Fix rare CME crash on world load caused by a call to `getRedstonePower`
- Closes #1256

**Possible compatibility issue:**
None expected