### PR TITLE
Apply Rotor Efficiency to all EU output from Turbine

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -118,7 +118,7 @@ public class LargeTurbineWorkableHandler extends FuelRecipeLogic {
         double relativeRotorSpeed = rotorHolder.getRelativeRotorSpeed();
         if (rotorHolder.getCurrentRotorSpeed() > 0 && rotorHolder.hasRotorInInventory()) {
             double rotorEfficiency = rotorHolder.getRotorEfficiency();
-            double totalEnergyOutput = (BASE_EU_OUTPUT + getBonusForTurbineType(largeTurbine) * rotorEfficiency) * (relativeRotorSpeed * relativeRotorSpeed);
+            double totalEnergyOutput = ((BASE_EU_OUTPUT + getBonusForTurbineType(largeTurbine)) * rotorEfficiency) * (relativeRotorSpeed * relativeRotorSpeed);
             return MathHelper.ceil(totalEnergyOutput);
         }
         return 0L;


### PR DESCRIPTION
**What:**
This PR changes the energy output calculations for the Large Turbine to apply the rotor efficiency to both the base output of the turbine and the bonus output of the turbine. The previous behavior was that the rotor efficiency was only applied to the bonus output of the turbine

**How solved:**
Changes the rotor efficiency from multiplying the bonus output to the sum of the bonus output and the base.

**Outcome:**
Changes Large Turbine rotor efficiency to apply to the total EU output of the Turbine. Closes #1678


**Possible compatibility issue:**
I would not expect any from this PR