### PR TITLE
Fixed CT 'inputs' getter, added 'nonConsumable' getter

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -1,11 +1,14 @@
 package gregtech.api.recipes.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.mc1120.item.MCItemStack;
 import crafttweaker.mc1120.liquid.MCLiquidStack;
+import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import stanhebben.zenscript.annotations.Optional;
@@ -31,18 +34,22 @@ public class CTRecipe {
     }
 
     @ZenGetter("inputs")
-    public List<InputIngredient> getInputs() {
+    public List<IIngredient> getInputs() {
         return this.backingRecipe.getInputs().stream()
         	.filter(out -> out.getCount() > 0)
-            .map(InputIngredient::new)
+            .map(ing -> new IngredientStack(
+	                		CraftTweakerMC.getIIngredient(ing.getIngredient()),
+	                		ing.getCount()))
             .collect(Collectors.toList());
     }
 
     @ZenGetter("nonConsumable")
-    public List<InputIngredient> getNonConsumableInputs() {
+    public List<IIngredient> getNonConsumableInputs() {
     	return this.backingRecipe.getInputs().stream()
 			.filter(out -> out.getCount() < 1)
-			.map(InputIngredient::new)
+			.map(CountableIngredient::getIngredient)
+			.map(CraftTweakerMC::getIIngredient)
+			.map(ing -> new IngredientStack(ing, 0))
 			.collect(Collectors.toList());
     }
     

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -33,10 +33,19 @@ public class CTRecipe {
     @ZenGetter("inputs")
     public List<InputIngredient> getInputs() {
         return this.backingRecipe.getInputs().stream()
+        	.filter(out -> out.getCount() > 0)
             .map(InputIngredient::new)
             .collect(Collectors.toList());
     }
 
+    @ZenGetter("nonConsumable")
+    public List<InputIngredient> getNonConsumableInputs() {
+    	return this.backingRecipe.getInputs().stream()
+			.filter(out -> out.getCount() < 1)
+			.map(InputIngredient::new)
+			.collect(Collectors.toList());
+    }
+    
     @ZenGetter("outputs")
     public List<IItemStack> getOutputs() {
         return this.backingRecipe.getOutputs().stream()
@@ -50,7 +59,8 @@ public class CTRecipe {
             .map(MCItemStack::new)
             .collect(Collectors.toList());
     }
-
+    
+    @Deprecated
     @ZenGetter("changedOutputs")
     public List<ChancedEntry> getChancedOutputs() {
         ArrayList<ChancedEntry> result = new ArrayList<>();

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -36,23 +36,23 @@ public class CTRecipe {
     @ZenGetter("inputs")
     public List<IIngredient> getInputs() {
         return this.backingRecipe.getInputs().stream()
-        	.filter(out -> out.getCount() > 0)
+            .filter(out -> out.getCount() > 0)
             .map(ing -> new IngredientStack(
-	                		CraftTweakerMC.getIIngredient(ing.getIngredient()),
-	                		ing.getCount()))
+                CraftTweakerMC.getIIngredient(ing.getIngredient()),
+                ing.getCount()))
             .collect(Collectors.toList());
     }
 
     @ZenGetter("nonConsumable")
     public List<IIngredient> getNonConsumableInputs() {
-    	return this.backingRecipe.getInputs().stream()
-			.filter(out -> out.getCount() < 1)
-			.map(CountableIngredient::getIngredient)
-			.map(CraftTweakerMC::getIIngredient)
-			.map(ing -> new IngredientStack(ing, 0))
-			.collect(Collectors.toList());
+        return this.backingRecipe.getInputs().stream()
+            .filter(out -> out.getCount() < 1)
+            .map(CountableIngredient::getIngredient)
+            .map(CraftTweakerMC::getIIngredient)
+            .map(ing -> new IngredientStack(ing, 0))
+            .collect(Collectors.toList());
     }
-    
+
     @ZenGetter("outputs")
     public List<IItemStack> getOutputs() {
         return this.backingRecipe.getOutputs().stream()
@@ -66,7 +66,7 @@ public class CTRecipe {
             .map(MCItemStack::new)
             .collect(Collectors.toList());
     }
-    
+
     @Deprecated
     @ZenGetter("changedOutputs")
     public List<ChancedEntry> getChancedOutputs() {

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -148,10 +148,16 @@ public class CTRecipeBuilder {
 
         @Override
         public boolean apply(@Nullable ItemStack itemStack) {
-            itemStack = itemStack.copy();
+            if (itemStack == null) {
+                // Avoiding NPE
+                itemStack = ItemStack.EMPTY;
+            }
+
             //because CT is dump enough to compare stack sizes by default...
-            itemStack.setCount(ingredient.getAmount());
-            return ingredient.matches(CraftTweakerMC.getIItemStack(itemStack));
+            // Setting stack size to 1 to avoid problem with non-consumable ingredients (count - 0)
+            IItemStack stack = CraftTweakerMC.getIItemStack(itemStack).amount(1);
+            return ingredient.amount(1)
+                    .matches(stack);
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
@@ -11,18 +11,24 @@ import stanhebben.zenscript.annotations.ZenGetter;
 
 import java.util.List;
 
+/**
+ * @deprecated
+ * 	1. Not full implementation
+ * 	2. CT provides required implementaions
+ * 	3. Buggy
+ *
+ */
+@Deprecated
 @ZenClass("mods.gregtech.recipe.InputIngredient")
 @ZenRegister
 public class InputIngredient implements IIngredient {
 
     private final IIngredient iingredient;
-    private final int amount;
 
     public InputIngredient(CountableIngredient backingIngredient) {
         iingredient = CraftTweakerMC
             .getIIngredient(backingIngredient.getIngredient())
-        	.amount(1);
-        amount = backingIngredient.getCount();
+        	.amount(backingIngredient.getCount());
     }
 
     @Override
@@ -32,7 +38,7 @@ public class InputIngredient implements IIngredient {
 
     @Override
     public int getAmount() {
-        return amount;
+        return iingredient.getAmount();
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
@@ -16,11 +16,13 @@ import java.util.List;
 public class InputIngredient implements IIngredient {
 
     private final IIngredient iingredient;
+    private final int amount;
 
     public InputIngredient(CountableIngredient backingIngredient) {
         iingredient = CraftTweakerMC
             .getIIngredient(backingIngredient.getIngredient())
-            .amount(backingIngredient.getCount());
+        	.amount(1);
+        amount = backingIngredient.getCount();
     }
 
     @Override
@@ -30,7 +32,7 @@ public class InputIngredient implements IIngredient {
 
     @Override
     public int getAmount() {
-        return iingredient.getAmount();
+        return amount;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/InputIngredient.java
@@ -16,7 +16,6 @@ import java.util.List;
  * 	1. Not full implementation
  * 	2. CT provides required implementaions
  * 	3. Buggy
- *
  */
 @Deprecated
 @ZenClass("mods.gregtech.recipe.InputIngredient")
@@ -28,7 +27,7 @@ public class InputIngredient implements IIngredient {
     public InputIngredient(CountableIngredient backingIngredient) {
         iingredient = CraftTweakerMC
             .getIIngredient(backingIngredient.getIngredient())
-        	.amount(backingIngredient.getCount());
+            .amount(backingIngredient.getCount());
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/recipes/CokeOvenRecipe.java
+++ b/src/main/java/gregtech/api/recipes/recipes/CokeOvenRecipe.java
@@ -51,10 +51,10 @@ public class CokeOvenRecipe {
     @ZenGetter("input")
     @Method(modid = GTValues.MODID_CT)
     public IIngredient ctGetInput() {
-    	CountableIngredient input = getInput();
+        CountableIngredient input = getInput();
         return new IngredientStack(
-        		CraftTweakerMC.getIIngredient(input.getIngredient()),
-        		input.getCount());
+                CraftTweakerMC.getIIngredient(input.getIngredient()),
+                input.getCount());
     }
 
     @ZenGetter("output")

--- a/src/main/java/gregtech/api/recipes/recipes/CokeOvenRecipe.java
+++ b/src/main/java/gregtech/api/recipes/recipes/CokeOvenRecipe.java
@@ -1,13 +1,14 @@
 package gregtech.api.recipes.recipes;
 
 import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.mc1120.liquid.MCLiquidStack;
 import gregtech.api.GTValues;
 import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.crafttweaker.InputIngredient;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Optional.Method;
@@ -49,8 +50,11 @@ public class CokeOvenRecipe {
 
     @ZenGetter("input")
     @Method(modid = GTValues.MODID_CT)
-    public InputIngredient ctGetInput() {
-        return new InputIngredient(getInput());
+    public IIngredient ctGetInput() {
+    	CountableIngredient input = getInput();
+        return new IngredientStack(
+        		CraftTweakerMC.getIIngredient(input.getIngredient()),
+        		input.getCount());
     }
 
     @ZenGetter("output")

--- a/src/main/java/gregtech/api/recipes/recipes/PrimitiveBlastFurnaceRecipe.java
+++ b/src/main/java/gregtech/api/recipes/recipes/PrimitiveBlastFurnaceRecipe.java
@@ -1,11 +1,12 @@
 package gregtech.api.recipes.recipes;
 
 import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import gregtech.api.GTValues;
 import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.crafttweaker.InputIngredient;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.Optional.Method;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -48,8 +49,11 @@ public class PrimitiveBlastFurnaceRecipe {
 
     @ZenGetter("input")
     @Method(modid = GTValues.MODID_CT)
-    public InputIngredient ctGetInput() {
-        return new InputIngredient(getInput());
+    public IIngredient ctGetInput() {
+    	CountableIngredient input = getInput();
+        return new IngredientStack(
+        		CraftTweakerMC.getIIngredient(input.getIngredient()),
+        		input.getCount());
     }
 
     @ZenGetter("output")

--- a/src/main/java/gregtech/api/recipes/recipes/PrimitiveBlastFurnaceRecipe.java
+++ b/src/main/java/gregtech/api/recipes/recipes/PrimitiveBlastFurnaceRecipe.java
@@ -50,10 +50,10 @@ public class PrimitiveBlastFurnaceRecipe {
     @ZenGetter("input")
     @Method(modid = GTValues.MODID_CT)
     public IIngredient ctGetInput() {
-    	CountableIngredient input = getInput();
+        CountableIngredient input = getInput();
         return new IngredientStack(
-        		CraftTweakerMC.getIIngredient(input.getIngredient()),
-        		input.getCount());
+                CraftTweakerMC.getIIngredient(input.getIngredient()),
+                input.getCount());
     }
 
     @ZenGetter("output")


### PR DESCRIPTION
Closes #1439

## What
While iterating recipes, in case recipe has non consumable ingredient (count = 0), it will crash. Crafttweaker has check for empty stacks.

## How solved:
Added filtration of inputs, to provide only normal ingredients. Non consumables getter was missing, so I added it.

## Outcome:
- Fixed CT crash on calling Recipe.inputs.
- Added CT getter for non consumable recipe inputs

## Additional info:
### Crash
```
java.lang.IllegalArgumentException: stack cannot be null
    at crafttweaker.mc1120.item.MCItemStack.<init>(MCItemStack.java:94)
    at crafttweaker.mc1120.item.MCItemStack.withAmount(MCItemStack.java:238)
    at crafttweaker.mc1120.item.MCItemStack.amount(MCItemStack.java:336)
    at crafttweaker.mc1120.item.MCItemStack.amount(MCItemStack.java:56)
    at gregtech.api.recipes.crafttweaker.InputIngredient.<init>(InputIngredient.java:23)
    at java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
    at java.util.Iterator.forEachRemaining(Unknown Source)
    at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source)
    at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
    at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
    at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
    at java.util.stream.ReferencePipeline.collect(Unknown Source)
    at gregtech.api.recipes.crafttweaker.CTRecipe.getInputs(CTRecipe.java:37)
```

### ZenScript example
```zs
for recipe in RecipeMaps.BLAST_RECIPES.recipes {
  var ingredients = recipe.inputs;
}
```

## Possible compatibility issue:
None, API changes only adds method, and fixing broken logic of one of old.