### PR TITLE
Fix time on Yttrium Barium Cuprate recipe

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
@@ -96,7 +96,7 @@ public class MixerRecipes {
             .input(dust, Copper, 3)
             .fluidInputs(Oxygen.getFluid(7000))
             .output(dust, YttriumBariumCuprate, 13)
-            .EUt(8).duration(8000).buildAndRegister();
+            .EUt(8).duration(800).buildAndRegister();
 
         for (DustMaterial dustMaterial : new DustMaterial[]{Talc, Soapstone, Redstone}) {
             MIXER_RECIPES.recipeBuilder()


### PR DESCRIPTION
**What:**
Fixes the time on the Yttrium Barium Cuprate mixer recipe. According to @DStrand1 he made a typo when adding the recipe and accidentally typed an 8000 tick duration instead of an 800 tick duration.

**How solved:**
Reduces the time on the recipe

**Outcome:**
Fixes Yttrium Barium Cuprate taking a long time to make in the mixer

**Possible compatibility issue:**
Only for addons or modpack makers that touched this recipe, although it will be a quick fix for them