### PR TITLE
Fix Electric Pump Assembler recipe using wrong cable

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -350,7 +350,7 @@ public class ComponentRecipes {
                     .duration(100).EUt(120).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(OrePrefix.cableGtSingle, Materials.Copper)
+                    .input(OrePrefix.cableGtSingle, Materials.Gold)
                     .input(OrePrefix.plate, Materials.Steel, 2)
                     .input(OrePrefix.screw, Materials.Steel)
                     .input(OrePrefix.rotor, Materials.Steel)


### PR DESCRIPTION
**What:**
Fixes a copy paste error in the new Assembler component recipes, where a copper cable was being used instead of a gold cable

**How solved:**
Adjusts the material type.

**Outcome:**
Fixes an error in the Assembler pump recipes.

**Possible compatibility issue:**
None expected. Packs would not need to adjust to the correct recipe any more, and the addons no longer needed to add these recipes as of the last version.