### PR TITLE
Fix Surface Block generation issue, add logging

### DIFF
--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
@@ -1,6 +1,7 @@
 package gregtech.api.worldgen.populator;
 
 import com.google.gson.JsonObject;
+import gregtech.api.util.GTLog;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.PredicateConfigUtils;
 import gregtech.api.worldgen.generator.GridEntryInfo;
@@ -20,6 +21,7 @@ public class SurfaceBlockPopulator implements VeinChunkPopulator {
     private IBlockState blockState;
     private int minIndicatorAmount;
     private int maxIndicatorAmount;
+    private int failedGenerationCounter = 0;
 
     public SurfaceBlockPopulator() {
     }
@@ -39,10 +41,20 @@ public class SurfaceBlockPopulator implements VeinChunkPopulator {
     public void initializeForVein(OreDepositDefinition definition) {
     }
 
+    /**
+     * Generates the Surface Block for an underground vein. Spawns the Surface Block on top of the applicable topmost block in
+     * the chunk, at a random position in the chunk. Does not run on a Flat world type
+     * @param world - The Minecraft world. Used for finding the top most block and its state
+     * @param chunkX - The X chunk coordinate
+     * @param chunkZ - The Z chunk coordinate
+     * @param random - A Random parameter. Used for determining the number of spawned Surface Blocks and their position
+     * @param definition - The Ore Vein definition
+     * @param gridEntryInfo - Information about the ore generation grid for the current generation section
+     */
     @Override
     public void populateChunk(World world, int chunkX, int chunkZ, Random random, OreDepositDefinition definition, GridEntryInfo gridEntryInfo) {
-        if (world.getWorldType() != WorldType.FLAT) {
-            int stonesCount = minIndicatorAmount + (minIndicatorAmount >= maxIndicatorAmount ? 0 : random.nextInt(maxIndicatorAmount - minIndicatorAmount));
+        int stonesCount = minIndicatorAmount + (minIndicatorAmount >= maxIndicatorAmount ? 0 : random.nextInt(maxIndicatorAmount - minIndicatorAmount));
+        if (stonesCount > 0 && world.getWorldType() != WorldType.FLAT) {
             for (int i = 0; i < stonesCount; i++) {
                 int randomX = chunkX * 16 + random.nextInt(16);
                 int randomZ = chunkZ * 16 + random.nextInt(16);
@@ -50,13 +62,36 @@ public class SurfaceBlockPopulator implements VeinChunkPopulator {
                 topBlockPos = world.getTopSolidOrLiquidBlock(topBlockPos).down();
                 IBlockState blockState = world.getBlockState(topBlockPos);
                 Block blockAtPos = blockState.getBlock();
-                if (blockState.getBlockFaceShape(world, topBlockPos, EnumFacing.UP) != BlockFaceShape.SOLID ||
-                    !blockState.isOpaqueCube() || !blockState.isFullBlock() || !(blockAtPos.isReplaceable(world, topBlockPos) &&
-                    blockState.getMaterial().isLiquid()))
+
+                //Check to see if the block below the planned generation position has a Solid top side. This is similar to
+                //an isSideSolid check
+                if (blockState.getBlockFaceShape(world, topBlockPos, EnumFacing.UP) != BlockFaceShape.SOLID) {
                     continue;
+                }
+
+                //Check to see if the selected block has special rendering parameters (like glass) or a special model
+                if(!blockState.isOpaqueCube() || !blockState.isFullBlock()) {
+                    continue;
+                }
+
+                //Checks if the block is a replaceable feature like grass or snow layers. Liquids are replaceable, so
+                // exclude one deep liquid blocks, for looks
+                if(!blockAtPos.isReplaceable(world, topBlockPos) || blockState.getMaterial().isLiquid()) {
+                    continue;
+                }
+
                 BlockPos surfaceRockPos = topBlockPos.up();
-                world.setBlockState(surfaceRockPos, this.blockState, 16);
+                boolean successful = world.setBlockState(surfaceRockPos, this.blockState, 16);
+
+                if(!successful) {
+                    failedGenerationCounter++;
+                }
             }
+        }
+
+        //Log if all Surface Block generation attempts were failed
+        if(failedGenerationCounter == stonesCount && maxIndicatorAmount > 0 && world.getWorldType() != WorldType.FLAT) {
+            GTLog.logger.debug("Failed all Surface Block generation attempts for vein {} at chunk with position: x: {}, z: {}", definition.getDepositName(), chunkX, chunkZ);
         }
     }
 

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.util.GTLog;
 import gregtech.api.worldgen.config.OreConfigUtils;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.generator.GridEntryInfo;
@@ -27,6 +28,7 @@ import java.util.*;
 public class SurfaceRockPopulator implements VeinChunkPopulator {
 
     private Material material;
+    private int failedGenerationCounter = 0;
 
     public SurfaceRockPopulator() {
     }
@@ -70,8 +72,21 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
             if (tileEntity != null)
                 tileEntity.setData(this.material, undergroundMaterials);
         }
+        else {
+            failedGenerationCounter++;
+        }
     }
 
+    /**
+     * Generates the Surface Rock for an underground vein. Replaces the applicable topmost block in the chunk with a
+     * Surface Rock, at a random position in the chunk. Does not run on a Flat world type
+     * @param world - The Minecraft world. Used for finding the top most block and its state
+     * @param chunkX - The X chunk coordinate
+     * @param chunkZ - The Z chunk coordinate
+     * @param random - A Random parameter. Used for determining the number of spawned Surface Blocks and their position
+     * @param definition - The Ore Vein definition
+     * @param gridEntryInfo - Information about the ore generation grid for the current generation section
+     */
     @Override
     public void populateChunk(World world, int chunkX, int chunkZ, Random random, OreDepositDefinition definition, GridEntryInfo gridEntryInfo) {
         int stonesCount = random.nextInt(2);
@@ -84,11 +99,31 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
                 int randomZ = chunkZ * 16 + 8 + random.nextInt(16);
                 BlockPos topBlockPos = world.getTopSolidOrLiquidBlock(new BlockPos(randomX, 0, randomZ));
                 Block blockAtPos = world.getBlockState(topBlockPos).getBlock();
-                if ((world.isAirBlock(topBlockPos) || (blockAtPos.isReplaceable(world, topBlockPos) && !world.getBlockState(topBlockPos).getMaterial().isLiquid()))
-                        && world.isSideSolid(topBlockPos.down(), EnumFacing.UP)) {
-                    setStoneBlock(world, topBlockPos, undergroundMaterials);
+
+                //Checks if there is an air block for the surface rock indicator to spawn at
+                if(!world.isAirBlock(topBlockPos)) {
+                    continue;
                 }
+
+                //Checks if the block is a replaceable feature like grass or snow layers. Liquids are replaceable, so
+                // exclude one deep liquid blocks, for looks
+                if(!blockAtPos.isReplaceable(world, topBlockPos) || world.getBlockState(topBlockPos).getMaterial().isLiquid()) {
+                    continue;
+                }
+
+                //Checks if the block below has a solid top. This method is also used to check what blocks redstone can
+                //be placed on.
+                if(!world.isSideSolid(topBlockPos.down(), EnumFacing.UP)) {
+                    continue;
+                }
+
+                setStoneBlock(world, topBlockPos, undergroundMaterials);
             }
+        }
+
+        //Log if all Surface Rock generation attempts were failed
+        if(failedGenerationCounter == stonesCount && stonesCount > 0 && world.getWorldType() != WorldType.FLAT) {
+            GTLog.logger.debug("Failed to generate surface rocks for vein {} at chunk with position: x: {}, z: {}", definition.getDepositName(), chunkX, chunkZ);
         }
     }
 

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -100,12 +100,7 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
                 BlockPos topBlockPos = world.getTopSolidOrLiquidBlock(new BlockPos(randomX, 0, randomZ));
                 Block blockAtPos = world.getBlockState(topBlockPos).getBlock();
 
-                //Checks if there is an air block for the surface rock indicator to spawn at
-                if(!world.isAirBlock(topBlockPos)) {
-                    continue;
-                }
-
-                //Checks if the block is a replaceable feature like grass or snow layers. Liquids are replaceable, so
+                //Checks if the block is a replaceable feature like grass, snow layers, or Air. Liquids are replaceable, so
                 // exclude one deep liquid blocks, for looks
                 if(!blockAtPos.isReplaceable(world, topBlockPos) || world.getBlockState(topBlockPos).getMaterial().isLiquid()) {
                     continue;


### PR DESCRIPTION
**What:**
Fixes some bad surface block generation logic added in #1619. In addition, breaks up the conditional statement for better readability and for documentation. In addition, adds logging for when all surface rocks/surface blocks for a vein fail to generate

**How solved:**
Fixed the conditional check, and broke up the conditional checks for better readability

**Outcome:**
Fixed Surface Block/Rock Spawning logic. Add log for if all generation attempts fail for Surface Rock/Block.


**Possible compatibility issue:**
None expected