### PR TITLE
Add warning to controller if Turbine is obstructed

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -131,6 +131,11 @@ public class MetaTileEntityLargeTurbine extends RotorHolderMultiblockController 
                             MIN_DURABILITY_TO_WARN, rotorDurability).setStyle(new Style().setColor(TextFormatting.RED)));
                 }
             }
+
+            if(!isRotorFaceFree()) {
+                textList.add(new TextComponentTranslation("gregtech.multiblock.turbine.obstructed")
+                        .setStyle(new Style().setColor(TextFormatting.RED)));
+            }
         }
         super.addDisplayText(textList);
     }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2995,6 +2995,7 @@ gregtech.multiblock.turbine.rotor_speed=Rotor Speed: %s / %s RPM
 gregtech.multiblock.turbine.rotor_efficiency=Rotor Efficiency: %s%%
 gregtech.multiblock.turbine.rotor_durability=Rotor Durability: %s%%
 gregtech.multiblock.turbine.low_rotor_durability=WARNING: Rotor Durability below %s%% (%s%%)
+gregtech.multiblock.turbine.obstructed=Turbine Face Obstructed
 
 gregtech.multiblock.large_boiler.temperature=Temperature: %s / %s C
 gregtech.multiblock.large_boiler.steam_output=Steam Output: %s mb/t


### PR DESCRIPTION
**What:**
Adds a warning to the controller GUI of the Turbine multiblocks if the front facing is obstructed. I have seen players confused on why their turbine was not functioning, and so I though a helpful warning would be useful.

**How solved:**
Checks if the front face is free, and adds a warning if it is not

**Outcome:**
Adds a warning to Turbines if their front face is obstructed

**Additional info:**
![java_4NHVbA4y6h](https://user-images.githubusercontent.com/31759736/129489388-70d1e5bb-8589-4e51-926b-7b91696a2c52.png)


**Possible compatibility issue:**
None