### PR TITLE
Update systems to new Recipe Properties

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.FusionEUToStartProperty;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.ValidationResult;
@@ -18,7 +19,7 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
 
     public FusionRecipeBuilder(Recipe recipe, RecipeMap<FusionRecipeBuilder> recipeMap) {
         super(recipe, recipeMap);
-        this.EUToStart = recipe.getIntegerProperty("EUToStart");
+        this.EUToStart = recipe.getRecipePropertyStorage().getRecipePropertyValue(FusionEUToStartProperty.getInstance(), 0);
     }
 
     public FusionRecipeBuilder(RecipeBuilder<FusionRecipeBuilder> recipeBuilder) {
@@ -49,17 +50,20 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
     }
 
     public ValidationResult<Recipe> build() {
-        return ValidationResult.newResult(finalizeAndValidate(),
-            new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                ImmutableMap.of("eu_to_start", EUToStart),
-                duration, EUt, hidden));
+        Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
+                duration, EUt, hidden);
+        if (!recipe.getRecipePropertyStorage().store(ImmutableMap.of(FusionEUToStartProperty.getInstance(), EUToStart))) {
+            return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
+        }
+
+        return ValidationResult.newResult(finalizeAndValidate(), recipe);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
             .appendSuper(super.toString())
-            .append("EUToStart", EUToStart)
+            .append(FusionEUToStartProperty.getInstance().getKey(), EUToStart)
             .toString();
     }
 }

--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -1,8 +1,11 @@
 package gregtech.api.recipes.builders;
 
+import com.google.common.collect.ImmutableMap;
+import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.ImplosionExplosiveProperty;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
@@ -22,6 +25,7 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
 
     public ImplosionRecipeBuilder(Recipe recipe, RecipeMap<ImplosionRecipeBuilder> recipeMap) {
         super(recipe, recipeMap);
+        this.explosivesType = recipe.getRecipePropertyStorage().getRecipePropertyValue(ImplosionExplosiveProperty.getInstance(), ItemStack.EMPTY);
     }
 
     public ImplosionRecipeBuilder(RecipeBuilder<ImplosionRecipeBuilder> recipeBuilder) {
@@ -68,27 +72,33 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
         return this;
     }
 
-    @Override
-    public void buildAndRegister() {
+    public ValidationResult<Recipe> build() {
+
+        //Adjust the explosive type and the explosive amount. This is done here because it was null otherwise, for some reason
         int amount = Math.max(1, explosivesAmount / 2);
         if (explosivesType == null) {
-            explosivesType = new ItemStack(Blocks.TNT, amount);
+            this.explosivesType = new ItemStack(Blocks.TNT, amount);
         } else {
-            explosivesType = new ItemStack(explosivesType.getItem(), amount, explosivesType.getMetadata());
+            this.explosivesType = new ItemStack(explosivesType.getItem(), amount, explosivesType.getMetadata());
         }
-        recipeMap.addRecipe(this.copy().inputs(explosivesType).build());
-    }
+        inputs.add(CountableIngredient.from(explosivesType));
 
-    public ValidationResult<Recipe> build() {
-        return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+
+        Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
+                duration, EUt, hidden);
+
+        if (!recipe.getRecipePropertyStorage().store(ImmutableMap.of(ImplosionExplosiveProperty.getInstance(), explosivesType))) {
+            return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
+        }
+
+        return ValidationResult.newResult(finalizeAndValidate(), recipe);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())
-                .append("explosivesAmount", explosivesAmount)
+                .append(ImplosionExplosiveProperty.getInstance().getKey(), explosivesType)
                 .toString();
     }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
@@ -1,0 +1,30 @@
+package gregtech.api.recipes.recipeproperties;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+
+public class FusionEUToStartProperty extends RecipeProperty<Integer>{
+
+
+    private static final String KEY = "eu_to_start";
+
+    private static FusionEUToStartProperty INSTANCE;
+
+    private FusionEUToStartProperty() {
+        super(KEY, Integer.class);
+    }
+
+    public static FusionEUToStartProperty getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new FusionEUToStartProperty();
+        }
+
+        return INSTANCE;
+    }
+
+    @Override
+    public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
+        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.eu_to_start",
+                value), x, y, color);
+    }
+}

--- a/src/main/java/gregtech/api/recipes/recipeproperties/ImplosionExplosiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/ImplosionExplosiveProperty.java
@@ -1,0 +1,36 @@
+package gregtech.api.recipes.recipeproperties;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+
+public class ImplosionExplosiveProperty extends RecipeProperty<ItemStack>{
+
+    private static final String KEY = "explosives";
+
+    private static ImplosionExplosiveProperty INSTANCE;
+
+
+    private ImplosionExplosiveProperty() {
+        super(KEY, ItemStack.class);
+    }
+
+    public static ImplosionExplosiveProperty getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ImplosionExplosiveProperty();
+        }
+
+        return INSTANCE;
+    }
+
+    @Override
+    public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
+        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.explosive",
+                ((ItemStack) value).getDisplayName()), x, y, color);
+    }
+
+    @Override
+    public boolean isHidden() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -27,6 +27,14 @@ public abstract class RecipeProperty<T> {
         return this.type.cast(value);
     }
 
+    /**
+     * Controls if the property should display any information in JEI
+     * @return true to hide information from JEI
+     */
+    public boolean isHidden() {
+        return false;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -138,7 +138,9 @@ public class GTRecipeWrapper implements IRecipeWrapper {
         minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), JEIHelpers.getMinTierForVoltage(recipe.getEUt())), 0, yPosition += LINE_HEIGHT, 0x111111);
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += LINE_HEIGHT, 0x111111);
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getRecipePropertyStorage().getRecipeProperties()) {
-            propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, 0x111111, propertyEntry.getValue());
+            if(!propertyEntry.getKey().isHidden()) {
+                propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, 0x111111, propertyEntry.getValue());
+            }
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2887,6 +2887,7 @@ gregtech.recipe.amperage=Amperage: %,d
 gregtech.recipe.not_consumed=Not consumed in process
 gregtech.recipe.chance=Chance: %s%% +%s%%/tier
 gregtech.recipe.blast_furnace_temperature=Temperature: %,dK (%s)
+gregtech.recipe.explosive=Explosive: %s
 gregtech.recipe.eu_to_start=Energy To Start: %,dEU
 
 gregtech.fluid.click_to_fill=§7Click with a empty fluid container to fill it from tank.


### PR DESCRIPTION
**What:**
This PR aims to update existing systems to the new Recipe Property system introduced in #1580.
As mentioned in #1614, after the Recipe Property rework the implosion compressor was not properly adding its properties to the list of Recipe Properties, which is one of the motivations of this PR.

This PR also adds an `isHidden` method to the Recipe Properties, which will control if the recipe property should display its key and value on the JEI page. This defaults false to keep current behavior.

Please let me know if there are any systems that I have forgotten to update to the new system, and I will update those. I want to update all systems in one go, so that there are not any PRs that have to be made later.

**How solved:**

### Implosion Compressor
Creates the `ImplosionExplosiveProperty`. The Recipe Property type for this property was chosen to be ItemStack, to easier incorporate any explosives added to the Implosion Compressor via crafttweaker, as having just an Integer in this case would not work correctly.

Removes the override of `buildAndRegister` in `ImplosionRecipeBuilder` and moves the logic that was in the method into `build`. This was done due to the explosive itemstack being null for some reason in the `build` method when it was not null before `build` was called. In addition, this brings the Builder inline with other builders as they do not override `buildAndRegister`.

This recipe property was set to hidden, as it does not make sense to see the information in JEI when it can be seen in the recipe.

### Fusion Reactor
Creates the `FusionEUToStartProperty` and uses it in the `FusionRecipeBuilder` class.


**Outcome:**
Updates systems to new Recipe Property system. Fixes #1614.

**Possible compatibility issue:**
I do not expect there to be any. Although `buildAndRegister` was removed in `ImplosionRecipeBuilder` I am not aware of any addons that were using this field. It may be safer to make the override just call `super` instead, but I will leave that up to feedback.