### PR TITLE
Adjusted sodium hydroxide recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
@@ -55,7 +55,7 @@ public class MixerRecipes {
             .duration(300).EUt(30).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
-            .input(dust, Salt, 2)
+            .input(dust, Salt)
             .fluidInputs(Water.getFluid(1000))
             .fluidOutputs(SaltWater.getFluid(1000))
             .duration(40).EUt(8).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -322,7 +322,7 @@ public class ReactorRecipes {
             .notConsumable(new IntCircuitIngredient(1))
             .input(dust, Sodium)
             .fluidInputs(Water.getFluid(1000))
-            .output(dust, SodiumHydroxide, 3)
+            .output(dust, SodiumHydroxide)
             .fluidOutputs(Hydrogen.getFluid(1000))
             .duration(40).EUt(8).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -65,7 +65,7 @@ public class SeparationRecipes {
 
         ELECTROLYZER_RECIPES.recipeBuilder()
             .fluidInputs(SaltWater.getFluid(1000))
-            .output(dust, SodiumHydroxide, 3)
+            .output(dust, SodiumHydroxide)
             .fluidOutputs(Chlorine.getFluid(1000))
             .fluidOutputs(Hydrogen.getFluid(1000))
             .duration(720).EUt(30).buildAndRegister();


### PR DESCRIPTION
**What:**
Fix incorrect ration of Sodium Hydroxide recipe, it recipe from salt water and salt water recipe itself.

**Outcome:**
No bug reported yet, I met this issue, and though it came from addon. According on GTs ore processors logic, recipe must be like this: NaOH (electrolysis) => 1x sodium dust + 1000mB oxygen + 1000mB hydrogen.