### PR TITLE
Make the Fusion Property protected

### DIFF
--- a/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
@@ -10,7 +10,7 @@ public class FusionEUToStartProperty extends RecipeProperty<Long>{
 
     private static FusionEUToStartProperty INSTANCE;
 
-    private FusionEUToStartProperty() {
+    protected FusionEUToStartProperty() {
         super(KEY, Long.class);
     }
 


### PR DESCRIPTION
**What:**
This PR makes the fusion eu_to_start property added in #1672 protected so that it can be improved upon by addon mods, since GTCE does not implement fusion at all.

**How solved:**
Makes the property protected

**Outcome:**
Makes the fusion recipe property protected for implementation by addons


**Possible compatibility issue:**
None
