### PR TITLE
Fix name overlaps in GUIs

### DIFF
--- a/src/main/java/gregtech/api/gui/ModularUI.java
+++ b/src/main/java/gregtech/api/gui/ModularUI.java
@@ -90,7 +90,12 @@ public final class ModularUI implements ISizeProvider {
     }
 
     public static Builder defaultBuilder() {
-        return new Builder(GuiTextures.BACKGROUND, 176, 166);
+        return defaultBuilder(0);
+    }
+
+    //to be called in order to change the gui height by a specific amount
+    public static Builder defaultBuilder(int yOffset) {
+        return new Builder(GuiTextures.BACKGROUND, 176, 166 + yOffset);
     }
 
     public static Builder borderedBuilder() {
@@ -186,6 +191,11 @@ public final class ModularUI implements ISizeProvider {
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation) {
             return bindPlayerInventory(inventoryPlayer, imageLocation, 8, 84);
+        }
+
+        //to be called in order to offset the player inventory from the top of the window
+        public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int yOffset) {
+            return bindPlayerInventory(inventoryPlayer, imageLocation, 8, 84 + yOffset);
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int x, int y) {

--- a/src/main/java/gregtech/api/gui/ModularUI.java
+++ b/src/main/java/gregtech/api/gui/ModularUI.java
@@ -190,7 +190,7 @@ public final class ModularUI implements ISizeProvider {
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation) {
-            return bindPlayerInventory(inventoryPlayer, imageLocation, 8, 84);
+            return bindPlayerInventory(inventoryPlayer, imageLocation, 0);
         }
 
         //to be called in order to offset the player inventory from the top of the window

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -56,6 +56,8 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     protected IItemHandler outputItemInventory;
     protected IFluidHandler outputFluidInventory;
 
+    private static final int FONT_HEIGHT = 9; // Minecraft's FontRenderer FONT_HEIGHT value
+
     public SimpleMachineMetaTileEntity(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, OrientedOverlayRenderer renderer, int tier) {
         this(metaTileEntityId, recipeMap, renderer, tier, true);
     }
@@ -319,34 +321,40 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     }
 
     protected ModularUI.Builder createGuiTemplate(EntityPlayer player) {
-        ModularUI.Builder builder = workable.recipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids)
+        RecipeMap<?> workableRecipeMap = workable.recipeMap;
+        int yOffset = 0;
+        if (workableRecipeMap.getMaxInputs() > 6 || workableRecipeMap.getMaxFluidInputs() > 6 || workableRecipeMap.getMaxOutputs() > 6 || workableRecipeMap.getMaxFluidOutputs() > 6) {
+            yOffset = FONT_HEIGHT;
+        }
+
+        ModularUI.Builder builder = workableRecipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids, yOffset)
             .widget(new LabelWidget(5, 5, getMetaFullName()))
-            .widget(new DischargerSlotWidget(chargerInventory, 0, 79, 62)
+            .widget(new DischargerSlotWidget(chargerInventory, 0, 79, 62 + yOffset)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.CHARGER_OVERLAY))
-            .widget(new ImageWidget(79, 42, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
+            .widget(new ImageWidget(79, 42 + yOffset, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
                 .setPredicate(workable::isHasNotEnoughEnergy))
-            .bindPlayerInventory(player.inventory);
+            .bindPlayerInventory(player.inventory, GuiTextures.SLOT, yOffset);
 
         int leftButtonStartX = 7;
         int rightButtonStartX = 176 - 7 - 24;
-        if (workable.recipeMap instanceof RecipeMapWithConfigButton) {
-            leftButtonStartX += ((RecipeMapWithConfigButton) workable.recipeMap).getLeftButtonOffset();
-            rightButtonStartX -= ((RecipeMapWithConfigButton) workable.recipeMap).getRightButtonOffset();
+        if (workableRecipeMap instanceof RecipeMapWithConfigButton) {
+            leftButtonStartX += ((RecipeMapWithConfigButton) workableRecipeMap).getLeftButtonOffset();
+            rightButtonStartX -= ((RecipeMapWithConfigButton) workableRecipeMap).getRightButtonOffset();
         }
 
         if (exportItems.getSlots() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
                 GuiTextures.BUTTON_ITEM_OUTPUT, this::isAutoOutputItems, this::setAutoOutputItems)
                 .setTooltipText("gregtech.gui.item_auto_output.tooltip"));
             leftButtonStartX += 18;
         }
         if (exportFluids.getTanks() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
                 GuiTextures.BUTTON_FLUID_OUTPUT, this::isAutoOutputFluids, this::setAutoOutputFluids)
                 .setTooltipText("gregtech.gui.fluid_auto_output.tooltip"));
         }
 
-        builder.widget(new CycleButtonWidget(rightButtonStartX, 60, 24, 20,
+        builder.widget(new CycleButtonWidget(rightButtonStartX, 60 + yOffset, 24, 20,
                 workable.getAvailableOverclockingTiers(), workable::getOverclockTier, workable::setOverclockTier)
                 .setTooltipHoverString("gregtech.gui.overclock.description"));
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -278,14 +278,24 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     //this DOES NOT include machine control widgets or binds player inventory
     public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        ModularUI.Builder builder = ModularUI.defaultBuilder();
-        builder.widget(new ProgressWidget(progressSupplier, 77, 22, 21, 20, progressBarTexture, moveType));
-        addInventorySlotGroup(builder, importItems, importFluids, false);
-        addInventorySlotGroup(builder, exportItems, exportFluids, true);
+        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids, 0);
+    }
+
+    //this DOES NOT include machine control widgets or binds player inventory
+    //to be called in order to offset widgets and slots from the top of the window
+    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
+        ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
+        builder.widget(new ProgressWidget(progressSupplier, 77, 22 + yOffset, 21, 20, progressBarTexture, moveType));
+        addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
+        addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
         return builder;
     }
 
     protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs) {
+        addInventorySlotGroup(builder, itemHandler, fluidHandler, isOutputs, 0);
+    }
+
+    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
         int itemInputsCount = itemHandler.getSlots();
         int fluidInputsCount = fluidHandler.getTanks();
         boolean invertFluids = false;
@@ -299,7 +309,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = isOutputs ? 106 : 69 - itemSlotsToLeft * 18;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
@@ -26,23 +26,23 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
 
     @Override
     public Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        ModularUI.Builder builder = ModularUI.defaultBuilder();
-        builder.widget(new ProgressWidget(progressSupplier, 77, 22, 21, 20, progressBarTexture, moveType));
-        addInventorySlotGroup(builder, importItems, importFluids, false);
-        BooleanWrapper booleanWrapper = new BooleanWrapper();
-        ServerWidgetGroup itemOutputGroup = createItemOutputWidgetGroup(exportItems, new ServerWidgetGroup(() -> !booleanWrapper.getCurrentMode()));
-        ServerWidgetGroup fluidOutputGroup = createFluidOutputWidgetGroup(exportFluids, new ServerWidgetGroup(booleanWrapper::getCurrentMode));
-        builder.widget(itemOutputGroup).widget(fluidOutputGroup);
-        ToggleButtonWidget buttonWidget = new ToggleButtonWidget(176 - 7 - 20, 60, 20, 20,
-            GuiTextures.BUTTON_SWITCH_VIEW, booleanWrapper::getCurrentMode, booleanWrapper::setCurrentMode)
-            .setTooltipText("gregtech.gui.toggle_view");
-        builder.widget(buttonWidget);
-        return builder;
+        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids, 0);
     }
 
     @Override
     public Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
-        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids);
+        ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
+        builder.widget(new ProgressWidget(progressSupplier, 77, 22 + yOffset, 21, 20, progressBarTexture, moveType));
+        addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
+        BooleanWrapper booleanWrapper = new BooleanWrapper();
+        ServerWidgetGroup itemOutputGroup = createItemOutputWidgetGroup(exportItems, new ServerWidgetGroup(() -> !booleanWrapper.getCurrentMode()), yOffset);
+        ServerWidgetGroup fluidOutputGroup = createFluidOutputWidgetGroup(exportFluids, new ServerWidgetGroup(booleanWrapper::getCurrentMode), yOffset);
+        builder.widget(itemOutputGroup).widget(fluidOutputGroup);
+        ToggleButtonWidget buttonWidget = new ToggleButtonWidget(176 - 7 - 20, 60 + yOffset, 20, 20,
+                GuiTextures.BUTTON_SWITCH_VIEW, booleanWrapper::getCurrentMode, booleanWrapper::setCurrentMode)
+                .setTooltipText("gregtech.gui.toggle_view");
+        builder.widget(buttonWidget);
+        return builder;
     }
 
     @Override
@@ -69,11 +69,15 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
     }
 
     protected ServerWidgetGroup createItemOutputWidgetGroup(IItemHandlerModifiable itemHandler, ServerWidgetGroup widgetGroup) {
+        return createItemOutputWidgetGroup(itemHandler, widgetGroup, 0);
+    }
+
+    protected ServerWidgetGroup createItemOutputWidgetGroup(IItemHandlerModifiable itemHandler, ServerWidgetGroup widgetGroup, int yOffset) {
         int[] inputSlotGrid = determineSlotsGrid(itemHandler.getSlots());
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = 106;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;
@@ -87,11 +91,15 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
     }
 
     protected ServerWidgetGroup createFluidOutputWidgetGroup(IMultipleTankHandler fluidHandler, ServerWidgetGroup widgetGroup) {
+        return createFluidOutputWidgetGroup(fluidHandler, widgetGroup, 0);
+    }
+
+    protected ServerWidgetGroup createFluidOutputWidgetGroup(IMultipleTankHandler fluidHandler, ServerWidgetGroup widgetGroup, int yOffset) {
         int[] inputSlotGrid = determineSlotsGrid(fluidHandler.getTanks());
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = 106;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
@@ -41,6 +41,11 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
     }
 
     @Override
+    public Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
+        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids);
+    }
+
+    @Override
     public int getLeftButtonOffset() {
         return 0;
     }


### PR DESCRIPTION
**What:**
This PR changes the way machine GUI templates are created so that a machine's name does not overlap its slots in the GUI, making UIs more clean and readable for players.

**How solved:**
Overloaded methods were added to `SimpleMachineMetaTileEntity`, `RecipeMap`, `ModularUI`, and `RecipeMapGroupOutput` in order to offset all of a given machine's UI information lower down on an extended background, and create adequate space for the machine's name to be clearly displayed. This y-offset is exactly 9 units, as that is the standard height of the minecraft font in the `FontRenderer` class. The fix is only applied if a machine has more than 6 input or output slots of any type, as that would result in a 3 or more rows of slots and thus a name overlap. The original UI size and GUI positions is left alone for any machine that does not require an adjustment, and any other methods utilizing this functionality will not need to be modified.

**Outcome:**
Machine names will no longer overlap with other GUI elements. Fixes #1223.

**Additional info:**
Old, Overlapping Assembler GUI:
![image](https://user-images.githubusercontent.com/37029404/121761193-616c7800-cafc-11eb-91c7-a68e2923cbda.png)

New, Non-Overlapping Assembler GUI: 
![image](https://user-images.githubusercontent.com/37029404/121750399-50127400-cada-11eb-8769-0d61180c3b44.png)


**Possible compatibility issue:**
I do not expect any compatibility issues. All method changes were done in the overloaded versions, and the existing methods now utilize their counterparts in a manner that does not change their functionality. 