### PR TITLE
Fix Quantum Chest voiding items near maximum capacity

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -318,7 +318,6 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             if(stack.getCount() > insertedAmount) {
                 remainingStack = stack.copy();
                 remainingStack.setCount(stack.getCount() - insertedAmount);
-                return ItemStack.EMPTY;
             }
             if (!simulate) {
                 if (itemStack.isEmpty()) {


### PR DESCRIPTION
**What:**
This PR fixes an issue where the quantum chest would void items when near maximum capacity in certain situations. 

This fix is done by preventing returning early when trying to insert more items than the available remaining space, resulting in the item merge actually proceeding.

This bug was produced using the following conditions:

Give yourself a quantum chest full of iron ingots using the command `/give @p gregtech:machine 1 1010 {ItemAmount: 4096064L, ItemStack: {id: "minecraft:iron_ingot", Count: 1, Damage: 0}}`

Place the chest and place a fluid solidifier (best at EV for the speed) next to the chest and set its auto output into the chest and enable the auto output. 

Build up a backstock of iron in output slot of the solidifier, and fluid iron in the tank of the solidifier.

Remove half a stack of iron from the quantum chest by right clicking on the stack of iron in the output slot.

See the chest refill itself from its internal inventory and from the fluid solidifier, however see that it never reaches its maximum stored amount and continuously drains iron from the fluid solidifier output, voiding the excess iron and newly created iron.

**How solved:**
Not returning early allows the merge to actually succeed and properly update the inventory, which prevent this issue. And also returns the correct remaining itemstack from the partial merge from the output slot of the fluid solidifier.

**Outcome:**
Fixes the Quantum Chest voiding items inserted into it in some cases when near/at maximum capacity.

**Possible compatibility issue:**
None expected.