### PR TITLE
Fix Surface block spawning

### DIFF
--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
@@ -76,7 +76,7 @@ public class SurfaceBlockPopulator implements VeinChunkPopulator {
 
                 //Checks if the block is a replaceable feature like grass or snow layers. Liquids are replaceable, so
                 // exclude one deep liquid blocks, for looks
-                if(!blockAtPos.isReplaceable(world, topBlockPos) || blockState.getMaterial().isLiquid()) {
+                if(!blockAtPos.isReplaceable(world, topBlockPos.up()) || blockState.getMaterial().isLiquid()) {
                     continue;
                 }
 


### PR DESCRIPTION
**What:**
Hopefully the last PR to fix surface block spawning. This PR makes sure to check if where the actual surface block will be placed is replaceable, instead of the block below it.

**How solved:**
Check the actual surface block position for replaceability

**Outcome:**
Fixes Surface Block spawning. Closes #1680 


**Possible compatibility issue:**
None