### PR TITLE
Fix a surface rock typo

### DIFF
--- a/src/main/resources/assets/gregtech/worldgen/overworld/monazite_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/overworld/monazite_vein.json
@@ -5,7 +5,7 @@
   "min_height": 20,
   "vein_populator": {
     "type": "surface_rock",
-    "material": "monzanite"
+    "material": "monazite"
   },
   "generator": {
     "type": "ellipsoid",


### PR DESCRIPTION
**What:**
Fixes a typo in the surface rock material identified in #1647 

**How solved:**
Fixes the typo

**Outcome:**
Fixes a typo for a surface rock material. Closes #1647.

