### PR TITLE
Add Component Assembler recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -1,0 +1,387 @@
+package gregtech.loaders.recipe;
+
+import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.unification.material.MarkerMaterials;
+import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.common.items.MetaItems;
+import net.minecraftforge.fluids.FluidStack;
+
+import static gregtech.api.GTValues.L;
+
+public class ComponentRecipes {
+
+    private static final FluidStack[] pumpFluids = {Materials.Rubber.getFluid(L), Materials.StyreneButadieneRubber.getFluid((L * 3)/4), Materials.SiliconeRubber.getFluid(L/2) };
+
+    public static void register() {
+
+        //Field Generators start ---------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.dust, Materials.EnderPearl, 1)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic, 4)
+                .fluidInputs(Materials.Osmium.getFluid(L * 2))
+                .outputs(MetaItems.FIELD_GENERATOR_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.dust, Materials.EnderEye, 1)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Good, 4)
+                .fluidInputs(Materials.Osmium.getFluid(L * 4))
+                .outputs(MetaItems.FIELD_GENERATOR_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(MetaItems.QUANTUM_EYE.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced, 4)
+                .fluidInputs(Materials.Osmium.getFluid(L * 8))
+                .outputs(MetaItems.FIELD_GENERATOR_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.dust, Materials.NetherStar, 1)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme, 4)
+                .fluidInputs(Materials.Osmium.getFluid(L * 16))
+                .outputs(MetaItems.FIELD_GENERATOR_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(MetaItems.QUANTUM_STAR.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite, 4)
+                .fluidInputs(Materials.Osmium.getFluid(L * 32))
+                .outputs(MetaItems.FIELD_GENERATOR_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Field Generators End -----------------------------------------------------------------------------------------
+
+        //Robot Arms Start ---------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tin, 3)
+                .input(OrePrefix.stick, Materials.Steel, 2)
+                .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm(2))
+                .inputs(MetaItems.ELECTRIC_PISTON_LV.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic)
+                .outputs(MetaItems.ROBOT_ARM_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Copper, 3)
+                .input(OrePrefix.stick, Materials.Aluminium, 2)
+                .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm(2))
+                .inputs(MetaItems.ELECTRIC_PISTON_MV.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Good)
+                .outputs(MetaItems.ROBOT_ARM_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Gold, 3)
+                .input(OrePrefix.stick, Materials.StainlessSteel, 2)
+                .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm(2))
+                .inputs(MetaItems.ELECTRIC_PISTON_HV.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced)
+                .outputs(MetaItems.ROBOT_ARM_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Aluminium, 3)
+                .input(OrePrefix.stick, Materials.Titanium, 2)
+                .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm(2))
+                .inputs(MetaItems.ELECTRIC_PISTON_EV.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme)
+                .outputs(MetaItems.ROBOT_ARM_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tungsten, 3)
+                .input(OrePrefix.stick, Materials.TungstenSteel, 2)
+                .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm(2))
+                .inputs(MetaItems.ELECTRIC_PISTON_IV.getStackForm())
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite)
+                .outputs(MetaItems.ROBOT_ARM_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Robot Arms End------------------------------------------------------------------------------------------------
+
+        //Motors Start--------------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tin, 2)
+                .input(OrePrefix.stick, Materials.Iron, 2)
+                .input(OrePrefix.stick, Materials.IronMagnetic)
+                .input(OrePrefix.wireGtSingle, Materials.Copper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tin, 2)
+                .input(OrePrefix.stick, Materials.Steel, 2)
+                .input(OrePrefix.stick, Materials.SteelMagnetic)
+                .input(OrePrefix.wireGtSingle, Materials.Copper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Copper, 2)
+                .input(OrePrefix.stick, Materials.Aluminium, 2)
+                .input(OrePrefix.stick, Materials.SteelMagnetic)
+                .input(OrePrefix.wireGtDouble, Materials.Copper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Gold, 2)
+                .input(OrePrefix.stick, Materials.StainlessSteel, 2)
+                .input(OrePrefix.stick, Materials.SteelMagnetic)
+                .input(OrePrefix.wireGtQuadruple, Materials.Copper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Aluminium, 2)
+                .input(OrePrefix.stick, Materials.Titanium, 2)
+                .input(OrePrefix.stick, Materials.NeodymiumMagnetic)
+                .input(OrePrefix.wireGtOctal, Materials.AnnealedCopper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tungsten, 2)
+                .input(OrePrefix.stick, Materials.TungstenSteel, 2)
+                .input(OrePrefix.stick, Materials.NeodymiumMagnetic)
+                .input(OrePrefix.wireGtHex, Materials.AnnealedCopper, 4)
+                .outputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Motors End----------------------------------------------------------------------------------------------------
+
+        //Sensors Start-------------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Brass)
+                .input(OrePrefix.plate, Materials.Steel)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic)
+                .input(OrePrefix.gem, Materials.Quartzite)
+                .outputs(MetaItems.SENSOR_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Electrum)
+                .input(OrePrefix.plate, Materials.Aluminium)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Good)
+                .input(OrePrefix.gem, Materials.NetherQuartz)
+                .outputs(MetaItems.SENSOR_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Chrome)
+                .input(OrePrefix.plate, Materials.StainlessSteel)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced)
+                .input(OrePrefix.gem, Materials.Emerald)
+                .outputs(MetaItems.SENSOR_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Platinum)
+                .input(OrePrefix.plate, Materials.Titanium)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme)
+                .input(OrePrefix.gem, Materials.EnderPearl)
+                .outputs(MetaItems.SENSOR_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Osmium)
+                .input(OrePrefix.plate, Materials.TungstenSteel)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite)
+                .input(OrePrefix.gem, Materials.EnderEye)
+                .outputs(MetaItems.SENSOR_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Sensors End---------------------------------------------------------------------------------------------------
+
+        //Emitters Start------------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Brass, 4)
+                .input(OrePrefix.cableGtSingle, Materials.Tin)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic, 2)
+                .input(OrePrefix.gem, Materials.Quartzite)
+                .circuitMeta(1)
+                .outputs(MetaItems.EMITTER_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Electrum, 4)
+                .input(OrePrefix.cableGtSingle, Materials.Copper)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Good, 2)
+                .input(OrePrefix.gem, Materials.NetherQuartz)
+                .circuitMeta(1)
+                .outputs(MetaItems.EMITTER_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Chrome, 4)
+                .input(OrePrefix.cableGtSingle, Materials.Gold)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced, 2)
+                .input(OrePrefix.gem, Materials.Emerald)
+                .circuitMeta(1)
+                .outputs(MetaItems.EMITTER_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Platinum, 4)
+                .input(OrePrefix.cableGtSingle, Materials.Aluminium)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme, 2)
+                .input(OrePrefix.gem, Materials.EnderPearl)
+                .circuitMeta(1)
+                .outputs(MetaItems.EMITTER_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Osmium, 4)
+                .input(OrePrefix.cableGtSingle, Materials.Tungsten)
+                .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite, 2)
+                .input(OrePrefix.gem, Materials.EnderEye)
+                .circuitMeta(1)
+                .outputs(MetaItems.EMITTER_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Emitters End--------------------------------------------------------------------------------------------------
+
+        //Pistons Start-------------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Steel, 2)
+                .input(OrePrefix.cableGtSingle, Materials.Tin, 2)
+                .input(OrePrefix.plate, Materials.Steel, 3)
+                .input(OrePrefix.gearSmall, Materials.Steel)
+                .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
+                .outputs(MetaItems.ELECTRIC_PISTON_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Aluminium, 2)
+                .input(OrePrefix.cableGtSingle, Materials.Copper, 2)
+                .input(OrePrefix.plate, Materials.Aluminium, 3)
+                .input(OrePrefix.gearSmall, Materials.Aluminium)
+                .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
+                .outputs(MetaItems.ELECTRIC_PISTON_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.StainlessSteel, 2)
+                .input(OrePrefix.cableGtSingle, Materials.Gold, 2)
+                .input(OrePrefix.plate, Materials.StainlessSteel, 3)
+                .input(OrePrefix.gearSmall, Materials.StainlessSteel)
+                .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
+                .outputs(MetaItems.ELECTRIC_PISTON_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Titanium, 2)
+                .input(OrePrefix.cableGtSingle, Materials.Aluminium, 2)
+                .input(OrePrefix.plate, Materials.Titanium, 3)
+                .input(OrePrefix.gearSmall, Materials.Titanium)
+                .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
+                .outputs(MetaItems.ELECTRIC_PISTON_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.TungstenSteel, 2)
+                .input(OrePrefix.cableGtSingle, Materials.Tungsten, 2)
+                .input(OrePrefix.plate, Materials.TungstenSteel, 3)
+                .input(OrePrefix.gearSmall, Materials.TungstenSteel)
+                .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
+                .outputs(MetaItems.ELECTRIC_PISTON_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Pistons End---------------------------------------------------------------------------------------------------
+
+        //Conveyors Start-----------------------------------------------------------------------------------------------
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tin)
+                .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm(2))
+                .fluidInputs(Materials.Rubber.getFluid(L * 6))
+                .outputs(MetaItems.CONVEYOR_MODULE_LV.getStackForm())
+                .duration(100).EUt(30).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Copper)
+                .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm(2))
+                .fluidInputs(Materials.Rubber.getFluid(L * 6))
+                .outputs(MetaItems.CONVEYOR_MODULE_MV.getStackForm())
+                .duration(100).EUt(120).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Gold)
+                .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm(2))
+                .fluidInputs(Materials.Rubber.getFluid(L * 6))
+                .outputs(MetaItems.CONVEYOR_MODULE_HV.getStackForm())
+                .duration(100).EUt(480).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Aluminium)
+                .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm(2))
+                .fluidInputs(Materials.Rubber.getFluid(L * 6))
+                .outputs(MetaItems.CONVEYOR_MODULE_EV.getStackForm())
+                .duration(100).EUt(1920).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.cableGtSingle, Materials.Tungsten)
+                .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm(2))
+                .fluidInputs(Materials.Rubber.getFluid(L * 6))
+                .outputs(MetaItems.CONVEYOR_MODULE_IV.getStackForm())
+                .duration(100).EUt(7680).buildAndRegister();
+
+        //Conveyors End-------------------------------------------------------------------------------------------------
+
+        //Pumps Start---------------------------------------------------------------------------------------------------
+        for(FluidStack fluid : pumpFluids) {
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.cableGtSingle, Materials.Tin)
+                    .input(OrePrefix.plate, Materials.Tin, 2)
+                    .input(OrePrefix.screw, Materials.Tin)
+                    .input(OrePrefix.rotor, Materials.Tin)
+                    .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
+                    .fluidInputs(fluid)
+                    .outputs(MetaItems.ELECTRIC_PUMP_LV.getStackForm())
+                    .duration(100).EUt(30).buildAndRegister();
+
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.cableGtSingle, Materials.Copper)
+                    .input(OrePrefix.plate, Materials.Bronze, 2)
+                    .input(OrePrefix.screw, Materials.Bronze)
+                    .input(OrePrefix.rotor, Materials.Bronze)
+                    .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
+                    .fluidInputs(fluid)
+                    .outputs(MetaItems.ELECTRIC_PUMP_MV.getStackForm())
+                    .duration(100).EUt(120).buildAndRegister();
+
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.cableGtSingle, Materials.Copper)
+                    .input(OrePrefix.plate, Materials.Steel, 2)
+                    .input(OrePrefix.screw, Materials.Steel)
+                    .input(OrePrefix.rotor, Materials.Steel)
+                    .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
+                    .fluidInputs(fluid)
+                    .outputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
+                    .duration(100).EUt(480).buildAndRegister();
+
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.cableGtSingle, Materials.Aluminium)
+                    .input(OrePrefix.plate, Materials.StainlessSteel, 2)
+                    .input(OrePrefix.screw, Materials.StainlessSteel)
+                    .input(OrePrefix.rotor, Materials.StainlessSteel)
+                    .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
+                    .fluidInputs(fluid)
+                    .outputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
+                    .duration(100).EUt(1920).buildAndRegister();
+
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.cableGtSingle, Materials.Tungsten)
+                    .input(OrePrefix.plate, Materials.TungstenSteel, 2)
+                    .input(OrePrefix.screw, Materials.TungstenSteel)
+                    .input(OrePrefix.rotor, Materials.TungstenSteel)
+                    .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
+                    .fluidInputs(fluid)
+                    .outputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
+                    .duration(100).EUt(7680).buildAndRegister();
+        }
+
+        //Pumps End-----------------------------------------------------------------------------------------------------
+    }
+}

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -15,7 +15,7 @@ public class ComponentRecipes {
 
     public static void register() {
 
-        //Field Generators start ---------------------------------------------------------------------------------------
+        //Field Generators Start ---------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.dust, Materials.EnderPearl, 1)
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic, 4)
@@ -51,7 +51,6 @@ public class ComponentRecipes {
                 .outputs(MetaItems.FIELD_GENERATOR_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Field Generators End -----------------------------------------------------------------------------------------
 
         //Robot Arms Start ---------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -99,7 +98,6 @@ public class ComponentRecipes {
                 .outputs(MetaItems.ROBOT_ARM_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Robot Arms End------------------------------------------------------------------------------------------------
 
         //Motors Start--------------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -150,7 +148,6 @@ public class ComponentRecipes {
                 .outputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Motors End----------------------------------------------------------------------------------------------------
 
         //Sensors Start-------------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -193,7 +190,6 @@ public class ComponentRecipes {
                 .outputs(MetaItems.SENSOR_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Sensors End---------------------------------------------------------------------------------------------------
 
         //Emitters Start------------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -241,7 +237,6 @@ public class ComponentRecipes {
                 .outputs(MetaItems.EMITTER_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Emitters End--------------------------------------------------------------------------------------------------
 
         //Pistons Start-------------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -289,12 +284,12 @@ public class ComponentRecipes {
                 .outputs(MetaItems.ELECTRIC_PISTON_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Pistons End---------------------------------------------------------------------------------------------------
 
         //Conveyors Start-----------------------------------------------------------------------------------------------
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Tin)
                 .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm(2))
+                .circuitMeta(1)
                 .fluidInputs(Materials.Rubber.getFluid(L * 6))
                 .outputs(MetaItems.CONVEYOR_MODULE_LV.getStackForm())
                 .duration(100).EUt(30).buildAndRegister();
@@ -302,6 +297,7 @@ public class ComponentRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Copper)
                 .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm(2))
+                .circuitMeta(1)
                 .fluidInputs(Materials.Rubber.getFluid(L * 6))
                 .outputs(MetaItems.CONVEYOR_MODULE_MV.getStackForm())
                 .duration(100).EUt(120).buildAndRegister();
@@ -309,6 +305,7 @@ public class ComponentRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Gold)
                 .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm(2))
+                .circuitMeta(1)
                 .fluidInputs(Materials.Rubber.getFluid(L * 6))
                 .outputs(MetaItems.CONVEYOR_MODULE_HV.getStackForm())
                 .duration(100).EUt(480).buildAndRegister();
@@ -316,6 +313,7 @@ public class ComponentRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Aluminium)
                 .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm(2))
+                .circuitMeta(1)
                 .fluidInputs(Materials.Rubber.getFluid(L * 6))
                 .outputs(MetaItems.CONVEYOR_MODULE_EV.getStackForm())
                 .duration(100).EUt(1920).buildAndRegister();
@@ -323,11 +321,11 @@ public class ComponentRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Tungsten)
                 .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm(2))
+                .circuitMeta(1)
                 .fluidInputs(Materials.Rubber.getFluid(L * 6))
                 .outputs(MetaItems.CONVEYOR_MODULE_IV.getStackForm())
                 .duration(100).EUt(7680).buildAndRegister();
 
-        //Conveyors End-------------------------------------------------------------------------------------------------
 
         //Pumps Start---------------------------------------------------------------------------------------------------
         for(FluidStack fluid : pumpFluids) {
@@ -381,7 +379,5 @@ public class ComponentRecipes {
                     .outputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
                     .duration(100).EUt(7680).buildAndRegister();
         }
-
-        //Pumps End-----------------------------------------------------------------------------------------------------
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -64,6 +64,7 @@ public class MachineRecipeLoader {
         ChemistryRecipes.init();
         FuelRecipes.registerFuels();
         AssemblyLineRecipeLoader.registerAssemblyLineRecipes();
+        ComponentRecipes.register();
 
         registerCircuitRecipes();
         registerCutterRecipes();
@@ -576,12 +577,6 @@ public class MachineRecipeLoader {
             .outputs(MetaItems.COVER_MACHINE_CONTROLLER.getStackForm(1))
             .EUt(16).duration(200)
             .buildAndRegister();
-
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(1800).EUt(30).input(OrePrefix.dust, Materials.EnderPearl, 1).input(OrePrefix.circuit, MarkerMaterials.Tier.Basic, 4).fluidInputs(Materials.Osmium.getFluid(L * 2)).outputs(MetaItems.FIELD_GENERATOR_LV.getStackForm()).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(1800).EUt(120).input(OrePrefix.dust, Materials.EnderEye, 1).input(OrePrefix.circuit, MarkerMaterials.Tier.Good, 4).fluidInputs(Materials.Osmium.getFluid(576)).outputs(MetaItems.FIELD_GENERATOR_MV.getStackForm()).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(1800).EUt(480).inputs(MetaItems.QUANTUM_EYE.getStackForm()).input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced, 4).fluidInputs(Materials.Osmium.getFluid(1152)).outputs(MetaItems.FIELD_GENERATOR_HV.getStackForm()).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(1800).EUt(1920).input(OrePrefix.dust, Materials.NetherStar, 1).input(OrePrefix.circuit, MarkerMaterials.Tier.Elite, 4).fluidInputs(Materials.Osmium.getFluid(2304)).outputs(MetaItems.FIELD_GENERATOR_EV.getStackForm()).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(1800).EUt(7680).inputs(MetaItems.QUANTUM_STAR.getStackForm()).input(OrePrefix.circuit, MarkerMaterials.Tier.Master, 4).fluidInputs(Materials.Osmium.getFluid(4608)).outputs(MetaItems.FIELD_GENERATOR_IV.getStackForm()).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(480).EUt(240).input(OrePrefix.dust, Materials.Graphite, 8).input(OrePrefix.foil, Materials.Silicon, 1).fluidInputs(Materials.Glue.getFluid(250)).outputs(OreDictUnifier.get(OrePrefix.dustSmall, Materials.Graphene, 1)).buildAndRegister();
 


### PR DESCRIPTION
**What:**
Adds assembler recipes for components, as described in #1605, with a few minor changes. The recipes in the assembler are mostly the exact same as the hand crafting recipes, except in the case of conveyors and pumps, which have had their rubber components transitioned to fluids. 

For the pumps specifically, I have added the ability for pumps to be made with Silicone Rubber in the assembler, and also introduced fluid cost savings depending on the fluid type used, with the fluid tiers following the same as for cables.

In addition, this PR changes the existing assembler recipes for EV and IV Field Generators to use on tier circuits, instead of tier + 1 circuits. This was done to match the crafting recipes, and the fact that other components taking on tier circuits

**How solved:**
Adds a new class `ComponentRecipes`, which handles all of the assembler component recipes. Moves the Field Generators into this class as well.

**Outcome:**
Adds assembler recipes for components. Closes #1605.

**Additional info:**
As it would be too long to display all the new recipes here, I will simply state that all assembler recipes are the same as the crafting table recipes, with the exception of the recipes specifically mentioned in the opening section.

**Possible compatibility issue:**
Addon mods could stop adding these recipes, but there is no issue for addon mods, just temporary duplicate recipes. For modpack makers, they could use these recipes or remove them with crafttweaker.