### PR TITLE
Revert "Fix name overlaps in GUIs (#1665)"

### DIFF
--- a/src/main/java/gregtech/api/gui/ModularUI.java
+++ b/src/main/java/gregtech/api/gui/ModularUI.java
@@ -90,12 +90,7 @@ public final class ModularUI implements ISizeProvider {
     }
 
     public static Builder defaultBuilder() {
-        return defaultBuilder(0);
-    }
-
-    //to be called in order to change the gui height by a specific amount
-    public static Builder defaultBuilder(int yOffset) {
-        return new Builder(GuiTextures.BACKGROUND, 176, 166 + yOffset);
+        return new Builder(GuiTextures.BACKGROUND, 176, 166);
     }
 
     public static Builder borderedBuilder() {
@@ -190,12 +185,7 @@ public final class ModularUI implements ISizeProvider {
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation) {
-            return bindPlayerInventory(inventoryPlayer, imageLocation, 0);
-        }
-
-        //to be called in order to offset the player inventory from the top of the window
-        public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int yOffset) {
-            return bindPlayerInventory(inventoryPlayer, imageLocation, 8, 84 + yOffset);
+            return bindPlayerInventory(inventoryPlayer, imageLocation, 8, 84);
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int x, int y) {

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -56,8 +56,6 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     protected IItemHandler outputItemInventory;
     protected IFluidHandler outputFluidInventory;
 
-    private static final int FONT_HEIGHT = 9; // Minecraft's FontRenderer FONT_HEIGHT value
-
     public SimpleMachineMetaTileEntity(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, OrientedOverlayRenderer renderer, int tier) {
         this(metaTileEntityId, recipeMap, renderer, tier, true);
     }
@@ -321,40 +319,34 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     }
 
     protected ModularUI.Builder createGuiTemplate(EntityPlayer player) {
-        RecipeMap<?> workableRecipeMap = workable.recipeMap;
-        int yOffset = 0;
-        if (workableRecipeMap.getMaxInputs() > 6 || workableRecipeMap.getMaxFluidInputs() > 6 || workableRecipeMap.getMaxOutputs() > 6 || workableRecipeMap.getMaxFluidOutputs() > 6) {
-            yOffset = FONT_HEIGHT;
-        }
-
-        ModularUI.Builder builder = workableRecipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids, yOffset)
+        ModularUI.Builder builder = workable.recipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids)
             .widget(new LabelWidget(5, 5, getMetaFullName()))
-            .widget(new DischargerSlotWidget(chargerInventory, 0, 79, 62 + yOffset)
+            .widget(new DischargerSlotWidget(chargerInventory, 0, 79, 62)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.CHARGER_OVERLAY))
-            .widget(new ImageWidget(79, 42 + yOffset, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
+            .widget(new ImageWidget(79, 42, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
                 .setPredicate(workable::isHasNotEnoughEnergy))
-            .bindPlayerInventory(player.inventory, GuiTextures.SLOT, yOffset);
+            .bindPlayerInventory(player.inventory);
 
         int leftButtonStartX = 7;
         int rightButtonStartX = 176 - 7 - 24;
-        if (workableRecipeMap instanceof RecipeMapWithConfigButton) {
-            leftButtonStartX += ((RecipeMapWithConfigButton) workableRecipeMap).getLeftButtonOffset();
-            rightButtonStartX -= ((RecipeMapWithConfigButton) workableRecipeMap).getRightButtonOffset();
+        if (workable.recipeMap instanceof RecipeMapWithConfigButton) {
+            leftButtonStartX += ((RecipeMapWithConfigButton) workable.recipeMap).getLeftButtonOffset();
+            rightButtonStartX -= ((RecipeMapWithConfigButton) workable.recipeMap).getRightButtonOffset();
         }
 
         if (exportItems.getSlots() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
                 GuiTextures.BUTTON_ITEM_OUTPUT, this::isAutoOutputItems, this::setAutoOutputItems)
                 .setTooltipText("gregtech.gui.item_auto_output.tooltip"));
             leftButtonStartX += 18;
         }
         if (exportFluids.getTanks() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
                 GuiTextures.BUTTON_FLUID_OUTPUT, this::isAutoOutputFluids, this::setAutoOutputFluids)
                 .setTooltipText("gregtech.gui.fluid_auto_output.tooltip"));
         }
 
-        builder.widget(new CycleButtonWidget(rightButtonStartX, 60 + yOffset, 24, 20,
+        builder.widget(new CycleButtonWidget(rightButtonStartX, 60, 24, 20,
                 workable.getAvailableOverclockingTiers(), workable::getOverclockTier, workable::setOverclockTier)
                 .setTooltipHoverString("gregtech.gui.overclock.description"));
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -285,24 +285,14 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     //this DOES NOT include machine control widgets or binds player inventory
     public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids, 0);
-    }
-
-    //this DOES NOT include machine control widgets or binds player inventory
-    //to be called in order to offset widgets and slots from the top of the window
-    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
-        ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
-        builder.widget(new ProgressWidget(progressSupplier, 77, 22 + yOffset, 21, 20, progressBarTexture, moveType));
-        addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
-        addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
+        ModularUI.Builder builder = ModularUI.defaultBuilder();
+        builder.widget(new ProgressWidget(progressSupplier, 77, 22, 21, 20, progressBarTexture, moveType));
+        addInventorySlotGroup(builder, importItems, importFluids, false);
+        addInventorySlotGroup(builder, exportItems, exportFluids, true);
         return builder;
     }
 
     protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs) {
-        addInventorySlotGroup(builder, itemHandler, fluidHandler, isOutputs, 0);
-    }
-
-    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
         int itemInputsCount = itemHandler.getSlots();
         int fluidInputsCount = fluidHandler.getTanks();
         boolean invertFluids = false;
@@ -316,7 +306,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = isOutputs ? 106 : 69 - itemSlotsToLeft * 18;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapGroupOutput.java
@@ -26,21 +26,16 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
 
     @Override
     public Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids, 0);
-    }
-
-    @Override
-    public Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
-        ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
-        builder.widget(new ProgressWidget(progressSupplier, 77, 22 + yOffset, 21, 20, progressBarTexture, moveType));
-        addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
+        ModularUI.Builder builder = ModularUI.defaultBuilder();
+        builder.widget(new ProgressWidget(progressSupplier, 77, 22, 21, 20, progressBarTexture, moveType));
+        addInventorySlotGroup(builder, importItems, importFluids, false);
         BooleanWrapper booleanWrapper = new BooleanWrapper();
-        ServerWidgetGroup itemOutputGroup = createItemOutputWidgetGroup(exportItems, new ServerWidgetGroup(() -> !booleanWrapper.getCurrentMode()), yOffset);
-        ServerWidgetGroup fluidOutputGroup = createFluidOutputWidgetGroup(exportFluids, new ServerWidgetGroup(booleanWrapper::getCurrentMode), yOffset);
+        ServerWidgetGroup itemOutputGroup = createItemOutputWidgetGroup(exportItems, new ServerWidgetGroup(() -> !booleanWrapper.getCurrentMode()));
+        ServerWidgetGroup fluidOutputGroup = createFluidOutputWidgetGroup(exportFluids, new ServerWidgetGroup(booleanWrapper::getCurrentMode));
         builder.widget(itemOutputGroup).widget(fluidOutputGroup);
-        ToggleButtonWidget buttonWidget = new ToggleButtonWidget(176 - 7 - 20, 60 + yOffset, 20, 20,
-                GuiTextures.BUTTON_SWITCH_VIEW, booleanWrapper::getCurrentMode, booleanWrapper::setCurrentMode)
-                .setTooltipText("gregtech.gui.toggle_view");
+        ToggleButtonWidget buttonWidget = new ToggleButtonWidget(176 - 7 - 20, 60, 20, 20,
+            GuiTextures.BUTTON_SWITCH_VIEW, booleanWrapper::getCurrentMode, booleanWrapper::setCurrentMode)
+            .setTooltipText("gregtech.gui.toggle_view");
         builder.widget(buttonWidget);
         return builder;
     }
@@ -69,15 +64,11 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
     }
 
     protected ServerWidgetGroup createItemOutputWidgetGroup(IItemHandlerModifiable itemHandler, ServerWidgetGroup widgetGroup) {
-        return createItemOutputWidgetGroup(itemHandler, widgetGroup, 0);
-    }
-
-    protected ServerWidgetGroup createItemOutputWidgetGroup(IItemHandlerModifiable itemHandler, ServerWidgetGroup widgetGroup, int yOffset) {
         int[] inputSlotGrid = determineSlotsGrid(itemHandler.getSlots());
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = 106;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;
@@ -91,15 +82,11 @@ public class RecipeMapGroupOutput extends RecipeMap<SimpleRecipeBuilder> impleme
     }
 
     protected ServerWidgetGroup createFluidOutputWidgetGroup(IMultipleTankHandler fluidHandler, ServerWidgetGroup widgetGroup) {
-        return createFluidOutputWidgetGroup(fluidHandler, widgetGroup, 0);
-    }
-
-    protected ServerWidgetGroup createFluidOutputWidgetGroup(IMultipleTankHandler fluidHandler, ServerWidgetGroup widgetGroup, int yOffset) {
         int[] inputSlotGrid = determineSlotsGrid(fluidHandler.getTanks());
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = 106;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;


### PR DESCRIPTION
**What:**
PR #1665 introduced bug where recipes in JEI for Electrolyzer and Centrifuge.
And this reverts its merge commit eea021c0ca9507b57993de30ad2c86d2c9e0c21e.

**How solved:**
Commit with PR was reverted.

**Outcome:**
No problems with JEI pages for mentioned machines.
Changes form #1665 are no longer in game.
Reopening issue #1223.

**Additional info:**
https://cdn.discordapp.com/attachments/719246196677410937/859609105281581076/unknown.png

**Possible compatibility issue:**
None as reverted PR did not introduced any API additions/items or NBT.