### PR TITLE
Add isHidden to RecipeMaps to hide the default RecipeMapCategory

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -59,6 +59,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private final TByteObjectMap<TextureArea> slotOverlays;
     protected TextureArea progressBarTexture;
     protected MoveType moveType;
+    public final boolean isHidden;
 
     private final Map<FluidKey, Collection<Recipe>> recipeFluidMap = new HashMap<>();
     private final Collection<Recipe> recipeList = new ArrayList<>();
@@ -67,6 +68,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                      int minInputs, int maxInputs, int minOutputs, int maxOutputs,
                      int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs,
                      R defaultRecipe) {
+        this(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, false);
+    }
+    public RecipeMap(String unlocalizedName,
+                     int minInputs, int maxInputs, int minOutputs, int maxOutputs,
+                     int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs,
+                     R defaultRecipe, boolean isHidden) {
         this.unlocalizedName = unlocalizedName;
         this.slotOverlays = new TByteObjectHashMap<>();
         this.progressBarTexture = GuiTextures.PROGRESS_BAR_ARROW;
@@ -82,11 +89,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         this.maxOutputs = maxOutputs;
         this.maxFluidOutputs = maxFluidOutputs;
 
+        this.isHidden = isHidden;
         defaultRecipe.setRecipeMap(this);
         this.recipeBuilderSample = defaultRecipe;
         RECIPE_MAPS.add(this);
     }
-
     @ZenMethod
     public static List<RecipeMap<?>> getRecipeMaps() {
         return Collections.unmodifiableList(RECIPE_MAPS);

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -68,7 +68,9 @@ public class GTJeiPlugin implements IModPlugin {
         registry.addRecipeCategories(new IntCircuitCategory(registry.getJeiHelpers().getGuiHelper()));
         registry.addRecipeCategories(new MultiblockInfoCategory(registry.getJeiHelpers()));
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
-            registry.addRecipeCategories(new RecipeMapCategory(recipeMap, registry.getJeiHelpers().getGuiHelper()));
+            if(!recipeMap.isHidden) {
+                registry.addRecipeCategories(new RecipeMapCategory(recipeMap, registry.getJeiHelpers().getGuiHelper()));
+            }
         }
         for (FuelRecipeMap fuelRecipeMap : FuelRecipeMap.getRecipeMaps()) {
             registry.addRecipeCategories(new FuelRecipeMapCategory(fuelRecipeMap, registry.getJeiHelpers().getGuiHelper()));


### PR DESCRIPTION
**What:**
This particular PR solves a problem with RecipeMaps, where the auto-generated RecipeMapCategory could not be stopped from being registered. For RecipeMaps with particularly notable features that required them to gain a new wrapper and category, this issue prevented them from stopping the registration of the default.

**How solved:**
To fix this, I added a boolean, isHidden, which when true, would prevent the default category from being registered. I made sure to add this through a new constructor in RecipeMap, which is linked to by the old one, to prevent compatibility issues.

**Outcome:**
Allows for default RecipeMapCategories to be hidden.

**Additional info:**
You may have noticed that I created a very similar PR a few hours ago. However, since my knowledge of Git is quite poor, that repository was riddled with duplicate commits, and as such, I was forced to delete it.

**Possible compatibility issue:**
Since the normal RecipeMap constructor is still used in this PR, and works as intended for the end user, there shouldn't be any compatibillity issues here.