### PR TITLE
Fix electric tools Taking damage when charged

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -349,22 +349,26 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
             }
             capability.discharge(energyAmount, capability.getTier(), true, false, simulate);
         }
-        T toolMetaItem = getItem(stack);
-        if (toolMetaItem == null) {
-            return 0;
+
+        if ( capability == null || capability.getCharge() <= 0) {
+            T toolMetaItem = getItem(stack);
+            if (toolMetaItem == null) {
+                return 0;
+            }
+            IToolStats toolStats = toolMetaItem.getToolStats();
+            if (!toolStats.isUsingDurability(stack)) {
+                return vanillaDamage;
+            }
+            int itemDamage = getItemDamage(stack);
+            int maxDamage = getMaxItemDamage(stack);
+            int damageRemaining = maxDamage - itemDamage;
+            int newDamageValue = itemDamage + calculateToolDamage(stack, itemRand, vanillaDamage);
+            if (!simulate && !setInternalDamage(stack, newDamageValue)) {
+                GTUtility.setItem(stack, toolStats.getBrokenStack(stack));
+            }
+            return Math.min(vanillaDamage, damageRemaining);
         }
-        IToolStats toolStats = toolMetaItem.getToolStats();
-        if (!toolStats.isUsingDurability(stack)) {
-            return vanillaDamage;
-        }
-        int itemDamage = getItemDamage(stack);
-        int maxDamage = getMaxItemDamage(stack);
-        int damageRemaining = maxDamage - itemDamage;
-        int newDamageValue = itemDamage + calculateToolDamage(stack, itemRand, vanillaDamage);
-        if (!simulate && !setInternalDamage(stack, newDamageValue)) {
-            GTUtility.setItem(stack, toolStats.getBrokenStack(stack));
-        }
-        return Math.min(vanillaDamage, damageRemaining);
+        return 1;
     }
 
     public int regainItemDurability(ItemStack itemStack, int maxDurabilityRegain) {


### PR DESCRIPTION
**What:**
This PR fixes electric tools taking damage if they have charge 

**How solved:**
I implemented a check to only apply damage to tools when the have no charge or are not electric.

**Outcome:**
Fix for electric tools taking damage when charged

**Possible compatibility issue:**
None to my knolage