### PR TITLE
Fix Ore generation Page glitches

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -75,7 +75,8 @@ public class GTValues {
         MODID_CT = "crafttweaker",
         MODID_TOP = "theoneprobe",
         MODID_CTM = "ctm",
-        MODID_CC = "cubicchunks";
+        MODID_CC = "cubicchunks",
+        MODID_AR = "advancedrocketry";
 
     //because forge is too fucking retarded to cache results or at least do not create fucking
     //immutable collections every time you retrieve indexed mod list

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -49,7 +49,7 @@ public class WorldGenRegistry {
     private final Map<String, Supplier<ShapeGenerator>> shapeGeneratorRegistry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, Supplier<BlockFiller>> blockFillerRegistry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, Supplier<IVeinPopulator>> veinPopulatorRegistry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    private final Map<String, Integer> namedDimensions = new HashMap<>();
+    private final Map<Integer, String> namedDimensions = new HashMap<>();
 
     private final List<OreDepositDefinition> registeredDefinitions = new ArrayList<>();
     private final Map<WorldProvider, WorldOreVeinCache> oreVeinCache = new WeakHashMap<>();
@@ -221,7 +221,7 @@ public class WorldGenRegistry {
         try {
             JsonArray dims = element.getAsJsonArray("dims");
             for(JsonElement dim : dims) {
-                namedDimensions.put(dim.getAsJsonObject().get("dimName").getAsString(), dim.getAsJsonObject().get("dimID").getAsInt());
+                namedDimensions.put(dim.getAsJsonObject().get("dimID").getAsInt(), dim.getAsJsonObject().get("dimName").getAsString());
             }
         } catch (RuntimeException exception){
             GTLog.logger.error("Failed to parse named dimensions", exception);
@@ -279,7 +279,7 @@ public class WorldGenRegistry {
         return Collections.unmodifiableList(INSTANCE.registeredDefinitions);
     }
 
-    public static Map<String, Integer> getNamedDimensions() {
+    public static Map<Integer, String> getNamedDimensions() {
         return INSTANCE.namedDimensions;
     }
 

--- a/src/main/java/gregtech/integration/jei/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/GTOreCategory.java
@@ -1,8 +1,11 @@
 package gregtech.integration.jei;
 
 import gregtech.api.gui.GuiTextures;
+import gregtech.api.util.GTLog;
+import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
 import gregtech.integration.jei.recipe.primitive.PrimitiveRecipeCategory;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiItemStackGroup;
@@ -11,20 +14,29 @@ import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.world.DimensionType;
+import net.minecraftforge.common.DimensionManager;
 
-import java.util.Map;
+import java.util.*;
+import java.util.function.Supplier;
+
+import static gregtech.api.GTValues.MODID_AR;
+import static gregtech.api.GTValues.isModLoaded;
 
 public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo> {
 
     protected final IDrawable slot;
+    protected OreDepositDefinition definition;
     protected String veinName;
     protected int minHeight;
     protected int maxHeight;
     protected int outputCount;
     protected int weight;
-    protected int[] dimensionIDs;
+    protected List<Integer> dimensionIDs;
     protected final int FONT_HEIGHT = Minecraft.getMinecraft().fontRenderer.FONT_HEIGHT;
     protected final Map<Integer, String> namedDimensions = WorldGenRegistry.getNamedDimensions();
+    private Map<DimensionType, IntSortedSet> dimMap =  DimensionManager.getRegisteredDimensions();
+    private Supplier<List<Integer>> dimension = this::getAllRegisteredDimensions;
     private final int NUM_OF_SLOTS = 5;
     private final int SLOT_WIDTH = 18;
     private final int SLOT_HEIGHT = 18;
@@ -65,7 +77,7 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
         maxHeight = recipeWrapper.getMaxHeight();
         outputCount = recipeWrapper.getOutputCount();
         weight = recipeWrapper.getWeight();
-        dimensionIDs = recipeWrapper.getDimensionIDs();
+        definition = recipeWrapper.getDefinition();
     }
 
     @Override
@@ -120,23 +132,25 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
         //Create the Dimensions
         minecraft.fontRenderer.drawString("Dimensions: ", 70, baseYPos + (2 * FONT_HEIGHT), 0x111111);
 
+        dimensionIDs = dimension.get();
+
         //Will attempt to write dimension IDs in a single line, separated by commas. If the list is so long such that it
         //would run off the end of the page, the list is continued on a new line.
-        for(int i = 0; i < dimensionIDs.length; i++) {
+        for(int i = 0; i < dimensionIDs.size(); i++) {
 
             //If the dimension name is included, append it to the dimension number
-            if(namedDimensions.containsKey(dimensionIDs[i])) {
-                dimName = namedDimensions.get(dimensionIDs[i]);
-                fullDimName = i == dimensionIDs.length - 1 ?
-                    dimensionIDs[i] + " (" + dimName + ")" :
-                    dimensionIDs[i] + " (" + dimName + "), ";
+            if(namedDimensions.containsKey(dimensionIDs.get(i))) {
+                dimName = namedDimensions.get(dimensionIDs.get(i));
+                fullDimName = i == dimensionIDs.size() - 1 ?
+                    dimensionIDs.get(i) + " (" + dimName + ")" :
+                    dimensionIDs.get(i) + " (" + dimName + "), ";
             }
             //If the dimension name is not included, just add the dimension number
             else {
 
-                fullDimName = i == dimensionIDs.length - 1 ?
-                    Integer.toString(dimensionIDs[i]) :
-                    dimensionIDs[i] + ", ";
+                fullDimName = i == dimensionIDs.size() - 1 ?
+                    Integer.toString(dimensionIDs.get(i)) :
+                    dimensionIDs.get(i) + ", ";
             }
 
             //Find the length of the dimension name string
@@ -174,5 +188,47 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
         int startPosition = (maxVeinNameLength - fontRenderer.getStringWidth(veinNameToDraw)) / 2;
 
         fontRenderer.drawString(veinNameToDraw, startPosition, 1, 0x111111);
+    }
+
+    public List<Integer> getAllRegisteredDimensions() {
+        List<Integer> dims = new ArrayList<>();
+        dimMap.values().stream()
+                .flatMap(Collection::stream)
+                .mapToInt(Integer::intValue)
+                .filter(num -> definition.getDimensionFilter().test(DimensionManager.createProviderFor(num)))
+                .forEach(dims::add);
+
+        if(isModLoaded(MODID_AR)) {
+            try {
+                int[] plantDims = DimensionManager.getDimensions(DimensionType.byName("planet"));
+                int[] asteroidDims = DimensionManager.getDimensions(DimensionType.byName("asteroid"));
+                int[] spaceDims = DimensionManager.getDimensions(DimensionType.byName("space"));
+
+                //Add the Planets to the dimension list
+                Arrays.stream(plantDims)
+                        .filter(num -> !dims.contains(num))
+                        .filter(num -> definition.getDimensionFilter().test(DimensionManager.createProviderFor(num)))
+                        .forEach(dims::add);
+
+                //Add the Asteroids to the dimension list
+                Arrays.stream(asteroidDims)
+                        .filter(num -> !dims.contains(num))
+                        .filter(num -> definition.getDimensionFilter().test(DimensionManager.createProviderFor(num)))
+                        .forEach(dims::add);
+
+                //Remove Space from the dimension list
+                for (int spaceDim : spaceDims) {
+                    if (dims.contains(spaceDim)) {
+                        dims.remove((Integer) spaceDim);
+                    }
+                }
+            }
+            catch (IllegalArgumentException e) {
+                GTLog.logger.error("Something went wrong with AR JEI integration, No DimensionType found");
+                GTLog.logger.error(e);
+            }
+        }
+
+        return dims;
     }
 }

--- a/src/main/java/gregtech/integration/jei/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/GTOreCategory.java
@@ -24,7 +24,7 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
     protected int weight;
     protected int[] dimensionIDs;
     protected final int FONT_HEIGHT = Minecraft.getMinecraft().fontRenderer.FONT_HEIGHT;
-    protected final Map<String, Integer> namedDimensions = WorldGenRegistry.getNamedDimensions();
+    protected final Map<Integer, String> namedDimensions = WorldGenRegistry.getNamedDimensions();
     private final int NUM_OF_SLOTS = 5;
     private final int SLOT_WIDTH = 18;
     private final int SLOT_HEIGHT = 18;
@@ -86,7 +86,7 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
         //Selected Ore
         this.slot.draw(minecraft, 22, baseYPos);
         //Surface Identifier
-        this.slot.draw(minecraft, 22, 73);
+        this.slot.draw(minecraft, 22, SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1);
 
         int yPos = 0;
         for(int i = 0; i < outputCount; i++) {
@@ -96,17 +96,20 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
             this.slot.draw(minecraft, xPos, yPos);
         }
 
-        baseYPos = yPos; //has to be set to position of last rendered slot for later use
+        //base positions set to position of last rendered slot for later use.
+        //Must account for the fact that yPos is the top corner of the slot, so add in another slot height
+        baseYPos = yPos + SLOT_HEIGHT; //has to be set to position of last rendered slot for later use. Accounts
 
         drawVeinName(minecraft.fontRenderer);
 
         //Begin Drawing information, depending on how many rows of ore outputs were created
         //Give room for 5 lines of 5 ores each, so 25 unique ores in the vein
-        if(baseYPos > 73) {
+        //73 is SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1
+        if(baseYPos >= SLOT_HEIGHT * NUM_OF_SLOTS) {
             minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, 70, baseYPos + 1, 0x111111);
         }
         else {
-            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, 70, 73, 0x111111);
+            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, 70, SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1, 0x111111);
             //Update the position at which the spawn information ends
             baseYPos = 73;
         }
@@ -122,22 +125,18 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
         for(int i = 0; i < dimensionIDs.length; i++) {
 
             //If the dimension name is included, append it to the dimension number
-            if(namedDimensions.containsValue(dimensionIDs[i])) {
-                int finalI = i;
-                dimName = namedDimensions.entrySet().stream()
-                                            .filter(entry -> dimensionIDs[finalI] == entry.getValue())
-                                            .map(Map.Entry::getKey)
-                                            .findFirst().get();
+            if(namedDimensions.containsKey(dimensionIDs[i])) {
+                dimName = namedDimensions.get(dimensionIDs[i]);
                 fullDimName = i == dimensionIDs.length - 1 ?
                     dimensionIDs[i] + " (" + dimName + ")" :
-                    dimensionIDs[i] + " (" + dimName + "),";
+                    dimensionIDs[i] + " (" + dimName + "), ";
             }
             //If the dimension name is not included, just add the dimension number
             else {
 
                 fullDimName = i == dimensionIDs.length - 1 ?
                     Integer.toString(dimensionIDs[i]) :
-                    dimensionIDs[i] + ",";
+                    dimensionIDs[i] + ", ";
             }
 
             //Find the length of the dimension name string
@@ -157,7 +156,7 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
 
 
         //Label the Surface Identifier
-        minecraft.fontRenderer.drawSplitString("SurfaceMaterial", 15, 92, 42, 0x111111);
+        minecraft.fontRenderer.drawSplitString("SurfaceMaterial", 15, 92, minecraft.fontRenderer.getStringWidth("Surface"), 0x111111);
 
     }
 

--- a/src/main/java/gregtech/integration/jei/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/GTOreCategory.java
@@ -98,7 +98,7 @@ public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo>
 
         //base positions set to position of last rendered slot for later use.
         //Must account for the fact that yPos is the top corner of the slot, so add in another slot height
-        baseYPos = yPos + SLOT_HEIGHT; //has to be set to position of last rendered slot for later use. Accounts
+        baseYPos = yPos + SLOT_HEIGHT;
 
         drawVeinName(minecraft.fontRenderer);
 

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -84,6 +84,7 @@ public class GTOreInfo implements IRecipeWrapper {
         this.biomeFunction = definition.getBiomeWeightModifier();
 
         //Gather the dimension IDs that the vein can spawn in
+        //AR Planet dimensions are not registered at this point for some reason, only "Space"
          dimensionIDs = dimMap.values().stream()
             .flatMap(Collection::stream)
             .mapToInt(Integer::intValue)
@@ -211,7 +212,7 @@ public class GTOreInfo implements IRecipeWrapper {
             }
         }
 
-        //Should never reach here?
+        //No defined surface rock
         return stack;
     }
 

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -9,7 +9,6 @@ import gregtech.api.worldgen.populator.FluidSpringPopulator;
 import gregtech.api.worldgen.populator.IVeinPopulator;
 import gregtech.api.worldgen.populator.SurfaceBlockPopulator;
 import gregtech.api.worldgen.populator.SurfaceRockPopulator;
-import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.block.Block;
@@ -17,9 +16,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.DimensionType;
 import net.minecraft.world.biome.Biome;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fluids.*;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -39,13 +36,11 @@ public class GTOreInfo implements IRecipeWrapper {
     private final String name;
     private final String description;
     private final int weight;
-    private final int[] dimensionIDs;
     private final IVeinPopulator veinPopulator;
     private final BlockFiller blockFiller;
     private List<List<ItemStack>> groupedInputsAsItemStacks = new ArrayList<>();
     private List<List<ItemStack>> groupedOutputsAsItemStacks = new ArrayList<>();
     private final Function<Biome, Integer> biomeFunction;
-    private Map<DimensionType, IntSortedSet> dimMap =  DimensionManager.getRegisteredDimensions();
 
     public GTOreInfo(OreDepositDefinition definition) {
         this.definition = definition;
@@ -82,14 +77,6 @@ public class GTOreInfo implements IRecipeWrapper {
         this.blockFiller = definition.getBlockFiller();
 
         this.biomeFunction = definition.getBiomeWeightModifier();
-
-        //Gather the dimension IDs that the vein can spawn in
-        //AR Planet dimensions are not registered at this point for some reason, only "Space"
-         dimensionIDs = dimMap.values().stream()
-            .flatMap(Collection::stream)
-            .mapToInt(Integer::intValue)
-            .filter(num -> definition.getDimensionFilter().test(DimensionManager.createProviderFor(num)))
-            .toArray();
 
         //Group the input ores and the Surface Identifier
         List<ItemStack> generatedBlocksAsItemStacks = findComponentBlocksAsItemStacks();
@@ -327,7 +314,6 @@ public class GTOreInfo implements IRecipeWrapper {
         return tooltip;
     }
 
-
     public int getOutputCount() {
         return groupedOutputsAsItemStacks.size();
     }
@@ -344,11 +330,11 @@ public class GTOreInfo implements IRecipeWrapper {
         return minHeight;
     }
 
-    public int[] getDimensionIDs() {
-        return  dimensionIDs;
-    }
-
     public int getWeight() {
         return weight;
+    }
+
+    public OreDepositDefinition getDefinition() {
+        return definition;
     }
 }


### PR DESCRIPTION
**What:**
This PR has some slight fixes to the Ore Generation page, mostly rendering, but also how the named dimensions were stored and accessed.

The main rendering issue was when the fifth row of the ore list would be used, text would be rendered under the slot
![java_2021-06-11_22-57-00](https://user-images.githubusercontent.com/31759736/121770028-d4d1b200-cb1b-11eb-8b17-9f60d779134c.png)

Adds support for detecting Advanced Rocketry dimensions and displaying them on the ore generation page.

**How solved:**
Adds an offset to the y position stored value, to account for the stored value being the top of the slot instead of the bottom of the slot.

Moves the dimension collection information to later on in loading, and adds support for gathering AR specific dimension information.

**Outcome:**
Fixed a rendering issue on the Ore Generation Page when the veins had large numbers of unique ores.
Adds support for displaying Advanced Rocketry dimension information. Closes #1669.

**Additional info:**
Fixed rendering for large ore veins:
![java_2021-06-11_23-12-18](https://user-images.githubusercontent.com/31759736/121770065-0d718b80-cb1c-11eb-96a6-1be5c89f6bd8.png)


**Possible compatibility issue:**
If any addons were using the public getter for the named dimensions, they will have to switch the order Map, but this is a minor issue as it would only affect a part of the JEI page, and I am not aware of any addons that were using this feature.

Due to moving where the dimension information was captured, some accessors are no longer available.