### PR TITLE
Fix consumable Integrated circuit being added to EBF recipe

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -113,7 +113,7 @@ public class MaterialRecipeHandler {
                             .blastFurnaceTemp(metalMaterial.blastFurnaceTemperature)
                             .duration(Math.max(1, duration / 9)).EUt(120);
                         if (circuitRequiringMaterials.contains(material)) {
-                            nuggetSmeltingBuilder.inputs(IntCircuitIngredient.getIntegratedCircuit(0));
+                            nuggetSmeltingBuilder.notConsumable(IntCircuitIngredient.getIntegratedCircuit(0));
                         }
                         nuggetSmeltingBuilder.buildAndRegister();
                     }


### PR DESCRIPTION
**What:**
Fixes a case were a consumable integrated circuit would be added to a blast furnace recipe, instead of a non-consumable integrated circuit

**How solved:**
Changes the circuit input to a not consumed input instead of a regular input

**Outcome:**
Fix some EBF recipes consuming an integrated circuit


**Possible compatibility issue:**
None expected