### PR TITLE
Change Fusion Property to Long

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
@@ -12,14 +12,14 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
 
-    private int EUToStart;
+    private long EUToStart;
 
     public FusionRecipeBuilder() {
     }
 
     public FusionRecipeBuilder(Recipe recipe, RecipeMap<FusionRecipeBuilder> recipeMap) {
         super(recipe, recipeMap);
-        this.EUToStart = recipe.getRecipePropertyStorage().getRecipePropertyValue(FusionEUToStartProperty.getInstance(), 0);
+        this.EUToStart = recipe.getRecipePropertyStorage().getRecipePropertyValue(FusionEUToStartProperty.getInstance(), 0L);
     }
 
     public FusionRecipeBuilder(RecipeBuilder<FusionRecipeBuilder> recipeBuilder) {
@@ -34,13 +34,13 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
     @Override
     public boolean applyProperty(String key, Object value) {
         if (key.equals("eu_to_start")) {
-            this.EUToStart(((Number) value).intValue());
+            this.EUToStart(((Number) value).longValue());
             return true;
         }
         return false;
     }
 
-    public FusionRecipeBuilder EUToStart(int EUToStart) {
+    public FusionRecipeBuilder EUToStart(long EUToStart) {
         if (EUToStart <= 0) {
             GTLog.logger.error("EU to start cannot be less than or equal to 0", new IllegalArgumentException());
             recipeStatus = EnumValidationResult.INVALID;

--- a/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
@@ -3,7 +3,7 @@ package gregtech.api.recipes.recipeproperties;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
-public class FusionEUToStartProperty extends RecipeProperty<Integer>{
+public class FusionEUToStartProperty extends RecipeProperty<Long>{
 
 
     private static final String KEY = "eu_to_start";
@@ -11,7 +11,7 @@ public class FusionEUToStartProperty extends RecipeProperty<Integer>{
     private static FusionEUToStartProperty INSTANCE;
 
     private FusionEUToStartProperty() {
-        super(KEY, Integer.class);
+        super(KEY, Long.class);
     }
 
     public static FusionEUToStartProperty getInstance() {


### PR DESCRIPTION
**What:**
This change is done for cleaner implementation in addon mods, as GTCE currently does not implement anything related to the Fusion Reactor besides providing its Property and Recipe Builder.

The implementation in addon mods (SoG, Gregicality) relies upon totaling the energy stored in a number of `IEnergyContainer`s, which store their energy value as a long. Therefore it would be required to compare the values of a long (Energy stored in the number of `IEnergyContainer`s) and an int (The Fusion Property).

This change simplifies things for addons somewhat, by instead storing the property as a Long.

**How solved:**
Changes the Property storage and the Recipe Builder to Store and Create recipes with a long property instead of an int

**Outcome:**
Changes Fusion Property to a long

**Possible compatibility issue:**
There may be minor compatibility issues with addons as they are attempting to gather the incorrect value from property storage, although the issues can be fixed quickly by changing the type of value that is retrieved.