### PR TITLE
Fix GT tools not working for some mod actions

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The Stats for GT Tools. Not including any Material Modifiers.
@@ -160,5 +161,13 @@ public interface IToolStats {
     default int getColor(ItemStack stack, int tintIndex) {
         SolidMaterial primaryMaterial = ToolMetaItem.getToolMaterial(stack);
         return tintIndex % 2 == 1 ? primaryMaterial.materialRGB : 0xFFFFFF;
+    }
+
+    /**
+     * @return The MC tool classes for cross-mod compatibility.
+     *         Default: no tool classes.
+     */
+    default Set<String> getToolClasses(ItemStack stack) {
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -761,7 +761,16 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
             enchantments.keySet().removeIf(enchantment -> !enchantment.canApply(itemStack));
             return enchantments;
         }
-
     }
 
+    @Override
+    @Nonnull
+    public Set<String> getToolClasses(@Nonnull ItemStack stack) {
+        T metaToolValueItem = getItem(stack);
+        if (metaToolValueItem != null) {
+            IToolStats toolStats = metaToolValueItem.getToolStats();
+            return toolStats.getToolClasses(stack);
+        }
+        return Collections.emptySet();
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolAxe.java
+++ b/src/main/java/gregtech/common/tools/ToolAxe.java
@@ -8,7 +8,12 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolAxe extends ToolBase {
+
+    private static final Set<String> AXE_TOOL_CLASSES = Collections.singleton("axe");
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -58,5 +63,10 @@ public class ToolAxe extends ToolBase {
             return ToolUtility.applyTimberAxe(stack, player.world, blockPos, player);
         }
         return false;
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return AXE_TOOL_CLASSES;
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolCrowbar.java
+++ b/src/main/java/gregtech/common/tools/ToolCrowbar.java
@@ -6,7 +6,12 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolCrowbar extends ToolBase {
+
+    private static final Set<String> CROWBAR_TOOL_CLASSES = Collections.singleton("crowbar");
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -38,5 +43,10 @@ public class ToolCrowbar extends ToolBase {
         String tool = block.getBlock().getHarvestTool(block);
         return (tool != null && tool.equals("crowbar")) ||
             block.getMaterial() == Material.CIRCUITS;
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return CROWBAR_TOOL_CLASSES;
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolFile.java
+++ b/src/main/java/gregtech/common/tools/ToolFile.java
@@ -4,7 +4,12 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolFile extends ToolBase {
+
+    private static final Set<String> FILE_TOOL_CLASSES = Collections.singleton("file");
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -28,4 +33,8 @@ public class ToolFile extends ToolBase {
             block.getMaterial() == Material.CIRCUITS;
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return FILE_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolHardHammer.java
+++ b/src/main/java/gregtech/common/tools/ToolHardHammer.java
@@ -15,9 +15,15 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ToolHardHammer extends ToolBase {
+
+    private static final Set<String> HAMMER_TOOL_CLASSES = new HashSet<String>() {{
+        add("hammer"); add("pickaxe");
+    }};
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -86,5 +92,10 @@ public class ToolHardHammer extends ToolBase {
     @Override
     public void addInformation(ItemStack stack, List<String> lines, boolean isAdvanced) {
         lines.add(I18n.format("metaitem.tool.tooltip.hammer.extra_drop"));
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return HAMMER_TOOL_CLASSES;
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolHoe.java
+++ b/src/main/java/gregtech/common/tools/ToolHoe.java
@@ -6,7 +6,12 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolHoe extends ToolBase {
+
+    private static final Set<String> HOE_TOOL_CLASSES = Collections.singleton("hoe");
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -30,4 +35,8 @@ public class ToolHoe extends ToolBase {
         item.addComponents(new HoeBehaviour(DamageValues.DAMAGE_FOR_HOE));
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return HOE_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolJackHammer.java
+++ b/src/main/java/gregtech/common/tools/ToolJackHammer.java
@@ -21,11 +21,13 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class ToolJackHammer extends ToolDrillLV {
+
+    private static final Set<String> HAMMER_TOOL_CLASSES = new HashSet<String>() {{
+        add("pickaxe"); add("hammer");
+    }};
 
     private static final ModeSwitchBehavior<JackHammerMode> MODE_SWITCH_BEHAVIOR = new ModeSwitchBehavior<>(JackHammerMode.class);
 
@@ -201,5 +203,10 @@ public class ToolJackHammer extends ToolDrillLV {
             case Z: return origin.add(x, 0, y);
             default: return BlockPos.ORIGIN;
         }
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return HAMMER_TOOL_CLASSES;
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolPickaxe.java
+++ b/src/main/java/gregtech/common/tools/ToolPickaxe.java
@@ -6,7 +6,12 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolPickaxe extends ToolBase {
+
+    private static final Set<String> PICK_TOOL_CLASSES = Collections.singleton("pickaxe");
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -38,4 +43,8 @@ public class ToolPickaxe extends ToolBase {
             block.getMaterial() == Material.GLASS;
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return PICK_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -20,9 +20,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import gregtech.api.items.toolitem.ToolMetaItem;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ToolSaw extends ToolBase {
+
+    private static final Set<String> SAW_TOOL_CLASSES = new HashSet<String>() {{
+        add("axe"); add("saw");
+    }};
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -80,6 +86,11 @@ public class ToolSaw extends ToolBase {
             ItemStack dropStack = new ItemStack(item, 1);
             dropList.add(dropStack);
         }
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return SAW_TOOL_CLASSES;
     }
 
     /**

--- a/src/main/java/gregtech/common/tools/ToolScoop.java
+++ b/src/main/java/gregtech/common/tools/ToolScoop.java
@@ -5,7 +5,12 @@ import gregtech.common.items.behaviors.ScoopBehaviour;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolScoop extends ToolBase {
+
+    private static final Set<String> SCOOP_TOOL_CLASSES = Collections.singleton("scoop");
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -23,4 +28,8 @@ public class ToolScoop extends ToolBase {
         item.addComponents(new ScoopBehaviour(DamageValues.DAMAGE_FOR_SCOOP));
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return SCOOP_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolScrewdriver.java
+++ b/src/main/java/gregtech/common/tools/ToolScrewdriver.java
@@ -5,7 +5,12 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolScrewdriver extends ToolBase {
+
+    private static final Set<String> DRIVER_TOOL_CLASSES = Collections.singleton("screwdriver");
 
     @Override
     public float getNormalDamageBonus(EntityLivingBase entity, ItemStack stack, EntityLivingBase attacker) {
@@ -34,5 +39,10 @@ public class ToolScrewdriver extends ToolBase {
         String tool = block.getBlock().getHarvestTool(block);
         return (tool != null && tool.equals("screwdriver")) ||
             block.getMaterial() == Material.CIRCUITS;
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return DRIVER_TOOL_CLASSES;
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolShovel.java
+++ b/src/main/java/gregtech/common/tools/ToolShovel.java
@@ -6,7 +6,12 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolShovel extends ToolBase {
+
+    private static final Set<String> SHOVEL_TOOL_CLASSES = Collections.singleton("shovel");
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -44,4 +49,8 @@ public class ToolShovel extends ToolBase {
             block.getMaterial() == Material.CLAY;
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return SHOVEL_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolSword.java
+++ b/src/main/java/gregtech/common/tools/ToolSword.java
@@ -6,7 +6,12 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolSword extends ToolBase {
+
+    private static final Set<String> SWORD_TOOL_CLASSES = Collections.singleton("sword");
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
@@ -60,4 +65,8 @@ public class ToolSword extends ToolBase {
             block.getMaterial() == Material.SPONGE;
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return SWORD_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolUniversalSpade.java
+++ b/src/main/java/gregtech/common/tools/ToolUniversalSpade.java
@@ -6,7 +6,14 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class ToolUniversalSpade extends ToolBase {
+
+    private static final Set<String> SPADE_TOOL_CLASSES = new HashSet<String>() {{
+        add("shovel"); add("axe"); add("saw"); add("sword"); add("crowbar");
+    }};
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -67,4 +74,8 @@ public class ToolUniversalSpade extends ToolBase {
         item.addComponents(new CrowbarBehaviour(DamageValues.DAMAGE_FOR_UNIVERSAL_SPADE));
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return SPADE_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolWireCutter.java
+++ b/src/main/java/gregtech/common/tools/ToolWireCutter.java
@@ -3,7 +3,12 @@ package gregtech.common.tools;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolWireCutter extends ToolBase {
+
+    private static final Set<String> CUTTER_TOOL_CLASSES = Collections.singleton("cutter");
 
     @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
@@ -26,4 +31,8 @@ public class ToolWireCutter extends ToolBase {
         return tool != null && tool.equals("cutter");
     }
 
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return CUTTER_TOOL_CLASSES;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolWrench.java
+++ b/src/main/java/gregtech/common/tools/ToolWrench.java
@@ -9,7 +9,12 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class ToolWrench extends ToolBase {
+
+    private static final Set<String> WRENCH_TOOL_CLASSES = Collections.singleton("wrench");
 
     @Override
     public float getNormalDamageBonus(EntityLivingBase entity, ItemStack stack, EntityLivingBase attacker) {
@@ -43,5 +48,10 @@ public class ToolWrench extends ToolBase {
     @Override
     public void onStatsAddedToTool(MetaValueItem item) {
         item.addComponents(new WrenchBehaviour(DamageValues.DAMAGE_FOR_WRENCH));
+    }
+
+    @Override
+    public Set<String> getToolClasses(ItemStack stack) {
+        return WRENCH_TOOL_CLASSES;
     }
 }


### PR DESCRIPTION
**What:**
This PR fixes GT tools not working in some cases for other mods. For example as detailed in #1704, trees from the Dynamic Trees mod cannot be chopped with a GT Axe or Saw.

**How solved:**
I overrode `getToolClasses` in `ToolMetaItem`, and specified tool classes in each tool type as applicable.

**Outcome:**
Closes #1704

**Additional info:**
As we are now marking "extra" tools as their proper classes, it is possible that additional compatibility with other mods will achieved. Particularly our Wrench and Crowbar.