### PR TITLE
Fix Fluid Regulator Keep Exact

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -89,7 +89,8 @@ public class CoverFluidRegulator extends CoverPump {
                 if(destProperties.getContents() != null && destProperties.getContents().isFluidEqual(sourceFluid)) {
                     destFluid = destProperties.getContents();
                     amountToDrainAndFill = Math.min(Math.max(0, keepAmount - destFluid.amount), fluidLeftToTransfer);
-                    // Should we break here? If we do, we will only allow interaction with the first tank found,
+                    break;
+                    // Breaking here will only allow interaction with the first tank found,
                     // which could hit the edge case of having the same fluid in multiple tanks. However, this will be
                     // a rare edge case, because Fluid Handlers are limited by recipe.
                 }

--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -79,19 +79,29 @@ public class CoverFluidRegulator extends CoverPump {
             FluidStack sourceFluid = tankProperties.getContents();
             if (sourceFluid == null || sourceFluid.amount == 0 || !fluidFilter.test(sourceFluid)) continue;
             sourceFluid.amount = keepAmount;
-            FluidStack destFluid = destHandler.drain(sourceFluid, false);
-            int amountToDrainAndFill;
-            //no fluid in destination
-            if (destFluid == null) {
-                amountToDrainAndFill = Math.min(keepAmount, fluidLeftToTransfer);
-            //if the amount of fluid in the destination is sufficient or the destinations fluid isnt equal to the sources
-            //how to check if destHandler is full?
-            } else if (destFluid.amount >= keepAmount || !destFluid.isFluidEqual(sourceFluid)) {
-                continue;
-            } else {
-            //if keepAmount is larger than the transferLimit we will have to stock it over several ticks (seconds?)
-                amountToDrainAndFill = Math.min(keepAmount - destFluid.amount, fluidLeftToTransfer);
+            FluidStack destFluid = null;
+
+            // Initialize the amount here, in case no fluid is found in destination inventory
+            int amountToDrainAndFill = Math.min(keepAmount, fluidLeftToTransfer);
+
+            // Check all tanks in the destination inventory
+            for(IFluidTankProperties destProperties : destHandler.getTankProperties()) {
+                if(destProperties.getContents() != null && destProperties.getContents().isFluidEqual(sourceFluid)) {
+                    destFluid = destProperties.getContents();
+                    amountToDrainAndFill = Math.min(Math.max(0, keepAmount - destFluid.amount), fluidLeftToTransfer);
+                    // Should we break here? If we do, we will only allow interaction with the first tank found,
+                    // which could hit the edge case of having the same fluid in multiple tanks. However, this will be
+                    // a rare edge case, because Fluid Handlers are limited by recipe.
+                }
             }
+
+            // If the Destination Fluid is still null at this point, the tanks in the target inventory are empty
+
+            // Check if there is already too much fluid in the destination fluid inventory
+            if(destFluid != null && (destFluid.amount >= keepAmount || !destFluid.isFluidEqual(sourceFluid))) {
+                continue;
+            }
+
             sourceFluid.amount = amountToDrainAndFill;
             if (GTFluidUtils.transferExactFluidStack(sourceHandler, destHandler, sourceFluid.copy())) {
                 fluidLeftToTransfer -= sourceFluid.amount;


### PR DESCRIPTION
**What:**
Fixes Fluid Regulators failing to follow Keep Exact mode as described in #1705 

**How solved:**
Previously, the destination fluid was failing to be populated, due to a failure during the `drain` call. This would leave `destFluid` as null, meaning that `amountToDrainAndFill` would always be populated, meaning that fluid would always be transferred. 

To fix this, I have changed the logic somewhat, initializing the amount to drain and fill to the amount it would be if no fluid was found in the destination inventory.

I then check the destination inventory to see if there are any fluids that match the fluid in the Source Inventory. If there is, the destination fluid is updated, and the amount to drain and fill is updated based on the amount of fluid in the destination tank. 

Note: I did cap `amountToDrainAndFill` to `0` here on the lower end, with a new call of `max`. This was because I was seeing negative values during debugging.

After checking for a matching fluid, I then check if the Fluid amount in the destination already exceeds the desired amount.

As noted in the comment, I considered putting a `break` after finding a valid destination fluid, but that could have a weird edge case if there was a Fluid Inventory with two tanks of the exact same fluid in the destination inventory. However, since fluid handlers are recipe based, I deemed this a very small chance edge case, but let me know your thoughts. I am leaning towards adding a `break` after finding a valid fluid.

**Outcome:**
Fix Fluid Regulator "Keep Exact" mode. Closes #1705 


**Possible compatibility issue:**
None expected