### PR TITLE
Fix small issues with forest capitator

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolUtility.java
+++ b/src/main/java/gregtech/common/tools/ToolUtility.java
@@ -42,6 +42,8 @@ public class ToolUtility {
         if(TreeChopTask.isLogBlock(blockState) == 1) {
             if(!world.isRemote) {
                 EntityPlayerMP playerMP = (EntityPlayerMP) player;
+                if (playerMP.getCooldownTracker().hasCooldown(itemStack.getItem()))
+                    return false;
                 TreeChopTask treeChopTask = new TreeChopTask(blockPos, world, playerMP, itemStack);
                 TaskScheduler.scheduleTask(world, treeChopTask);
             }

--- a/src/main/java/gregtech/common/tools/TreeChopTask.java
+++ b/src/main/java/gregtech/common/tools/TreeChopTask.java
@@ -45,6 +45,7 @@ public class TreeChopTask implements Task {
         this.world = world;
         this.itemStack = toolStack.copy();
         this.player = player;
+        player.getCooldownTracker().setCooldown(itemStack.getItem(),20);
     }
 
     @Override
@@ -62,6 +63,8 @@ public class TreeChopTask implements Task {
         if (toolValueItem == null) {
             return false;
         }
+        if (world.getTotalWorldTime() % 10 == 0)
+            player.getCooldownTracker().setCooldown(itemStack.getItem(),20);
         IToolStats toolStats = toolValueItem.getToolStats();
         int damagePerBlockBreak = toolStats.getToolDamagePerBlockBreak(itemStack);
 
@@ -117,7 +120,6 @@ public class TreeChopTask implements Task {
                 this.world.destroyBlock(woodPos, true);
                 return true;
             }
-            return true;
         }
         return false;
     }

--- a/src/main/java/gregtech/common/tools/TreeChopTask.java
+++ b/src/main/java/gregtech/common/tools/TreeChopTask.java
@@ -42,6 +42,7 @@ public class TreeChopTask implements Task {
         this.startBlockPos = startPos.toImmutable();
         this.currentPos.setPos(startPos);
         this.woodBlockPos.add(startPos.toImmutable());
+        this.visitedBlockPos.add(startPos.toImmutable());
         this.world = world;
         this.itemStack = toolStack.copy();
         this.player = player;


### PR DESCRIPTION
**What:**
Fixed extra damage to tool when iterating over non-log block.
Fixed possibility of creating multiple chop tasks which could lead to additional damage/energy usage.

**How solved:**
Using forest capitator now has cooldown of 20 ticks which is held for the duration of chopping.
Remove return true in case when no block was broken. It still lead to item being damaged.

**Outcome:**
Fixed additional capitator durability/energy usage in certain cases.