### PR TITLE
Allow the harvest level of ores to be changed

### DIFF
--- a/src/main/java/gregtech/api/unification/material/type/DustMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/type/DustMaterial.java
@@ -95,7 +95,7 @@ public class DustMaterial extends FluidMaterial {
      * Tool level needed to harvest block of this material
      */
     @ZenProperty
-    public final int harvestLevel;
+    public int harvestLevel;
 
     /**
      * Material to which smelting of this material ore will result


### PR DESCRIPTION
**What:**
Recently I've seen some questions about how to change the harvest level of GTCE ores. Since the field was final this was not possible.

**How solved:**
I solved this by removing the final modifier of the `harvestLevel` field.

**Outcome:**
Modpack developers can now change the harvest level of DustMaterials via ZenScript.


